### PR TITLE
Add test for findById returning 404

### DIFF
--- a/test/model.test.js
+++ b/test/model.test.js
@@ -296,6 +296,13 @@ describe('Model', function() {
             done();
           });
       });
+
+      it('Converts null result of findById to 404 Not Found', function(done) {
+        request(app)
+          .get('/users/not-found')
+          .expect(404)
+          .end(done);
+      });
     });
   
     describe('Model.beforeRemote(name, fn)', function(){


### PR DESCRIPTION
The test verifies the remoting configuration of loopback-datasource-juggler, ensuring that
`DataAccessObject.findById()` has `rest.before` handler correctly set up. See strongloop/loopback-datasource-juggler#44.

/to: @raymondfeng or @ritch - please review
/cc: @Schoonology FYI
