### PR TITLE
Replace `on` with `once` in middleware examples

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -451,7 +451,7 @@ function tryReadConfig(cwd, fileName) {
  *
  *    Usage:
  *    ```js
- *    app.on('middleware:preprocessors', function() {
+ *    app.once('middleware:preprocessors', function() {
  *      app.use(loopback.limit('5.5mb'))
  *    });
  *    ```
@@ -461,7 +461,7 @@ function tryReadConfig(cwd, fileName) {
  *
  *    Usage:
  *    ```js
- *    app.on('middleware:handlers', function() {
+ *    app.once('middleware:handlers', function() {
  *      app.use('/admin', adminExpressApp);
  *      app.use('/custom', function(req, res, next) {
  *        res.send(200, { url: req.url });
@@ -483,7 +483,7 @@ function tryReadConfig(cwd, fileName) {
  *    ```js
  *    var bunyan = require('bunyan');
  *    var log = bunyan.createLogger({name: "myapp"});
- *    app.on('middleware:error-loggers', function() {
+ *    app.once('middleware:error-loggers', function() {
  *      app.use(function(err, req, res, next) {
  *        log.error(err);
  *        next(err);


### PR DESCRIPTION
Fix the jsdox for `app.installMiddleware` to use `app.once` for
listening on 'middleware:*' events.

The previous doc version using `on` was a sort of preliminary
pessimisation, becase the event handlers would stay in the heap
for the whole life-time of the app, even though they won't be called
more than once.

/cc: @ritch

See also the [comment](https://github.com/strongloop/loopback-workspace/pull/37#discussion_r8849677) in loopback-workspace#37.
