### PR TITLE
Ensure roleId and principalId to be string in Role#isInRole

### DIFF
--- a/lib/models/role.js
+++ b/lib/models/role.js
@@ -373,8 +373,14 @@ Role.isInRole = function (role, context, callback) {
     async.some(context.principals, function (p, done) {
       var principalType = p.type || undefined;
       var principalId = p.id || undefined;
+      var roleId = result.id.toString();
+      
+      if(principalId !== null && principalId !== undefined && (typeof principalId !== 'string') ) {
+        principalId = principalId.toString();
+      }
+
       if (principalType && principalId) {
-        roleMappingModel.findOne({where: {roleId: result.id,
+        roleMappingModel.findOne({where: {roleId: roleId,
             principalType: principalType, principalId: principalId}},
           function (err, result) {
             debug('Role mapping found: %j', result);


### PR DESCRIPTION
This fix is similar with issue #246, when roleId or principalId is a ObjectId, we won't get expected access control. The roleId in this context must be presence, so I just make type casting on it. Please check it.
