### PR TITLE
app.boot() now loads the "boot" directory

### DIFF
--- a/docs/api-app.md
+++ b/docs/api-app.md
@@ -58,6 +58,7 @@ Initialize an application from an options object or a set of JSON and JavaScript
 1. **DataSources** are created from an `options.dataSources` object or `datasources.json` in the current directory
 2. **Models** are created from an `options.models` object or `models.json` in the current directory
 3. Any JavaScript files in the `./models` directory are loaded with `require()`.
+4. Any JavaScript files in the `./boot` directory are loaded with `require()`.
 
 **Options**
 

--- a/lib/application.js
+++ b/lib/application.js
@@ -290,6 +290,7 @@ app.boot = function(options) {
 
   // require directories
   var requiredModels = requireDir(path.join(appRootDir, 'models'));
+  var requiredBootScripts = requireDir(path.join(appRootDir, 'boot'));
 }
 
 function assertIsValidConfig(name, config) {

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -1,3 +1,6 @@
+var path = require('path');
+var SIMPLE_APP = path.join(__dirname, 'fixtures', 'simple-app');
+
 describe('app', function() {
 
   describe('app.model(Model)', function() {
@@ -73,6 +76,23 @@ describe('app', function() {
         bar: 'bat'
       });
       expect(this.app.get('baz')).to.eql(true);
+    });
+
+    describe('boot and models directories', function() {
+      beforeEach(function() {
+        var app = this.app = loopback();
+        app.boot(SIMPLE_APP);
+      });
+
+      it('should run all modules in the boot directory', function () {
+        assert(process.loadedFooJS);
+        delete process.loadedFooJS;
+      });
+
+      it('should run all modules in the models directory', function () {
+        assert(process.loadedBarJS);
+        delete process.loadedBarJS;
+      });
     });
 
     describe('PaaS and npm env variables', function() {
@@ -162,7 +182,7 @@ describe('app', function() {
     it('Load config files', function () {
       var app = loopback();
 
-      app.boot(require('path').join(__dirname, 'fixtures', 'simple-app'));
+      app.boot(SIMPLE_APP);
 
       assert(app.models.foo);
       assert(app.models.Foo);

--- a/test/fixtures/simple-app/boot/bad.txt
+++ b/test/fixtures/simple-app/boot/bad.txt
@@ -1,0 +1,1 @@
+this is not a js file!

--- a/test/fixtures/simple-app/boot/foo.js
+++ b/test/fixtures/simple-app/boot/foo.js
@@ -1,0 +1,1 @@
+process.loadedFooJS = true;

--- a/test/fixtures/simple-app/models/bar.js
+++ b/test/fixtures/simple-app/models/bar.js
@@ -1,0 +1,1 @@
+process.loadedBarJS = true;


### PR DESCRIPTION
/to @bajtos 
/cc @sam-github @raymondfeng 

The idea here is pretty straightforward. We load any `.js` scripts in the `boot` directory before we load any in the `models` directory. Its useful for the following cases.
- Setup anything your app needs directly after it is booted
- Run your own boot specific scripts without modifying `app.js`

The issue I'm still thinking about is what exact order makes sense. Where I've landed is that we need a set of events instead of enforcing any order on loaded scripts. This means that the splitting up of `boot` and `models` is mostly semantic. Anything you could do in a `boot` script you could just do in a `models` script.
