### PR TITLE
Add testing helpers

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -156,6 +156,7 @@ app.dataSources = app.datasources = {};
  */
 
 app.enableAuth = function() {
+  var AccessToken = require('./models/access-token');
   var remotes = this.remotes();
 
   remotes.before('**', function(ctx, next, method) {
@@ -169,35 +170,22 @@ app.enableAuth = function() {
       modelId = req.param('id');
     }
 
-    if(req.accessToken) {
-      Model.checkAccess(
-        req.accessToken,
-        modelId,
-        method.name,
-        function(err, allowed) {
-          if(err) {
-            next(err);
-          } else if(allowed) {
-            next();
-          } else {
-            var e = new Error('Access Denied');
-            e.statusCode = 401;
-            next(e);
-          }
+    Model.checkAccess(
+      req.accessToken || AccessToken.ANONYMOUS_TOKEN,
+      modelId,
+      method.name,
+      function(err, allowed) {
+        if(err) {
+          next(err);
+        } else if(allowed) {
+          next();
+        } else {
+          var e = new Error('Access Denied');
+          e.statusCode = 401;
+          next(e);
         }
-      );
-    } else if(
-      Model.requireToken === false ||
-      Model.settings.requireToken === false ||
-      method.fn && method.fn.requireToken === false
-    ) {
-      next();
-    } else {
-      var e = new Error('Access Denied');
-      e.statusCode = 401;
-
-      next(e);
-    }
+      }
+    );
   });
 }
 
@@ -287,12 +275,14 @@ app.boot = function(options) {
   }
 
   // disable token requirement for swagger, if available
-  var swagger = app.remotes().exports.swagger;
-  var requireTokenForSwagger = appConfig.swagger
-                            && appConfig.swagger.requireToken;
-  if(swagger) {
-    swagger.requireToken = requireTokenForSwagger || false;
-  }
+  process.nextTick(function() {
+    var swagger = app.remotes().exports.swagger;
+    var requireTokenForSwagger = appConfig.swagger
+                              && appConfig.swagger.requireToken;
+    if(swagger) {
+      swagger.requireToken = requireTokenForSwagger || false;
+    }
+  });
 
   // require directories
   var requiredModels = requireDir(path.join(appRootDir, 'models'));

--- a/lib/loopback.js
+++ b/lib/loopback.js
@@ -269,3 +269,9 @@ loopback.RoleMapping.autoAttach = dataSourceTypes.DB;
 loopback.ACL.autoAttach = dataSourceTypes.DB;
 loopback.Scope.autoAttach = dataSourceTypes.DB;
 loopback.Application.autoAttach = dataSourceTypes.DB;
+
+/**
+ * Mocha test helpers
+ */
+
+loopback.testing = require('./testing');

--- a/lib/models/access-token.js
+++ b/lib/models/access-token.js
@@ -9,7 +9,8 @@ var Model = require('../loopback').Model
   , uid = require('uid2')
   , DEFAULT_TTL = 1209600 // 2 weeks in seconds
   , DEFAULT_TOKEN_LEN = 64
-  , ACL = require('./acl').ACL;
+  , ACL = require('./acl').ACL
+  , Role = require('./role');
 
 /**
  * Default AccessToken properties.
@@ -27,7 +28,19 @@ var properties = {
  * Extends from the built in `loopback.Model` type.
  */
 
-var AccessToken = module.exports = Model.extend('AccessToken', properties);
+var AccessToken = module.exports = Model.extend('AccessToken', properties, {
+  acls: [
+    {
+      principalType: ACL.ROLE,
+      principalType: Role.EVERYONE,
+      property: 'create',
+      permission: ACL.ALLOW
+    }
+  ],
+  foo: 'bar'
+});
+
+AccessToken.ANONYMOUS_TOKEN = new AccessToken({id: '$anonymous'});
 
 /**
  * Create a cryptographically random access token id.

--- a/lib/models/acl.js
+++ b/lib/models/acl.js
@@ -371,6 +371,7 @@ ACL.checkAccessForToken = function(token, model, modelId, method, callback) {
     accessType: modelCtor._getAccessTypeForMethod(method),
     id: modelId
   };
+
   ACL.checkAccess(context, function(err, access) {
     if(err) {
       callback && callback(err);

--- a/lib/models/model.js
+++ b/lib/models/model.js
@@ -4,6 +4,7 @@
 var loopback = require('../loopback');
 var ModelBuilder = require('loopback-datasource-juggler').ModelBuilder;
 var modeler = new ModelBuilder();
+var assert = require('assert');
 
 /**
  * Define the built in loopback.Model.

--- a/lib/testing.js
+++ b/lib/testing.js
@@ -1,0 +1,243 @@
+var _describe = {};
+var _it = {};
+var _beforeEach = {};
+var helpers = module.exports = {
+  describe: _describe,
+  it: _it,
+  beforeEach: _beforeEach
+};
+var loopback = require('./loopback');
+var assert = require('assert');
+var request = require('supertest');
+var qs = require('qs');
+
+_beforeEach.withApp = function(app) {
+  beforeEach(function() {
+    this.app = app;
+    var _request = this.request = request(app);
+    this.post = _request.post;
+    this.get = _request.get;
+    this.put = _request.put;
+    this.del = _request.del;
+  });
+}
+
+_describe.model = function describeModel(app, modelName, cb) {
+  assert(app, 'describeModel called without app');
+
+  describe('Model: ' + modelName, function() {
+    beforeEach(function() {
+      this.app = app;
+      this.model = loopback.getModel(modelName);
+      assert(this.model, 'you must define a model before testing it');
+    });
+    cb();
+  });
+}
+
+function mixin(obj, into) {
+  Object.keys(obj).forEach(function(key) {
+    if(typeof obj[key] === 'function') {
+      into[key] = obj[key];
+    }
+  });
+}
+
+_describe.staticMethod = function(methodName, cb) {
+  describe('.' + methodName, function() {
+    beforeEach(function() {
+      this.method = methodName;
+      this.isStaticMethod = true;
+    });
+    cb();
+  });
+}
+
+_describe.instanceMethod = function(methodName, cb) {
+  describe('.prototype.' + methodName, function() {
+    beforeEach(function() {
+      this.method = methodName;
+      this.isInstanceMethod = true;
+    });
+    cb();
+  });
+}
+
+_beforeEach.withArgs = function() {
+  var args = Array.prototype.slice.call(arguments, 0);
+  beforeEach(function() {
+    this.args = args;
+  });
+}
+
+_beforeEach.givenModel = function(modelName, attrs, optionalHandler) {
+  if(typeof attrs === 'funciton') {
+    optionalHandler = attrs;
+    attrs = undefined;
+  }
+
+  attrs = attrs || {};
+
+  var model = loopback.getModel(modelName);
+
+  beforeEach(function(done) {
+    var test = this;
+    model.create(attrs, function(err, result) {
+      if(err) {
+        done(err);
+      } else {
+        test[modelName] = result;
+        done();
+      }
+    });
+  });
+
+  if(typeof optionalHandler === 'function') {
+    beforeEach(optionalHandler);
+  }
+
+  afterEach(function(done) {
+    this[modelName].destroy(done);
+  });
+}
+
+_beforeEach.givenUser = function(attrs, optionalHandler) {
+  _beforeEach.givenModel('user', attrs, optionalHandler);
+}
+
+_beforeEach.givenAnUnauthenticatedToken = function(attrs, optionalHandler) {
+  _beforeEach.givenModel('accessToken', attrs, optionalHandler);
+}
+
+_beforeEach.givenAnAnonymousToken = function(attrs, optionalHandler) {
+  _beforeEach.givenModel('accessToken', {id: '$anonymous'}, optionalHandler);
+}
+
+_describe.whenCalledRemotely = function(verb, url, cb) {
+  var urlStr = url;
+  if(typeof url === 'function') {
+    urlStr = '/<dynamic>';
+  }
+  describe(verb.toUpperCase() + ' ' + urlStr, function() {
+    beforeEach(function(cb) {
+      if(typeof url === 'function') {
+        url = url.call(this);
+      }
+      this.remotely = true;
+      this.verb = verb.toUpperCase();
+      this.url = url;
+      var methodForVerb = verb.toLowerCase();
+      if(methodForVerb === 'delete') methodForVerb = 'del';
+
+      this.http = this.request[methodForVerb](url);
+      this.http.set('Accept', 'application/json');
+      this.req = this.http.req;
+      var test = this;
+      this.http.end(function(err) {
+        test.res = test.http.res;
+        cb();
+      });
+    });
+
+    cb();
+  });
+}
+
+_describe.whenCalledByUser = function(credentials, verb, url, cb) {
+  _describe.whenLoggedInAsUser(credentials, function() {
+    _describe.whenCalledRemotely(verb, url, cb);
+  });
+}
+
+_describe.whenCalledAnonymously = function(verb, url, cb) {
+  _describe.whenCalledRemotely(verb, url, function() {
+    _beforeEach.givenAnAnonymousToken();
+    cb();
+  });
+}
+
+_describe.whenCalledUnauthenticated = function(verb, url, cb) {
+  _describe.whenCalledRemotely(verb, url, function() {
+    _beforeEach.givenAnUnauthenticatedToken();
+    cb();
+  });
+}
+
+_describe.whenLoggedInAsUser = function(credentials, cb) {
+  describe('when logged in user', function() {
+    _beforeEach.givenUser(credentials, function(done) {
+      var test = this;
+      this.remotely = true;
+      this.user.constructor.login(credentials, function(err, token) {
+        if(err) {
+          done(err);
+        } else {
+          test.accessToken = token;
+          test.req.set('authorization', token.id);
+          done();
+        }
+      });
+    });
+
+    afterEach(function(done) {
+      this.accessToken.destroy(done);
+    });
+  });
+}
+
+_it.shouldBeAllowed = function() {
+  it('should be allowed', function() {
+    assert(this.req);
+    assert(this.res);
+    assert.notEqual(this.res.statusCode, 401);
+  });
+}
+
+_it.shouldBeDenied = function() {
+  it('should not be allowed', function() {
+    assert(this.res);
+    assert.equal(this.res.statusCode, 401);
+  });
+}
+
+_it.shouldBeAllowedWhenCalledAnonymously =
+function(verb, url) {
+  _describe.whenCalledAnonymously(verb, url, function() {
+    _it.shouldBeAllowed();
+  });
+}
+
+_it.shouldBeDeniedWhenCalledAnonymously =
+function(verb, url) {
+  _describe.whenCalledAnonymously(verb, url, function() {
+    _it.shouldBeDenied();
+  });
+}
+
+_it.shouldBeAllowedWhenCalledUnauthenticated =
+function(verb, url) {
+  _describe.whenCalledUnauthenticated(verb, url, function() {
+    _it.shouldBeAllowed();
+  });
+}
+
+_it.shouldBeDeniedWhenCalledUnauthenticated =
+function(verb, url) {
+  _describe.whenCalledUnauthenticated(verb, url, function() {
+    _it.shouldBeDenied();
+  });
+}
+
+_it.shouldBeAllowedWhenCalledByUser =
+function(credentials, verb, url) {
+  _describe.whenCalledByUser(credentials, verb, url, function() {
+    _it.shouldBeAllowed();
+  });
+}
+
+_it.shouldBeDeniedWhenCalledByUser =
+function(credentials, verb, url) {
+  _describe.whenCalledByUser(credentials, verb, url, function() {
+    _it.shouldBeDenied();
+  });
+}

--- a/package.json
+++ b/package.json
@@ -25,8 +25,10 @@
     "bcryptjs": "~0.7.10",
     "underscore.string": "~2.3.3",
     "underscore": "~1.5.2",
+    "supertest": "~0.8.1",
     "uid2": "0.0.3",
-    "async": "~0.2.9"
+    "async": "~0.2.9",
+    "qs": "~0.6.6"
   },
   "peerDependencies": {
     "loopback-datasource-juggler": "~1.2.0"
@@ -34,8 +36,7 @@
   "devDependencies": {
     "loopback-datasource-juggler": "~1.2.0",
     "mocha": "~1.14.0",
-    "strong-task-emitter": "0.0.x",
-    "supertest": "~0.8.1"
+    "strong-task-emitter": "0.0.x"
   },
   "repository": {
     "type": "git",

--- a/test/access-token.test.js
+++ b/test/access-token.test.js
@@ -42,6 +42,12 @@ describe('AccessToken', function () {
     assert.equal(this.token.id.length, 64);
   });
 
+  describe('AccessToken.ANONYMOUS_TOKEN', function () {
+    it('should have an id of $anonymous', function () {
+      assert.equal(Token.ANONYMOUS_TOKEN.id, '$anonymous');
+    });
+  });
+
   it('should auto-generate created date', function () {
     assert(this.token.created);
     assert(Object.prototype.toString.call(this.token.created), '[object Date]');

--- a/test/testing.test.js
+++ b/test/testing.test.js
@@ -1,0 +1,64 @@
+var loopback = require('../');
+var helpers = loopback.testing;
+
+describe('loopback.testing', function () {
+  var testApp = loopback();
+  var db = testApp.dataSource('db', {connector: loopback.Memory});
+  var testModel = testApp.model('xxx-test-model', {dataSource: 'db'});
+
+  testApp.use(loopback.rest());
+
+  helpers.beforeEach.withApp(testApp);
+
+  describe('helpers.it', function() {
+    ['shouldBeAllowed',
+     'shouldBeDenied']
+    .forEach(function(func) {
+      it('should have a method named ' + func, function () {
+        assert.equal(typeof helpers.it[func], 'function');
+      });
+    });
+  });
+
+  describe('helpers.describe', function() {
+    ['staticMethod',
+     'whenLoggedInAsUser',
+     'whenCalledAnonymously',
+     'model']
+    .forEach(function(func) {
+      it('should have a method named ' + func, function () {
+        assert.equal(typeof helpers.describe[func], 'function');
+      });
+    });
+  });
+
+  describe('helpers.beforeEach', function() {
+    ['withArgs',
+     'givenModel',
+     'givenUser']
+    .forEach(function(func) {
+      it('should have a helper method named ' + func, function () {
+        assert.equal(typeof helpers.beforeEach[func], 'function');
+      });
+    });
+  });
+
+  describe('helpers.beforeEach.givenModel', function() {
+    helpers.beforeEach.givenModel('AccessToken');
+    it('should have an AccessToken property', function () {
+      assert(this.AccessToken);
+      assert(this.AccessToken.id);
+    });
+  });
+
+  describe('whenCalledRemotely', function() {
+    helpers.describe.staticMethod('create', function() {
+      helpers.beforeEach.withArgs({foo: 'bar'});
+      helpers.describe.whenCalledRemotely('POST', '/xxx-test-models', function() {
+        it('should call the method over rest', function () {
+          assert.equal(this.res.statusCode, 200);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
/to @bajtos 
/cc @raymondfeng 

Here is some example tests using these helpers:

This patch also includes some changes to the way tokens are authenticated. Can you take a look @raymondfeng?

``` js
helpers.describeModel(app, 'accessToken', function() {
  helpers.staticMethod('create', function() {
    helpers.withArgs({});
    helpers.anonymously(function() {
      helpers.remotely('POST', '/api/accessTokens', function() {
        helpers.shouldBeAllowed();
      });
    });
  });
  helpers.staticMethod('find', function() {
    helpers.anonymously(function() {
      helpers.remotely('GET', '/api/accessTokens', function() {
        helpers.shouldBeDenied();
      });
    });
  });
  helpers.staticMethod('findById', function() {
    helpers.anonymously(function() {
      helpers.givenModel('accessToken');
      helpers.remotely('GET', urlForToken, function() {
        helpers.shouldBeDenied();
      });
    });
  });
  helpers.staticMethod('updateOrCreate', function() {
    helpers.anonymously(function() {
      helpers.givenModel('accessToken');
      helpers.remotely('PUT', urlForToken, function() {
        helpers.shouldBeDenied();
      });
    });
  });
  helpers.staticMethod('removeById', function() {
    helpers.anonymously(function() {
      helpers.givenModel('accessToken');
      helpers.remotely('DELETE', urlForToken, function() {
        helpers.shouldBeDenied();
      });
    });
  });
});
```
