### PR TITLE
Make app.get/app.set available in browser

### DIFF
--- a/lib/browser-express.js
+++ b/lib/browser-express.js
@@ -1,7 +1,25 @@
 module.exports = browserExpress;
 
 function browserExpress() {
-  return {};
+  return new BrowserExpress();
 }
 
 browserExpress.errorHandler = {};
+
+function BrowserExpress() {
+  this.settings = {};
+}
+
+BrowserExpress.prototype.set = function(key, value) {
+  if (arguments.length == 1) {
+    return this.get(key);
+  }
+
+  this.settings[key] = value;
+
+  return this; // fluent API
+};
+
+BrowserExpress.prototype.get = function(key) {
+  return this.settings[key];
+};


### PR DESCRIPTION
Implement settings object and methods in browser-express.

This is a back-port of #299 minus the tests, because the 1.x branch does not have `describeOnServer` helpers required to run `app.test.js` in the browser.

/to @ritch or @raymondfeng: please review.

This patch is needed to make loopback 1.x compatible with loopback-boot running in a browser, loopback-boot 2.0 and the new project layout.
