### PR TITLE
Implement app.installMiddleware

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -439,6 +439,131 @@ function tryReadConfig(cwd, fileName) {
   }
 }
 
+/**
+ * Install all express middleware required by LoopBack.
+ *
+ * It is possible to inject your own middleware by listening on one of the
+ * following events:
+ *
+ *  - `middleware:preprocessors` is emitted after all other
+ *    request-preprocessing middleware was installed, but before any
+ *    request-handling middleware is configured.
+ *
+ *    Usage:
+ *    ```js
+ *    app.on('middleware:preprocessors', function() {
+ *      app.use(loopback.limit('5.5mb'))
+ *    });
+ *    ```
+ *  - `middleware:handlers` is emitted when it's time to add your custom
+ *    request-handling middleware. Note that you should not install any
+ *    express routes at this point (express routes are discussed later).
+ *
+ *    Usage:
+ *    ```js
+ *    app.on('middleware:handlers', function() {
+ *      app.use('/admin', adminExpressApp);
+ *      app.use('/custom', function(req, res, next) {
+ *        res.send(200, { url: req.url });
+ *      });
+ *    });
+ *    ```
+ *  - `middleware:error-loggers` is emitted at the end, before the loopback
+ *    error handling middleware is installed. This is the point where you
+ *    can install your own middleware to log errors.
+ *
+ *    Notes:
+ *     - The middleware function must take four parameters, otherwise it won't
+ *       be called by express.
+ *
+ *     - It should also call `next(err)` to let the loopback error handler convert
+ *       the error to an HTTP error response.
+ *
+ *    Usage:
+ *    ```js
+ *    var bunyan = require('bunyan');
+ *    var log = bunyan.createLogger({name: "myapp"});
+ *    app.on('middleware:error-loggers', function() {
+ *      app.use(function(err, req, res, next) {
+ *        log.error(err);
+ *        next(err);
+ *      });
+ *    });
+ *    ```
+ *
+ * Express routes should be added after `installMiddleware` was called.
+ * This way the express router middleware is injected at the right place in the
+ * middleware chain. If you add an express route before calling this function,
+ * bad things will happen: Express will automatically add the router
+ * middleware and since we haven't added request-preprocessing middleware like
+ * cookie & body parser yet, your route handlers will receive raw unprocessed
+ * requests.
+ *
+ * This is the correct order in which to call `app` methods:
+ * ```js
+ * app.boot(__dirname); // optional
+ *
+ * app.installMiddleware();
+ *
+ * // [register your express routes here]
+ *
+ * app.listen();
+ * ```
+ */
+app.installMiddleware = function() {
+  var loopback = require('../');
+
+  /*
+   * Request pre-processing
+   */
+  this.use(loopback.favicon());
+  // TODO(bajtos) refactor to app.get('loggerFormat')
+  var loggerFormat = this.get('env') === 'development' ? 'dev' : 'default';
+  this.use(loopback.logger(loggerFormat));
+  this.use(loopback.cookieParser(this.get('cookieSecret')));
+  this.use(loopback.token({ model: this.models.accessToken }));
+  this.use(loopback.bodyParser());
+  this.use(loopback.methodOverride());
+
+  // Allow the app to install custom preprocessing middleware
+  this.emit('middleware:preprocessors');
+
+  /*
+   * Request handling
+   */
+
+  // LoopBack REST transport
+  this.use(this.get('restApiRoot') || '/api', loopback.rest());
+
+  // Allow the app to install custom request handling middleware
+  this.emit('middleware:handlers');
+
+  // Let express routes handle requests that were not handled
+  // by any of the middleware registered above.
+  // This way LoopBack REST and API Explorer take precedence over
+  // express routes.
+  this.use(this.router);
+
+  // The static file server should come after all other routes
+  // Every request that goes through the static middleware hits
+  // the file system to check if a file exists.
+  this.use(loopback.static(path.join(__dirname, 'public')));
+
+  // Requests that get this far won't be handled
+  // by any middleware. Convert them into a 404 error
+  // that will be handled later down the chain.
+  this.use(loopback.urlNotFound());
+
+  /*
+   * Error handling
+   */
+
+  // Allow the app to install custom error logging middleware
+  this.emit('middleware:error-handlers');
+
+  // The ultimate error handler.
+  this.use(loopback.errorHandler());
+};
 
 /**
  * Listen for connections and update the configured port.

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -197,6 +197,102 @@ describe('app', function() {
     });
   });
 
+  describe('installMiddleware()', function() {
+    var app;
+    beforeEach(function() { app = loopback(); });
+
+    it('installs loopback.token', function(done) {
+      app.models.accessToken = loopback.AccessToken;
+
+      app.installMiddleware();
+
+      app.get('/', function(req, res) {
+        res.send({ accessTokenId: req.accessToken && req.accessToken.id });
+      });
+
+      app.models.accessToken.create({}, function(err, token) {
+        if (err) done(err);
+        request(app).get('/')
+          .set('Authorization', token.id)
+          .expect(200, { accessTokenId: token.id })
+          .end(done);
+      });
+    });
+
+    it('emits "middleware:preprocessors" before handlers are installed',
+      function(done) {
+        app.on('middleware:preprocessors', function() {
+          this.use(function(req, res, next) {
+            req.preprocessed = true;
+            next();
+          });
+        });
+
+        app.installMiddleware();
+
+        app.get('/', function(req, res) {
+          res.send({ preprocessed: req.preprocessed });
+        });
+
+        request(app).get('/')
+          .expect(200, { preprocessed: true})
+          .end(done);
+      }
+    );
+
+    it('emits "middleware:handlers before installing express router',
+      function(done) {
+        app.on('middleware:handlers', function() {
+          this.use(function(req, res, next) {
+            res.send({ handler: 'middleware' });
+          });
+        });
+
+        app.installMiddleware();
+
+        app.get('/', function(req, res) {
+          res.send({ handler: 'router' });
+        });
+
+        request(app).get('/')
+          .expect(200, { handler: 'middleware' })
+          .end(done);
+      }
+    );
+
+    it('emits "middleware:error-handlers" after all request handlers',
+      function(done) {
+        var logs = [];
+        app.on('middleware:error-handlers', function() {
+          app.use(function(err, req, res, next) {
+            logs.push(req.url);
+            next(err);
+          });
+        });
+
+        app.installMiddleware();
+
+        request(app).get('/not-found')
+          .expect(404)
+          .end(function(err, res) {
+            if (err) done(err);
+            expect(logs).to.eql(['/not-found']);
+            done();
+          });
+      }
+    );
+
+    it('installs REST transport', function(done) {
+      app.model(loopback.Application);
+      app.set('restApiRoot', '/api');
+      app.installMiddleware();
+
+      request(app).get('/api/applications')
+        .expect(200, [])
+        .end(done);
+    });
+  });
+
   describe('listen()', function() {
     it('starts http server', function(done) {
       var app = loopback();


### PR DESCRIPTION
The implementation is mostly a copy of [loopback-workspace/templates/app.js](https://github.com/strongloop/loopback-workspace/blob/e7214ee150e0e5f467e55fa89e8fc9ad93e0d75b/templates/app.js).

What was omitted:
- loopback-explorer. It should be configured from `boot/explorer.js`
  
  ``` js
  try {
    var explorer = require('loopback-explorer');
    app.on('middleware:handlers', function() {
      app.use('/explorer', explorer(app));
    });
    app.on('start', function() {
      console.log('explorer available at etc.');
    });
  } catch(e){
    console.log('run npm install loopback-explorer etc.');
  }
  ```
- status report at the root URL, which is is an ordinary express route and should never go to `app.installMiddleware`. I don't have a solution for loading express routes yet, I suppose we should auto-load all files from `routes/` directory. Anyhow, (custom) express routes are out of scope of this pull request.
  
  ``` js
  // this is the code in app.js
  app.get('/', loopback.status())
  ```
- authentication & swagger remotes.
  
  ``` js
  var swaggerRemote = app.remotes().exports.swagger;
  if (swaggerRemote) swaggerRemote.requireToken = false;
  
  app.enableAuth();
  ```
  
  This code does not belong to `installMiddleware`, so I am keeping it in app.js template for now.

See API docs for description and examples on how to use the new method.

This is how the new app.js template should look like:

``` js
// require()s, cluster setup, etc.

app.boot(__dirname);
app.installMiddleware();

// TODO - move to strong-remoting, loopback-explorer or boot/auth.js
var swaggerRemote = app.remotes().exports.swagger;
if (swaggerRemote) swaggerRemote.requireToken = false;

// TODO - move to boot/auth.js
app.enableAuth();

app.start = function() {
  // skipped here
}

if(require.main === module) {
  app.start();
}
```

/to @ritch @sam-github please review
/cc @raymondfeng @Schoonology 
