### PR TITLE
Register existing model to app.models during app.model()

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -105,26 +105,30 @@ app.disuse = function (route) {
  */
 
 app.model = function (Model, config) {
+  var modelName = Model;
   if(arguments.length === 1) {
     assert(typeof Model === 'function', 'app.model(Model) => Model must be a function / constructor');
-    assert(Model.modelName, 'Model must have a "modelName" property');
+    modelName = Model.modelName;
+    assert(modelName, 'Model must have a "modelName" property');
     var remotingClassName = compat.getClassNameForRemoting(Model);
     this.remotes().exports[remotingClassName] = Model;
     this.models().push(Model);
+    this.models[modelName] =
+    this.models[classify(modelName)] =
+    this.models[camelize(modelName)] = Model;
     clearHandlerCache(this);
     Model.shared = true;
     Model.app = this;
     Model.emit('attached', this);
     return;
   }
-  var modelName = Model;
   config = config || {};
   assert(typeof modelName === 'string', 'app.model(name, config) => "name" name must be a string');
 
-  Model =
+  Model = modelFromConfig(modelName, config, this);
   this.models[modelName] =
   this.models[classify(modelName)] =
-  this.models[camelize(modelName)] = modelFromConfig(modelName, config, this);
+  this.models[camelize(modelName)] = Model;
 
   if(config.public !== false) {
     this.model(Model);

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -29,6 +29,13 @@ describe('app', function() {
       expect(app.remotes().exports).to.eql({ color: Color });
     });
 
+    it('registers existing models to app.models', function() {
+      var Color = db.createModel('color', {name: String});
+      app.model(Color);
+      expect(app.models.color).to.eql(Color);
+      expect(app.models.Color).to.eql(Color);
+    });
+
     it('updates REST API when a new model is added', function(done) {
       app.use(loopback.rest());
       request(app).get('/colors').expect(404, function(err, res) {


### PR DESCRIPTION
/to @ritch 

The PR enables app.model(Model) to register the Model class with app.models using Model.modelName.
