### PR TITLE
Improve the error message when ACL is not attached

### DIFF
--- a/lib/models/acl.js
+++ b/lib/models/acl.js
@@ -307,6 +307,11 @@ ACL.prototype.debug = function() {
  * @param {Function} callback
  */
 ACL.checkAccess = function (context, callback) {
+  if (!this.find) {
+    return callback(new Error('ACL model is not attached to a datasource.' +
+      ' Make sure your application calls app.autoAttach().'));
+  }
+
   if(!(context instanceof AccessContext)) {
     context = new AccessContext(context);
   }

--- a/test/acl.test.js
+++ b/test/acl.test.js
@@ -263,6 +263,28 @@ describe('security ACLs', function () {
     });
   });
 
+  it('should report helpful error when ACL is not attached', function(done) {
+    // HACK(bajtos) We need an ACL model that was not attached yet
+    // Since other tests are already attaching ACL to a datasource,
+    // we have to reload the module.
+    delete require('module')._cache[require.resolve('../lib/models/acl.js')];
+    acl = require('../lib/models/acl');
+    loopback.ACL = ACL = acl.ACL;
+    loopback.Scope = Scope = acl.Scope;
+
+    // Verify the assumption that ACL.find is not defined yet
+    expect(ACL.find).to.equal(undefined);
+
+    ACL.checkAccess({
+      model: 'User',
+      property: ACL.ALL,
+      accessType: ACL.ALL
+    }, function(err) {
+      if (!err) done(new Error('ACL.checkAccess was supposed to throw'));
+      expect(err.message).to.contain('app.autoAttach');
+      done();
+    });
+  });
 });
 
 


### PR DESCRIPTION
Check whether the ACL model is attached to a datasource and report a helpful message if it is not.

One of the reasons why the ACL model may not be attached is that the user did not call `loopback.autoAttach()`.

This is the original error message:

```
TypeError: Object function ModelConstructor(data, dataSource) {
  if (!(this instanceof ModelConstructor)) {
    return new ModelConstructor(data, dataSource);
  }
  if (ModelClass.settings.unresolved) {
    throw new Error('Model ' + ModelClass.modelName + ' is not defined.');
  }
  ModelBaseClass.apply(this, arguments);
  if (dataSource) {
    hiddenProperty(this, '__dataSource', dataSource);
  }
} has no method 'find'
```

/to: @raymondfeng or @ritch please review
