### PR TITLE
Clear handler cache

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -102,6 +102,7 @@ app.model = function (Model, config) {
     var remotingClassName = compat.getClassNameForRemoting(Model);
     this.remotes().exports[remotingClassName] = Model;
     this.models().push(Model);
+    clearHandlerCache(this);
     Model.shared = true;
     Model.app = this;
     Model.emit('attached', this);
@@ -637,6 +638,10 @@ function tryReadConfig(cwd, fileName) {
       throw e;
     }
   }
+}
+
+function clearHandlerCache(app) {
+  app._handlers = undefined;
 }
 
 /**

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -29,6 +29,14 @@ describe('app', function() {
       expect(app.remotes().exports).to.eql({ color: Color });
     });
 
+    it('clears handler cache', function() {
+      var originalRestHandler = app.handler('rest');
+      var Color = db.createModel('color', {name: String});
+      app.model(Color);
+      var newRestHandler = app.handler('rest');
+      expect(originalRestHandler).to.not.equal(newRestHandler);
+    });
+
     describe('in compat mode', function() {
       before(function() {
         loopback.compat.usePluralNamesForRemoting = true;
@@ -89,7 +97,7 @@ describe('app', function() {
     beforeEach(function () {
       app.boot({
         app: {
-          port: 3000, 
+          port: 3000,
           host: '127.0.0.1',
           restApiRoot: '/rest-api',
           foo: {bar: 'bat'},
@@ -106,7 +114,7 @@ describe('app', function() {
         dataSources: {
           'the-db': {
             connector: 'memory'
-          } 
+          }
         }
       });
     });
@@ -153,14 +161,14 @@ describe('app', function() {
           var app = loopback();
           app.boot({
             app: {
-              port: undefined, 
+              port: undefined,
               host: undefined
             }
           });
           return app;
         }
       });
-      
+
       it('should be honored', function() {
         var assertHonored = function (portKey, hostKey) {
           process.env[hostKey] = randomPort();


### PR DESCRIPTION
(For some background to this PR, please see https://github.com/strongloop/loopback/pull/187)

This is the simplest possible way I can think of clearing the handler cache after registering a new model. I've  opened this PR as a starting point so that you guys can help point me in the right direction.

@bajtos, @rmg, @ritch what do you think?
