### PR TITLE
Fix a slowdown caused by mutation of an incoming accessToken option.

### DIFF
--- a/lib/models/access-token.js
+++ b/lib/models/access-token.js
@@ -191,11 +191,9 @@ function tokenIdForRequest(req, options) {
   var length;
   var id;
 
-  params.push('access_token');
-  headers.push('X-Access-Token');
-  headers.push('authorization');
-  cookies.push('access_token');
-  cookies.push('authorization');
+  params = params.concat(['access_token']);
+  headers = headers.concat(['X-Access-Token', 'authorization']);
+  cookies = cookies.concat(['access_token', 'authorization']);
 
   for(length = params.length; i < length; i++) {
     id = req.param(params[i]);


### PR DESCRIPTION
When any options are provided to `loopback.token()`, they are mutated by `models/access-token.js` upon every request, leading to steadily increasing memory usage and a gradual slowdown as the number of headers/params/cookies checked increases linearly with every request.

After just a few requests, you might end up with the following: 
![Imgur](http://i.imgur.com/lFnCjwZ.png?1)

Rather than mutating the incoming option, this PR creates a new array.
