### PR TITLE
Remove the generated flag for access token id

### DIFF
--- a/lib/models/access-token.js
+++ b/lib/models/access-token.js
@@ -17,7 +17,7 @@ var Model = require('../loopback').Model
  */
 
 var properties = {
-  id: {type: String, generated: true, id: 1},
+  id: {type: String, id: true},
   ttl: {type: Number, ttl: true, default: DEFAULT_TTL}, // time to live in seconds
   created: {type: Date, default: function() {
     return new Date();


### PR DESCRIPTION
The generated flag is used to indicate if the id is automatically generated
by the backend store. If it's set, the data type will be updated when the
model is attached to a datasource.

The AccessToken model defines a string id, which is set in the beforeCreate
hook. So it's client provided id.

/to @bajtos @ritch 
