### PR TITLE
Add loopback.urlNotFound() middleware.

### DIFF
--- a/lib/middleware/urlNotFound.js
+++ b/lib/middleware/urlNotFound.js
@@ -1,0 +1,18 @@
+/**
+ * Export the middleware.
+ */
+module.exports = urlNotFound;
+
+/**
+ * Convert any request not handled so far to a 404 error
+ * to be handled by error-handling middleware.
+ * See discussion in Connect pull request #954 for more details
+ * https://github.com/senchalabs/connect/pull/954
+ */
+function urlNotFound() {
+  return function raiseUrlNotFoundError(req, res, next) {
+    var error = new Error('Cannot ' + req.method + ' ' + req.url);
+    error.status = 404;
+    next(error);
+  }
+}


### PR DESCRIPTION
The middleware should be used as the last 3-parameter middleware (regular
request handles) before any 4-parameter middleware (error handlers).

This way a request to a URL not handled by any middleware is converted to
a 404 error that can be handled by whatever error handling strategy is
configured in the application.

See senchalabs/connect#954 for more details.

There is a related loopback-workspace pull request coming soon.

/to: @ritch 
/cc: @Schoonology @raymondfeng
