### PR TITLE
app: update `url` on `listening` event

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -879,6 +879,13 @@ app.listen = function(cb) {
 
   server.on('listening', function() {
     self.set('port', this.address().port);
+    if (!self.get('url')) {
+      // A better default host would be `0.0.0.0`,
+      // but such URL is not supported by Windows
+      var host = self.get('host') || '127.0.0.1';
+      var url = 'http://' + host + ':' + self.get('port') + '/';
+      self.set('url', url);
+    }
   });
 
   var useAppConfig =

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -481,6 +481,18 @@ describe('app', function() {
       });
     });
 
+    it('updates "url" on "listening" event', function(done) {
+      var app = loopback();
+      app.set('port', 0);
+      app.set('host', undefined);
+
+      app.listen(function() {
+        expect(app.get('url'), 'url')
+          .to.equal('http://127.0.0.1:' + app.get('port') + '/');
+        done();
+      });
+    });
+
     it('forwards to http.Server.listen on more than one arg', function(done) {
       var app = loopback();
       app.set('port', 1);


### PR DESCRIPTION
Most applications report the URL when started (at least the apps we
are scaffolding using loopback-workspace). Constructing the URL in the
loopback core allows us to simplify the templates and reduce the amount
of repeated code.

/to @ritch please review

Once this is landed in both `master` and `2.0`, I will simplify the templates in loopback-workspace 3.0.
