### PR TITLE
Fix verify confirm

### DIFF
--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -91,12 +91,12 @@ var options = {
       permission: ACL.ALLOW,
       property: "updateAttributes"
     },
-     {
+    {
       principalType: ACL.ROLE,
       principalId: Role.EVERYONE,
       permission: ACL.ALLOW,
       property: "confirm"
-     }
+    }
   ],
   relations: {
     accessTokens: {
@@ -287,7 +287,6 @@ User.prototype.verify = function (options, fn) {
     if(err) {
       fn(err);
     } else {
-      // base64 may not produce a url safe string so we are using hex
       user.verificationToken = buf.toString('hex');
       user.save(function (err) {
         if(err) {


### PR DESCRIPTION
- replace 'base64' in encryption with url safer 'hex'
- add ACL for 'confirm' link sent by email
- 'from' field was not included in verify email sent, this is necessary in some environments (such as AWS SES) where from address must be specified
