### PR TITLE
relax too precise assertions in test/geo-point 

### DIFF
--- a/test/geo-point.test.js
+++ b/test/geo-point.test.js
@@ -3,8 +3,9 @@ describe('GeoPoint', function() {
     it("Get the distance to another `GeoPoint`", function() {
       var here = new GeoPoint({lat: 10, lng: 10});
       var there = new GeoPoint({lat: 5, lng: 5});
-      
-      assert.equal(here.distanceTo(there, {type: 'meters'}), 782777.923052584);
+      var distance = here.distanceTo(there, {type: 'meters'});
+
+      assert.equal(Math.floor(distance), 782777);
     });
   });
 
@@ -12,8 +13,9 @@ describe('GeoPoint', function() {
     it("Get the distance between two points", function() {
       var here = new GeoPoint({lat: 10, lng: 10});
       var there = new GeoPoint({lat: 5, lng: 5});
+      var distance = GeoPoint.distanceBetween(here, there, {type: 'feet'});
       
-      assert.equal(GeoPoint.distanceBetween(here, there, {type: 'feet'}), 2568169.038886431);
+      assert.equal(Math.floor(distance), 2568169);
     });
   });
   


### PR DESCRIPTION
Relax the assertions to verify only the integer part of the distances.
The decimal part is subject to small variances depending on the exact
implementation of floating-point arithmetic.

For example, the distance calculated on Node v0.11.13 is different
than the distance calculated on Node v0.10.x.

/cc @ritch @raymondfeng FYI
