### PR TITLE
Fix/mail transports

### DIFF
--- a/lib/connectors/mail.js
+++ b/lib/connectors/mail.js
@@ -3,7 +3,8 @@
  */
 
 var mailer = require('nodemailer')
-  , assert = require('assert');
+  , assert = require('assert')
+  , debug = require('debug');
 
 /**
  * Export the MailConnector class.
@@ -19,6 +20,7 @@ function MailConnector(settings) {
   assert(typeof settings === 'object', 'cannot initiaze MailConnector without a settings object');
   var transports = settings.transports || [];
   this.transportsIndex = {};
+  this.transports = transports;
 
   transports.forEach(this.setupTransport.bind(this));
 }
@@ -87,9 +89,8 @@ Mailer.send = function (options, fn) {
   var connector = dataSource.connector;
   var transportsIndex = connector.transportsIndex;
   var transport = transportsIndex[options.transport || 'SMTP'] || connector.transports[0];
-  assert(transport, 'You must supply an Email.settings.transports array containing at least one transport');
   
-  if(settings && settings.debug) {
+  if(debug.enabled || settings && settings.debug) {
     console.log('Sending Mail:');
     if(options.transport) {
       console.log('\t TRANSPORT:', options.transport);
@@ -101,7 +102,16 @@ Mailer.send = function (options, fn) {
     console.log('\t HTML:', options.html);
   }
 
-  transport.sendMail(options, fn);
+  if(transport) {
+    assert(transport.sendMail, 'You must supply an Email.settings.transports containing a valid transport');
+    transport.sendMail(options, fn);
+  } else {
+    console.warn('Warning: No email transport specified for sending email.'
+      + ' Setup a transport to send mail messages.');
+    process.nextTick(function() {
+      fn(null, options);
+    });
+  }
 }
 
 /**


### PR DESCRIPTION
/to @raymondfeng @bajtos 

This provides a sane default for the mail connector.

Given the following example you will see a warning. Maybe it should just throw. If that is the case we should provide a "testing" transport similar to the memory connector that will work out of the box with a new LB app.

``` js
var email = require('app').models.email;

email.send({
  to: 'joe@bob.com',
  from: 'bob@jim.com',
  subject: 'hey man'
}, function (err, msg) {
  console.log(msg);
});
```

``` sh
# output
Warning: No email transport specified for sending email. Setup a transport to send mail messages.
{ to: 'joe@bob.com', from: 'bob@jim.com', subject: 'hey man' }
```
