### PR TITLE
Initial auth implementation

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -44,12 +44,6 @@ app.disuse = function (route) {
 }
 
 /**
- * App models.
- */
-
-app._models = [];
-
-/**
  * Expose a model.
  *
  * @param Model {Model}
@@ -60,7 +54,7 @@ app.model = function (Model, config) {
     assert(typeof Model === 'function', 'app.model(Model) => Model must be a function / constructor');
     assert(Model.pluralModelName, 'Model must have a "pluralModelName" property');
     this.remotes().exports[Model.pluralModelName] = Model;
-    this._models.push(Model);
+    this.models().push(Model);
     Model.shared = true;
     Model.app = this;
     Model.emit('attached', this);
@@ -83,19 +77,11 @@ app.model = function (Model, config) {
 }
 
 /**
- * Get a Model by name.
- */
-
-app.getModel = function (modelName) {
-  this.models
-};
-
-/**
  * Get all exposed models.
  */
 
 app.models = function () {
-  return this._models;
+  return this._models || (this._models = []);
 }
 
 /**
@@ -144,7 +130,6 @@ app.docs = function (options) {
   swagger(remotes, options);
 }
 
-
 /*!
  * Get a handler of the specified type from the handler cache.
  */
@@ -165,6 +150,52 @@ app.handler = function (type) {
  */
 
 app.dataSources = app.datasources = {};
+
+/**
+ * Enable app wide authentication.
+ */
+
+app.enableAuth = function() {
+  var remotes = this.remotes();
+
+  remotes.before('**', function(ctx, next, method) {
+    var req = ctx.req;
+    var Model = method.ctor;
+    var modelInstance = ctx.instance;
+    var modelId = modelInstance && modelInstance.id;
+
+    // TODO(ritch) - this fallback could be less express dependent
+    if(modelInstance && !modelId) {
+      modelId = req.param('id');
+    }
+
+    if(req.accessToken) {
+      Model.checkAccess(
+        req.accessToken,
+        modelId,
+        method.name,
+        function(err, allowed) {
+          if(err) {
+            next(err);
+          } else if(allowed) {
+            next();
+          } else {
+            var e = new Error('Access Denied');
+            e.statusCode = 401;
+            next(e);
+          }
+        }
+      );
+    } else if(method.fn && method.fn.requireToken === false) {
+      next();
+    } else {
+      var e = new Error('Access Denied');
+      e.statusCode = 401;
+
+      next(e);
+    }
+  });
+}
 
 /**
  * Initialize the app using JSON and JavaScript files.

--- a/lib/loopback.js
+++ b/lib/loopback.js
@@ -252,7 +252,6 @@ loopback.RoleMapping = require('./models/role').RoleMapping;
 loopback.ACL = require('./models/acl').ACL;
 loopback.Scope = require('./models/acl').Scope;
 
-
 /**
  * Automatically attach these models to dataSources
  */

--- a/lib/models/access-token.js
+++ b/lib/models/access-token.js
@@ -8,7 +8,8 @@ var Model = require('../loopback').Model
   , crypto = require('crypto')
   , uid = require('uid2')
   , DEFAULT_TTL = 1209600 // 2 weeks in seconds
-  , DEFAULT_TOKEN_LEN = 64;
+  , DEFAULT_TOKEN_LEN = 64
+  , ACL = require('./acl').ACL;
 
 /**
  * Default AccessToken properties.

--- a/lib/models/acl.js
+++ b/lib/models/acl.js
@@ -274,6 +274,10 @@ Scope.checkPermission = function (scope, model, property, accessType, callback) 
 ACL.checkAccess = function (context, callback) {
   context = context || {};
   var principals = context.principals || [];
+
+  // add ROLE.EVERYONE
+  principals.unshift({principalType: ACL.ROLE, principalId: Role.EVERYONE});
+
   var model = context.model;
   model = ('string' === typeof model) ? loopback.getModel(model) : model;
   var id = context.id;
@@ -369,7 +373,7 @@ ACL.checkAccessForToken = function(token, model, modelId, method, callback) {
       callback && callback(err);
       return;
     }
-    callback && callback(access.permission !== ACL.DENY);
+    callback && callback(null, access.permission !== ACL.DENY);
   });
 };
 

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -12,7 +12,6 @@ describe('User', function(){
   User.setMaxListeners(0);
   
   before(function () {
-    debugger;
     User.hasMany(AccessToken, {as: 'accessTokens', foreignKey: 'userId'});  
   });
   
@@ -257,8 +256,7 @@ describe('User', function(){
             assert(result.token);
             
             
-            var lines = result.email.message.split('\n');
-            assert(lines[3].indexOf('To: bar@bat.com') === 0);
+            assert(~result.email.message.indexOf('To: bar@bat.com'));
             done();
           });
         });


### PR DESCRIPTION
/to @raymondfeng 
## app.enableAuth()
- Enable ACL based access checking via a `app.remotes().before('**, ...)` (before all) hook.
- Requires every request to invoke a remote method be signed with an `AccessToken`
## bugfixes
- Fixed a test that depends on a very specific line order for email headers
- Fixed some basic issues in the ACL implementation
