### PR TITLE
Unify format of REST error responses

### DIFF
--- a/lib/loopback.js
+++ b/lib/loopback.js
@@ -48,18 +48,6 @@ function createApplication() {
 }
 
 /**
- * Expose express.middleware as loopback.*
- * for example `loopback.errorHandler` etc.
- */
-
-for (var key in express) {
-  Object.defineProperty(
-      loopback
-    , key
-    , Object.getOwnPropertyDescriptor(express, key));
-}
-
-/**
  * Expose additional loopback middleware
  * for example `loopback.configure` etc.
  */
@@ -72,6 +60,23 @@ fs
   .forEach(function (m) {
     loopback[m.replace(/\.js$/, '')] = require('./middleware/' + m);
   });
+
+/**
+ * Expose express.middleware as loopback.*
+ * for example `loopback.favicon` etc.
+ */
+
+for (var key in express) {
+  if (loopback.hasOwnProperty(key)) {
+    // skip middleware overriden in loopback
+    continue;
+  }
+
+  Object.defineProperty(
+    loopback
+    , key
+    , Object.getOwnPropertyDescriptor(express, key));
+}
 
 /**
  * Error handler title

--- a/lib/middleware/errorHandler.js
+++ b/lib/middleware/errorHandler.js
@@ -1,0 +1,41 @@
+var expressErrorHandler = require('express').errorHandler;
+var remoting = require('strong-remoting');
+
+/**
+ * Export the middleware.
+ */
+module.exports = errorHandler;
+
+/**
+ * Custom error handling middleware that calls RestAdapter error handler
+ * for json requests and falls back to the default express/connect handler.
+ */
+function errorHandler() {
+  var restHandler = new remoting().adapter('rest').errorHandler();
+  var fallbackHandler = expressErrorHandler();
+
+  return function(err, req, res, next) {
+    if (/json/.test(req.headers.accept || '')) {
+      console.log('calling rest handler');
+      restHandler(err, req, res, next);
+    }
+    else {
+      console.log('calling fallback handler');
+      fallbackHandler(err, req, res, next);
+    }
+  };
+}
+
+// Forward all properties like title to connect/express handler
+for (var key in expressErrorHandler) {
+  var prop =  Object.getOwnPropertyDescriptor(expressErrorHandler, key);
+  Object.defineProperty(
+    errorHandler,
+    key,
+    {
+      get: function() { return expressErrorHandler[key]; },
+      set: function(value) { expressErrorHandler[key] = value; },
+      enumerable: prop.enumerable
+    }
+  );
+}

--- a/test/errorHandler.test.js
+++ b/test/errorHandler.test.js
@@ -1,0 +1,36 @@
+var express = require('express');
+describe('errorHandler middleware', function() {
+  var app;
+  beforeEach(function() {
+    app = loopback();
+    app.use(loopback.rest());
+    app.use(loopback.urlNotFound());
+    app.use(loopback.errorHandler());
+  });
+
+  it('returns RestAdapter\'s response when JSON is accepted', function(done) {
+    request(app).get('/not-found')
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .end(function(err, resp) {
+        if (err) return done(err);
+        assert(
+          resp.body.error.name == 'Error',
+          'expected error.name "Error" but got ' +
+            JSON.stringify(resp.body.error.name) + '.'
+        );
+        done();
+      });
+  });
+
+  it('returns text response when json or html is not accepted', function(done) {
+    request(app).get('/not-found')
+      .expect('Content-Type', 'text/plain')
+      .end(done);
+  });
+
+  it('exposes properties of connect handler', function() {
+    loopback.errorHandler.title = 'a title';
+    assert.equal(express.errorHandler.title, 'a title');
+  });
+});


### PR DESCRIPTION
Modify loopback.errorHandler() to call the error handler provided by
strong-remoting's RestAdapter when the client accepts json, and fall
back to connect/express handler otherwise.

This way when a LoopBack client requests a URL not mapped to any shared
method, the server returns response in the same format as is produced
in other cases.

Requires strongloop/strong-remoting#23.

/to: @raymondfeng or @ritch Please review.
/cc: @Schoonology FYI.

---

This change deserves some discussion before we go ahead and merge.

What problem I am trying to solve:

``` js
var app = loopback();
app.use(loopback.rest());
app.get('/foo/bar', function() { /* ... */ });
app.use(loopback.urlNotFound());
app.use(loopback.errorHandler()); 

// 1. Request to an unknown URL falls through loopback.rest()
// and is handled by loopback.errorHandler()

// 2. LoopBack client accessing  '/foo/bar' and expecting a remote method there
// will get error formatted by loopback.errorHandler()
// (assuming the request fails)
```

What is still not solved:

``` js
var app = loopback();
app.use(loopback.rest());
// possibly missing urlNotFound handler
app.use(myCustomErrorHandlerNotAwareOfJson());

// LoopBack client requesting an unknown url
// (object/method not implemented) gets error response
// in an unexpected format (whatever the custom handler produced,
// or the default text response when urlNotFound was not installed).
```

---

Here is a radically different approach that will make this pull request unnecessary:
- Make every adapter own the whole URL subspace, do not allow developers to mix REST API routes with website routes in the same space.
- REST adapter can install `urlNotFound` and `restErrorHandler` middleware to ensure errors are handled consistently.
- Developers can still start the REST handler as a standalone application. If they want to use it as a part of a bigger app, they have to mount it at a sub-path.
- Error handler used by the root application does not affect error handling of requests for the REST endpoint

``` js
// 1. The application is all about REST
var app = loopback();
app.use(loopback.rest());
// Any middleware registered below this point won't be called. Ever.

// 2. The application combines REST and website
app.use('/api', loopback.rest());
// register app middleware, e.g.
//   app.use(express.router);
// Even if you don't install urlNotFound and errorHandler,
// all unknown requests starting with /api/ return expected
// json response.
```

This should also prevent hard-to-debug bugs caused by incorrect ordering of middleware registration, i.e. when the URL is handled by both loopback and some other middleware.

Thoughts?
