### PR TITLE
[2.0] Remove loopback-explorer from dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,8 +72,7 @@
     "karma": "~0.12.16",
     "karma-browserify": "~0.2.1",
     "karma-mocha": "~0.1.3",
-    "grunt-karma": "~0.8.3",
-    "loopback-explorer": "~1.1.1"
+    "grunt-karma": "~0.8.3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
1. loopback-explorer has a peer dependency on loopback, which
   forces `npm install` to install loopback within loopback. Somehow
   npm ends up installing loopback 1.x, which is not compatible with
   datasource-juggler 2.x.
2. The only place using loopback-explorer is the app used by e2e tests.
   However, the e2e test app does not load the explorer at the moment
   and the e2e test are not being run anyway.

/to @ritch 

In the longer term, I'd like to refactor loopback-explorer to check loopback version at runtime, using the `app` object provided to the middleware factory.
