### PR TITLE
Mark `app.boot` as deprecated.

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -167,6 +167,9 @@ app.model = function (Model, config) {
 /**
  * Get the models exported by the app. Returns only models defined using `app.model()`
  *
+ * **Deprecated. Use the package
+ * [loopback-boot](https://github.com/strongloop/loopback-boot) instead.**
+
  * There are two ways to access models:
  *
  * 1.  Call `app.models()` to get a list of all models.


### PR DESCRIPTION
loopback-boot supports both loopback 1.x and 2.x and provide some extra features compared to `app.boot` shipped in loopback.

/to @ritch please review
