### PR TITLE
Expose loopback as `app.loopback`

### DIFF
--- a/lib/loopback.js
+++ b/lib/loopback.js
@@ -59,6 +59,8 @@ function createApplication() {
 
   merge(app, proto);
 
+  app.loopback = loopback;
+
   // Create a new instance of models registry per each app instance
   app.models = function() {
     return proto.models.apply(this, arguments);

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -585,4 +585,9 @@ describe('app', function() {
       expect(app.connectors.FOOBAR).to.equal(loopback.Memory);
     });
   });
+
+  it('exposes loopback as a property', function() {
+    var app = loopback();
+    expect(app.loopback).to.equal(loopback);
+  });
 });


### PR DESCRIPTION
The primary intention is to allow loopback plugins to determine
the version of the loopback framework from the `app` object.

/to @ritch @raymondfeng please review.
