### PR TITLE
Support all 1.x versions of datasource-juggler

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
     "async": "~0.2.10"
   },
   "peerDependencies": {
-    "loopback-datasource-juggler": "~1.3.11"
+    "loopback-datasource-juggler": "^1.3.11"
   },
   "devDependencies": {
-    "loopback-datasource-juggler": "~1.3.11",
+    "loopback-datasource-juggler": "^1.3.11",
     "mocha": "~1.17.1",
     "strong-task-emitter": "0.0.x",
     "supertest": "~0.9.0",


### PR DESCRIPTION
Modify the loopback-datasource-juggler semver specifier in
peerDependencies and devDependencies from `~1.3.11` to `^1.3.11`.
The goal is to support newer 1.x versions like 1.4.0 or 1.5.x.

/to @ritch or @raymondfeng please review

I am intending to release this change as a patch version 1.8.1. Are you aware of any reason why a minor version 1.9.0 should be published instead?
