### PR TITLE
Fix misleading token middleware documentation

### DIFF
--- a/lib/middleware/token.js
+++ b/lib/middleware/token.js
@@ -15,9 +15,9 @@ module.exports = token;
  * Check for an access token in cookies, headers, and query string parameters.
  * This function always checks for the following:
  * 
- * - `access_token`
- * - `X-Access-Token`
- * - `authorization`
+ * - `access_token` (params only)
+ * - `X-Access-Token` (headers only)
+ * - `authorization` (headers and cookies)
  *
  * It checks for these values in cookies, headers, and query string parameters _in addition_ to the items
  * specified in the options parameter.


### PR DESCRIPTION
Update documentation for token middleware.

Signed-off-by: Aleksandr Tsertkov tsertkov@gmail.com
