### PR TITLE
Describe the "id" parameter of model's sharedCtor

### DIFF
--- a/lib/models/model.js
+++ b/lib/models/model.js
@@ -100,8 +100,9 @@ Model.setup = function () {
   };
 
   // Map the prototype method to /:id with data in the body
+  var idDesc = ModelCtor.modelName + ' id';
   ModelCtor.sharedCtor.accepts = [
-    {arg: 'id', type: 'any', http: {source: 'path'}}
+    {arg: 'id', type: 'any', http: {source: 'path'}, description: idDesc}
     // {arg: 'instance', type: 'object', http: {source: 'body'}}
   ];
 


### PR DESCRIPTION
Extend remoting metadata to describe the "id" parameter accepted
by the sharedCtor of all models.

The description is used by client SDK code generators like loopback-angular.

/to @raymondfeng  or @ritch please review.
