### PR TITLE
Rename the method so that it won't conflict with Model.checkAccess

### DIFF
--- a/lib/models/acl.js
+++ b/lib/models/acl.js
@@ -356,7 +356,7 @@ ACL.prototype.debug = function() {
  * @property {String} accessType The access type
  * @param {Function} callback
  */
-ACL.checkAccess = function (context, callback) {
+ACL.checkAccessForContext = function (context, callback) {
   if(!(context instanceof AccessContext)) {
     context = new AccessContext(context);
   }
@@ -422,7 +422,7 @@ ACL.checkAccess = function (context, callback) {
       if(resolved && resolved.permission === ACL.DEFAULT) {
         resolved.permission = (model && model.settings.defaultPermission) || ACL.ALLOW;
       }
-      debug('checkAccess() returns: %j', resolved);
+      debug('checkAccessForContext() returns: %j', resolved);
       callback && callback(null, resolved);
     });
   });
@@ -455,7 +455,7 @@ ACL.checkAccessForToken = function (token, model, modelId, method, callback) {
 
   context.debug();
 
-  this.checkAccess(context, function (err, access) {
+  this.checkAccessForContext(context, function (err, access) {
     if (err) {
       callback && callback(err);
       return;

--- a/test/acl.test.js
+++ b/test/acl.test.js
@@ -268,7 +268,7 @@ describe('security ACLs', function () {
 
               log('ACL 2: ', acl.toObject());
 
-              ACL.checkAccess({
+              ACL.checkAccessForContext({
                 principals: [
                   {type: ACL.USER, id: userId}
                 ],
@@ -279,7 +279,7 @@ describe('security ACLs', function () {
                 assert(!err && access.permission === ACL.ALLOW);
               });
 
-              ACL.checkAccess({
+              ACL.checkAccessForContext({
                 principals: [
                   {type: ACL.ROLE, id: Role.EVERYONE}
                 ],


### PR DESCRIPTION
/to @ritch 

/api/acls triggers the Model.checkAccess which was shadowed by ACL.checkAccess. The fix renames ACL.checkAccess to checkAccessForContext so that it won't interfere with Model.checkAccess logic.

See https://github.com/strongloop/loopback/issues/239
