### PR TITLE
[2.0] Fix remote method definition in client-server example

### DIFF
--- a/example/client-server/models.js
+++ b/example/client-server/models.js
@@ -22,8 +22,7 @@ CartItem.sum = function(cartId, callback) {
   });
 }
 
-loopback.remoteMethod(
-  CartItem.sum,
+CartItem.remoteMethod('sum',
   {
     accepts: {arg: 'cartId', type: 'number'},
     returns: {arg: 'total', type: 'number'}


### PR DESCRIPTION
Fix remote method definition in client-server example. This is the new API for remote methods. Instead of adding meta data to the function object, it creates actual `strongRemoting.SharedMethod` objects on the `Model.sharedClass` (which is a `strongRemoting.SharedClass`).

/to @raymondfeng @bajtos 
/cc @sumitha @kpalacz
