### PR TITLE
Require data-sources directory in addition to models directory in `app.boot()`.

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -471,11 +471,13 @@ app.boot = function(options) {
   forEachKeyedObject(dataSourceConfig, function(key, obj) {
     app.dataSource(key, obj);
   });
+  requireDir(path.join(appRootDir, 'data-sources'));
 
   // instantiate models
   forEachKeyedObject(modelConfig, function(key, obj) {
     app.model(key, obj);
   });
+  requireDir(path.join(appRootDir, 'models'));
 
   // try to attach models to dataSources by type
   try {
@@ -497,7 +499,6 @@ app.boot = function(options) {
   }
 
   // require directories
-  var requiredModels = requireDir(path.join(appRootDir, 'models'));
   var requiredBootScripts = requireDir(path.join(appRootDir, 'boot'));
 }
 


### PR DESCRIPTION
This prevents a potential issue where a model is loaded from config JSON that specifies use a datasource
that is loaded via JS (e.g. via a module in `./data-sources`). The model would typically be loaded before the datasource in this case, leading to an assertion error as the datasource is not properly set up.

This allows the files in `data-sources` to be loaded with the full `appConfig` attached to the app object, allowing a datasource module to use environment configuration in its configuration.
