### PR TITLE
Include user in login result

### DIFF
--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -127,10 +127,15 @@ var User = module.exports = Model.extend('User', properties, options);
  * @param {AccessToken} token
  */
 
-User.login = function (credentials, fn) {
-  var UserCtor = this;
+User.login = function (credentials, include, fn) {
+  if (typeof include === 'function') {
+    fn = include;
+    include = undefined;
+  }
+
+  include = (include || '').toLowerCase();
+
   var query = {};
-  
   if(credentials.email) {
     query.email = credentials.email;
   } else if(credentials.username) {
@@ -151,7 +156,19 @@ User.login = function (credentials, fn) {
         } else if(isMatch) {
           user.accessTokens.create({
             ttl: Math.min(credentials.ttl || User.settings.ttl, User.settings.maxTTL)
-          }, fn);
+          }, function(err, token) {
+            if (err) return fn(err);
+            if (include === 'user') {
+              // NOTE(bajtos) We can't set token.user here:
+              //  1. token.user already exists, it's a function injected by
+              //     "AccessToken belongsTo User" relation
+              //  2. ModelBaseClass.toJSON() ignores own properties, thus
+              //     the value won't be included in the HTTP response
+              // See also loopback#161 and loopback#162
+              token.__data.user = user;
+            }
+            fn(err, token);
+          });
         } else {
           fn(defaultError);
         }
@@ -386,9 +403,18 @@ User.setup = function () {
     UserModel.login,
     {
       accepts: [
-        {arg: 'credentials', type: 'object', required: true, http: {source: 'body'}}
+        {arg: 'credentials', type: 'object', required: true, http: {source: 'body'}},
+        {arg: 'include', type: 'string', http: {source: 'query' }, description:
+          'Related objects to include in the response. ' +
+            'See the description of return value for more details.'}
       ],
-      returns: {arg: 'accessToken', type: 'object', root: true},
+      returns: {
+        arg: 'accessToken', type: 'object', root: true, description:
+          'The response body contains properties of the AccessToken created on login.\n' +
+            'Depending on the value of `include` parameter, the body may contain ' +
+            'additional properties:\n\n' +
+            '  - `user` - `{User}` - Data of the currently logged in user. (`include=user`)\n\n'
+      },
       http: {verb: 'post'}
     }
   );


### PR DESCRIPTION
The first commit is unrelated, it improves the ngdoc documentation generated by loopback-angular.

The second commit implements the necessary changes.

Close #161. See also #162.

/to: @ritch please review
/cc: @raymondfeng 
/cc: @seanbrookes This change should simplify your iCars controllers, as you don't have to send two requests on login (`User.login`, `User.get`).
