### PR TITLE
fix/role-where-clause

### DIFF
--- a/lib/models/role.js
+++ b/lib/models/role.js
@@ -353,8 +353,8 @@ Role.isInRole = function (role, context, callback) {
       var principalType = p.type || undefined;
       var principalId = p.id || undefined;
       if (principalType && principalId) {
-        roleMappingModel.findOne({where: {roleId: result.id,
-            principalType: principalType, principalId: principalId}},
+        roleMappingModel.findOne({roleId: result.id,
+            principalType: principalType, principalId: principalId},
           function (err, result) {
             debug('Role mapping found: %j', result);
             done(!err && result); // The only arg is the result
@@ -425,8 +425,8 @@ Role.getRoles = function (context, callback) {
     if (principalType && principalId) {
       // Please find() treat undefined matches all values
       inRoleTasks.push(function (done) {
-        roleMappingModel.find({where: {principalType: principalType,
-          principalId: principalId}}, function (err, mappings) {
+        roleMappingModel.find({principalType: principalType,
+          principalId: principalId}, function (err, mappings) {
           debug('Role mappings found: %s %j', err, mappings);
           if (err) {
             done && done(err);


### PR DESCRIPTION
Fix for getRoles and isInRole methods where find is not returning any results when searching with multiple parameters. Removing where clause resolves issue and find is returning results.
