### PR TITLE
[2.0] Make getModel throw when not found

### DIFF
--- a/lib/models/acl.js
+++ b/lib/models/acl.js
@@ -261,7 +261,7 @@ ACL.resolvePermission = function resolvePermission(acls, req) {
  * @return {Object[]} An array of ACLs
  */
 ACL.getStaticACLs = function getStaticACLs(model, property) {
-  var modelClass = loopback.getModel(model);
+  var modelClass = loopback.findModel(model);
   var staticACLs = [];
   if (modelClass && modelClass.settings.acls) {
     modelClass.settings.acls.forEach(function (acl) {
@@ -343,7 +343,7 @@ ACL.checkPermission = function checkPermission(principalType, principalId,
       acls = acls.concat(dynACLs);
       resolved = self.resolvePermission(acls, req);
       if(resolved && resolved.permission === ACL.DEFAULT) {
-        var modelClass = loopback.getModel(model);
+        var modelClass = loopback.findModel(model);
         resolved.permission = (modelClass && modelClass.settings.defaultPermission) || ACL.ALLOW;
       }
       callback && callback(null, resolved);

--- a/lib/models/change.js
+++ b/lib/models/change.js
@@ -128,7 +128,7 @@ Change.idForModel = function(modelName, modelId) {
  */
 
 Change.findOrCreateChange = function(modelName, modelId, callback) {
-  assert(loopback.getModel(modelName), modelName + ' does not exist');
+  assert(loopback.findModel(modelName), modelName + ' does not exist');
   var id = this.idForModel(modelName, modelId);
   var Change = this;
 

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -176,10 +176,26 @@ registry.configureModel = function(ModelCtor, config) {
  * @param {String} modelName The model name
  * @returns {Model} The model class
  *
+ * @header loopback.findModel(modelName)
+ */
+registry.findModel = function(modelName) {
+  return this.Model.modelBuilder.models[modelName];
+};
+
+/**
+ * Look up a model class by name from all models created by
+ * `loopback.createModel()`. Throw an error when no such model exists.
+ *
+ * @param {String} modelName The model name
+ * @returns {Model} The model class
+ *
  * @header loopback.getModel(modelName)
  */
 registry.getModel = function(modelName) {
-  return this.Model.modelBuilder.models[modelName];
+  var model = this.findModel(modelName);
+  if (model) return model;
+
+  throw new Error('Model not found: ' + modelName);
 };
 
 /**

--- a/test/loopback.test.js
+++ b/test/loopback.test.js
@@ -107,7 +107,7 @@ describe('loopback', function() {
         });
         assert(loopback.getModel('MyModel') === MyModel);
         assert(loopback.getModel('MyCustomModel') === MyCustomModel);
-        assert(loopback.getModel('Invalid') === undefined);
+        assert(loopback.findModel('Invalid') === undefined);
       });
       it('should be able to get model by type', function () {
         var MyModel = loopback.createModel('MyModel', {}, {
@@ -123,6 +123,11 @@ describe('loopback', function() {
         });
         assert(loopback.getModelByType(MyModel) === MyCustomModel);
         assert(loopback.getModelByType(MyCustomModel) === MyCustomModel);
+      });
+
+      it('should throw when the model does not exist', function() {
+        expect(function() { loopback.getModel(uniqueModelName); })
+          .to.throw(Error, new RegExp('Model not found: ' + uniqueModelName));
       });
     });
   });


### PR DESCRIPTION
Rename `loopback.getModel` to `loopback.findModel`.

Implement `loopback.getModel` as a wrapper around `findModel` that
throws an error when the model as not found.

/to @ritch please review. We have discussed this change on Friday.
