### PR TITLE
Fix a typo in `app.boot` caused by the change from restBasePath to restApiRoot.

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -455,10 +455,10 @@ app.boot = function(options) {
     app.set('port', appConfig.port);
   }
 
-  assert(appConfig.restApiRoot !== undefined, 'app.restBasePath is required');
-  assert(typeof appConfig.restApiRoot === 'string', 'app.restBasePath must be a string');
-  assert(/^\//.test(appConfig.restApiRoot), 'app.restBasePath must start with "/"');
-  app.set('restApiRoot', appConfig.restBasePath);
+  assert(appConfig.restApiRoot !== undefined, 'app.restApiRoot is required');
+  assert(typeof appConfig.restApiRoot === 'string', 'app.restApiRoot must be a string');
+  assert(/^\//.test(appConfig.restApiRoot), 'app.restApiRoot must start with "/"');
+  app.set('restApiRoot', appConfig.restApiRoot);
 
   for(var configKey in appConfig) {
     var cur = app.get(configKey);


### PR DESCRIPTION
There were some inconsistencies within `app.boot` here that caused the wrong property to be set to `app`'s internal config, as well as the wrong error messages when `restApiRoot` is improperly formed.
