### PR TITLE
Convert principalId to String

### DIFF
--- a/lib/models/acl.js
+++ b/lib/models/acl.js
@@ -297,7 +297,7 @@ ACL.checkPermission = function checkPermission(principalType, principalId,
                                                model, property, accessType,
                                                callback) {
   if(principalId !== null && principalId !== undefined && (typeof principalId !== 'string') ) {
-    principlaId = principalId.toString();
+    principalId = principalId.toString();
   }
   property = property || ACL.ALL;
   var propertyQuery = (property === ACL.ALL) ? undefined : {inq: [property, ACL.ALL]};


### PR DESCRIPTION
When principalId is a object, for example, ObjectId in MongoDB, ACL.checkPermission always load empty dynACLs, this add can fix it. Also make tests passing described in issue #245.
