### PR TITLE
Documentation (generated) fix

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -321,7 +321,7 @@ app.enableAuth = function() {
  * 
  * **Options**
  * 
- *  - `cwd` - _optional_ - the directory to use when loading JSON and JavaScript files
+ *  - `appRootDir` - _optional_ - the directory to use when loading JSON and JavaScript files
  *  - `models` - _optional_ - an object containing `Model` definitions
  *  - `dataSources` - _optional_ - an object containing `DataSource` definitions
  *


### PR DESCRIPTION
In the file `lib/application.js`, the documentation of method `boot()` states the following about options :
- `cwd` - _optional_ - the directory to use when loading JSON and JavaScript files

But in the code it is not `options.cwd` : 

```
var appRootDir = options.appRootDir = options.appRootDir || process.cwd();
```
