### PR TITLE
Define schema for GCM push-notification settings

### DIFF
--- a/lib/models/application.js
+++ b/lib/models/application.js
@@ -23,11 +23,14 @@ var APNSSettingSchema = {
     }}
 };
 
+var GcmSettingsSchema = {
+  serverApiKey: String
+}
+
 // Push notification settings
 var PushNotificationSettingSchema = {
-    platform: {type: String, required: true}, // apns, gcm, mpns
-    // configuration: {type: Object} // platform-specific configurations
-    apns: APNSSettingSchema
+    apns: APNSSettingSchema,
+    gcm: GcmSettingsSchema
 };
 
 /**


### PR DESCRIPTION
Remove unused property PushNotificationSettingSchema.platform.

Flatten GCM settings schema. There is no need to distinquish between
pushOptions and feedback, as there is only single HTTP channel shared
by both.

/to @raymondfeng please review.
