### PR TITLE
Add ValidationError to loopback exports.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
  */
  
 var loopback = module.exports = require('./lib/loopback');
+var datasourceJuggler = require('loopback-datasource-juggler');
 
 /**
  * Connectors
@@ -17,3 +18,4 @@ loopback.Mail = require('./lib/connectors/mail');
  */
 
 loopback.GeoPoint = require('loopback-datasource-juggler/lib/geo').GeoPoint;
+loopback.ValidationError = datasourceJuggler.ValidationError;

--- a/test/loopback.test.js
+++ b/test/loopback.test.js
@@ -1,4 +1,11 @@
 describe('loopback', function() {
+  describe('exports', function() {
+    it('ValidationError', function() {
+      expect(loopback.ValidationError).to.be.a('function')
+        .and.have.property('name', 'ValidationError');
+    });
+  });
+
   describe('loopback.createDataSource(options)', function(){
     it('Create a data source with a connector.', function() {
       var dataSource = loopback.createDataSource({


### PR DESCRIPTION
Simplify the construction of validation errors in user-land code:

``` js
var error = new loopback.ValidationError(invalidModel);
```

/to: @ritch @raymondfeng 

See also strongloop/loopback-push-notification#22.
