### PR TITLE
Fix bug in User#resetPassword

### DIFF
--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -379,7 +379,7 @@ User.resetPassword = function(options, cb) {
 
   options = options || {};
   if(typeof options.email === 'string') {
-    UserModel.findOne({email: options.email}, function(err, user) {
+    UserModel.findOne({ where: {email: options.email} }, function(err, user) {
       if(err) {
         cb(err);
       } else if(user) {
@@ -392,7 +392,8 @@ User.resetPassword = function(options, cb) {
             cb();
             UserModel.emit('resetPasswordRequest', {
               email: options.email,
-              accessToken: accessToken
+              accessToken: accessToken,
+              user: user
             });
           }
         })


### PR DESCRIPTION
We should use `{ where: {email: options.email} }` rather than `{email: options.email}` in UserModel.findOne.
