### PR TITLE
Fix ReferenceError: loopback is not defined in registry.memory().

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -248,7 +248,7 @@ registry.memory = function (name) {
 
   if(!memory) {
     memory = this._memoryDataSources[name] = this.createDataSource({
-      connector: loopback.Memory
+      connector: 'memory'
     });
   }
 


### PR DESCRIPTION
I'm not sure if this is the best way to fix this.

Also, it is important to note that memory.test.js does not currently fail with ReferenceError because loopback is defined globally in support.js. This global definition of loopback effectively masks the bug.
