### PR TITLE
Speed up tests accessing User.password

### DIFF
--- a/test/support.js
+++ b/test/support.js
@@ -11,6 +11,11 @@ app = null;
 TaskEmitter = require('strong-task-emitter');
 request = require('supertest');
 
+
+// Speed up the password hashing algorithm
+// for tests using the built-in User model
+loopback.User.settings.saltWorkFactor = 4;
+
 beforeEach(function () {
   app = loopback();
 


### PR DESCRIPTION
Decrease User.settings.saltWorkFactor in order to speed up unit-tests.

See also strongloop/loopback-testing#10

Interestingly enough, both changes are necessary.

/to: @ritch or @raymondfeng please review.
