### PR TITLE
Make app.datasources unique per app instance

### DIFF
--- a/lib/loopback.js
+++ b/lib/loopback.js
@@ -76,6 +76,9 @@ function createApplication() {
     return proto.models.apply(this, arguments);
   };
 
+  // Create a new instance of datasources registry per each app instance
+  app.datasources = app.dataSources = {};
+
   return app;
 }
 

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -111,10 +111,20 @@ describe('app', function() {
 
   describe('app.models', function() {
     it('is unique per app instance', function() {
+      app.dataSource('db', { connector: 'memory' });
       var Color = app.model('Color', { dataSource: 'db' });
       expect(app.models.Color).to.equal(Color);
       var anotherApp = loopback();
       expect(anotherApp.models.Color).to.equal(undefined);
+    });
+  });
+
+  describe('app.dataSources', function() {
+    it('is unique per app instance', function() {
+      app.dataSource('ds', { connector: 'memory' });
+      expect(app.datasources.ds).to.not.equal(undefined);
+      var anotherApp = loopback();
+      expect(anotherApp.datasources.ds).to.equal(undefined);
     });
   });
 


### PR DESCRIPTION
This removes a source of confusion in unit-tests.

/to @raymondfeng @ritch please review
