### PR TITLE
Add placeholders for client apis

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -6,9 +6,11 @@
     "docs/gettingstarted.md",
     "docs/resources.md",
     "docs/concepts.md",
-    {"title": "API", "depth": 2},
+    "docs/cli.md",
     "docs/api.md",
-    "docs/rest.md",
-    "docs/cli.md"
+    "docs/ios.md",
+    "docs/js.md",
+    "docs/java.md",
+    "docs/rest.md"
   ]
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -889,18 +889,26 @@ var memory = loopback.createDataSource({
 });
 ```
     
-**Available Connectors**
+**Database Connectors**
  
  - [In Memory](#memory-connector)
- - [REST](http://github.com/strongloop/loopback-connector-rest)
  - [Oracle](http://github.com/strongloop/loopback-connector-oracle)
  - [MongoDB](http://github.com/strongloop/loopback-connector-mongodb)
- - TODO - [MySQL](http://github.com/strongloop/loopback-connector-mysql)
- - TODO - [SQLite3](http://github.com/strongloop/loopback-connector-sqlite)
- - TODO - [Postgres](http://github.com/strongloop/loopback-connector-postgres)
- - TODO - [Redis](http://github.com/strongloop/loopback-connector-redis)
- - TODO - [CouchDB](http://github.com/strongloop/loopback-connector-couch)
- - TODO - [Firebird](http://github.com/strongloop/loopback-connector-firebird)
+ - [MySQL](http://github.com/strongloop/loopback-connector-mysql) - In Development
+ - [SQLite3](http://github.com/strongloop/loopback-connector-sqlite) - In Development
+ - [Postgres](http://github.com/strongloop/loopback-connector-postgres) - In Development
+ - [Redis](http://github.com/strongloop/loopback-connector-redis) - In Development
+ - [CouchDB](http://github.com/strongloop/loopback-connector-couch) - In Development
+ - [Firebird](http://github.com/strongloop/loopback-connector-firebird) - In Development
+
+**Other Connectors**
+
+ - [REST](http://github.com/strongloop/loopback-connector-rest)
+ - [Email](#email-model)
+ - [JSON RPC](http://github.com/strongloop/loopback-connector-jsonrpc) - In Development
+ - [SOAP](http://github.com/strongloop/loopback-connector-soap) - In Development
+ - [Push Notifications](https://github.com/strongloop/loopback-push-notification) - In Development
+ - [File Storage](https://github.com/strongloop/loopback-storage-service) - In Development
 
 **Installing Connectors**
 
@@ -948,8 +956,6 @@ function count() {
   Product.count(console.log); // 3
 }
 ```
-
-###### Operations
 
 **CRUD / Query**
 

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -1,0 +1,3 @@
+## iOS API
+
+<h3><em>Stay tuned. Currently in development.</em></h3>

--- a/docs/java.md
+++ b/docs/java.md
@@ -1,0 +1,3 @@
+## Android API
+
+<h3><em>Stay tuned. Currently in development.</em></h3>

--- a/docs/js.md
+++ b/docs/js.md
@@ -1,0 +1,3 @@
+## Browser API
+
+<h3><em>Stay tuned. Currently in development.</em></h3>


### PR DESCRIPTION
/to @raymondfeng
/cc @Schoonology 
- the iOS doc should probably just link directly to the doxygen docs... but it would be nice to list out the apis...
- added in more connectors, should probably update the table at the top
