### PR TITLE
Make sure User.setup calls Model.setup to support shared ctor

### DIFF
--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -251,6 +251,8 @@ User.confirm = function (uid, token, redirect, fn) {
  */
 
 User.setup = function () {
+  // We need to call the base class's setup method
+  Model.setup.call(this);
   var UserModel = this;
   
   UserModel.setter.password = function (plain) {


### PR DESCRIPTION
Customer extends User, which extends Model. User.setup needs to call Model.setup so that the shared ctor is set up correctly for remoting.
