### PR TITLE
Add app.restApiRoot setting

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -241,6 +241,11 @@ app.boot = function(options) {
     app.get('port') || 
     3000;
 
+  appConfig.restApiRoot =
+    appConfig.restApiRoot ||
+    app.get('restApiRoot') ||
+    '/api';
+
   if(appConfig.host !== undefined) {
     assert(typeof appConfig.host === 'string', 'app.host must be a string');
     app.set('host', appConfig.host);
@@ -251,6 +256,11 @@ app.boot = function(options) {
     assert(portType === 'string' || portType === 'number', 'app.port must be a string or number');
     app.set('port', appConfig.port);
   }
+
+  assert(appConfig.restApiRoot !== undefined, 'app.restBasePath is required');
+  assert(typeof appConfig.restApiRoot === 'string', 'app.restBasePath must be a string');
+  assert(/^\//.test(appConfig.restApiRoot), 'app.restBasePath must start with "/"');
+  app.set('restApiRoot', appConfig.restBasePath);
 
   for(var configKey in appConfig) {
     var cur = app.get(configKey);

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -44,6 +44,7 @@ describe('app', function() {
         app: {
           port: 3000, 
           host: '127.0.0.1',
+          restApiRoot: '/rest-api',
           foo: {bar: 'bat'},
           baz: true
         },
@@ -69,6 +70,10 @@ describe('app', function() {
 
     it('should have host setting', function() {
       assert.equal(this.app.get('host'), '127.0.0.1');
+    });
+
+    it('should have restApiRoot setting', function() {
+      assert.equal(this.app.get('restApiRoot'), '/rest-api');
     });
 
     it('should have other settings', function () {


### PR DESCRIPTION
Allow loopback users to configure API root via config file, instead of
editing app.js generated by loopback-workspace.

Allow loopback plugins to discover the path where the REST adapter is
mounted.

/to: @ritch 
