### PR TITLE
Support custom setup of static middleware.

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -651,6 +651,7 @@ function tryReadConfig(cwd, fileName) {
  *      app.use(loopback.limit('5.5mb'))
  *    });
  *    ```
+
  *  - `middleware:handlers` is emitted when it's time to add your custom
  *    request-handling middleware. Note that you should not install any
  *    express routes at this point (express routes are discussed later).
@@ -664,6 +665,21 @@ function tryReadConfig(cwd, fileName) {
  *      });
  *    });
  *    ```
+
+ *  - `middleware:static` is emitted just before the 404 handler is installed.
+ *    Use it to install middleware serving static files.
+ *
+ *    Since every request that goes through the static middleware hits
+ *    the file system to check if the file exists, the static middleware should
+ *    be installed at the very end of the middleware chain.
+ *
+ *    Usage:
+ *    ```js
+ *    app.once('middleware:static', function() {
+ *      app.use(loopback.static(path.join(__dirname, 'public')));
+ *    });
+ *    ```
+ *
  *  - `middleware:error-loggers` is emitted at the end, before the loopback
  *    error handling middleware is installed. This is the point where you
  *    can install your own middleware to log errors.
@@ -743,7 +759,7 @@ app.installMiddleware = function() {
   // The static file server should come after all other routes
   // Every request that goes through the static middleware hits
   // the file system to check if a file exists.
-  this.use(loopback.static(path.join(__dirname, 'public')));
+  this.emit('middleware:static');
 
   // Requests that get this far won't be handled
   // by any middleware. Convert them into a 404 error

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -291,6 +291,30 @@ describe('app', function() {
         .expect(200, [])
         .end(done);
     });
+
+    it('emits "middleware:static" after express router', function(done) {
+      app.on('middleware:static', function() {
+        this.use(function(req, res, next) {
+          res.send({ handler: 'static' });
+        });
+      });
+
+      app.installMiddleware();
+
+      app.get('/router', function(req, res) {
+        res.send({ handler: 'router' });
+      });
+
+      // First check the middleware order
+      request(app).get('/router')
+        .expect(200, { handler: 'router' })
+        .end(function() {
+          // Then check that the static router was installed
+          request(app).get('/static')
+            .expect(200, { handler: 'static' })
+            .end(done);
+        });
+    });
   });
 
   describe('listen()', function() {


### PR DESCRIPTION
Add `middleware:static` event that allows LB application to install
middleware serving static files.

Remove the hard-coded static middleware serving the content of `public/`
subdirectory.

Close #140 

/to: @ritch please review.
