### PR TITLE
Add app.isAuthEnabled.

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -305,7 +305,9 @@ app.enableAuth = function() {
       next();
     }
   });
-}
+
+  this.isAuthEnabled = true;
+};
 
 /**
  * Initialize an application from an options object or a set of JSON and JavaScript files.

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -400,6 +400,14 @@ describe('app', function() {
     });
   });
 
+  describe('enableAuth', function() {
+    it('should set app.isAuthEnabled to true', function() {
+      expect(app.isAuthEnabled).to.not.equal(true);
+      app.enableAuth();
+      expect(app.isAuthEnabled).to.equal(true);
+    });
+  });
+
   describe('app.get("/", loopback.status())', function () {
     it('should return the status of the application', function (done) {
       var app = loopback();


### PR DESCRIPTION
The flag is set by `app.enableAuth` and can be used to detect whether the access control is enabled.

This is another follow-up for #167. I am planning to use this flag in loopback-explorer to decide whether the swagger descriptors should include `authorizations`.

/to @raymondfeng or @ritch please review.
