### PR TITLE
lib/application: Remove forgotten `loopback` ref

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -141,7 +141,7 @@ app.model = function (Model, config) {
     configureModel(Model, config, this);
     isPublic = config.public !== false;
   } else {
-    assert(Model.prototype instanceof loopback.Model,
+    assert(Model.prototype instanceof registry.Model,
       'Model must be a descendant of loopback.Model');
   }
 


### PR DESCRIPTION
Use `registry.Model` instead of `loopback.Model`.

I am intentionally leaving out the test for this fix. `test/support.js` installs a global `loopback` variable, which makes for rather ugly code in the test that is supposed to fail when the tested code uses an undefined `loopback` variable.

``` js
it('throws when the ctor is not a Model', function() {
  var lb = global.loopback;
  global.loopback = undefined;

  try {
    var ctor = function NotModel() {};
    expect(function() { app.model(ctor); })
      .to.throw(/descendant of loopback\.Model/);
    } finally {
     global.loopback = lb;
   }
});
```

/cc @ritch 
