### PR TITLE
Refactor modelBuilder to registry and set up default model

### DIFF
--- a/lib/models/model.js
+++ b/lib/models/model.js
@@ -3,8 +3,6 @@
  */
 var registry = require('../registry');
 var compat = require('../compat');
-var ModelBuilder = require('loopback-datasource-juggler').ModelBuilder;
-var modeler = new ModelBuilder();
 var assert = require('assert');
 
 /**
@@ -14,7 +12,7 @@ var assert = require('assert');
  * @param {Object} data
  */
 
-var Model = module.exports = modeler.define('Model');
+var Model = module.exports = registry.modelBuilder.define('Model');
 
 Model.shared = true;
 

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -9,11 +9,15 @@
 
 var assert = require('assert');
 var extend = require('util')._extend;
-var DataSource = require('loopback-datasource-juggler').DataSource;
+var juggler = require('loopback-datasource-juggler');
+var DataSource = juggler.DataSource;
+var ModelBuilder = juggler.ModelBuilder;
 
 var registry = module.exports;
 
 registry.defaultDataSources = {};
+
+registry.modelBuilder = new ModelBuilder();
 
 /**
  * Create a named vanilla JavaScript class constructor with an attached
@@ -179,7 +183,7 @@ registry.configureModel = function(ModelCtor, config) {
  * @header loopback.getModel(modelName)
  */
 registry.getModel = function(modelName) {
-  return this.Model.modelBuilder.models[modelName];
+  return this.modelBuilder.models[modelName];
 };
 
 /**
@@ -194,7 +198,7 @@ registry.getModel = function(modelName) {
 registry.getModelByType = function(modelType) {
   assert(typeof modelType === 'function',
     'The model type must be a constructor');
-  var models = this.Model.modelBuilder.models;
+  var models = this.modelBuilder.models;
   for(var m in models) {
     if(models[m].prototype instanceof modelType) {
       return models[m];
@@ -216,10 +220,10 @@ registry.getModelByType = function(modelType) {
  */
 
 registry.createDataSource = function (name, options) {
-  var loopback = this;
-  var ds = new DataSource(name, options, loopback.Model.modelBuilder);
+  var self = this;
+  var ds = new DataSource(name, options, self.modelBuilder);
   ds.createModel = function (name, properties, settings) {
-    var ModelCtor = loopback.createModel(name, properties, settings);
+    var ModelCtor = self.createModel(name, properties, settings);
     ModelCtor.attachTo(ds);
     return ModelCtor;
   };
@@ -293,7 +297,7 @@ registry.getDefaultDataSourceForType = function(type) {
  */
 
 registry.autoAttach = function() {
-  var models = this.Model.modelBuilder.models;
+  var models = this.modelBuilder.models;
   assert.equal(typeof models, 'object', 'Cannot autoAttach without a models object');
 
   Object.keys(models).forEach(function(modelName) {
@@ -327,3 +331,6 @@ registry.DataSource = DataSource;
 
 registry.Model = require('./models/model');
 registry.DataModel = require('./models/data-model');
+
+// Set the default model base class. This is done after the Model class is defined.
+registry.modelBuilder.defaultModelBaseClass = registry.Model;

--- a/test/loopback.test.js
+++ b/test/loopback.test.js
@@ -13,12 +13,29 @@ describe('loopback', function() {
     });
   });
 
-  describe('loopback.createDataSource(options)', function(){
+  describe('loopback.createDataSource(options)', function() {
     it('Create a data source with a connector.', function() {
       var dataSource = loopback.createDataSource({
         connector: loopback.Memory
       });
       assert(dataSource.connector);
+    });
+  });
+
+  describe('data source created by loopback', function() {
+    it('should create model extending Model by default', function () {
+      var dataSource = loopback.createDataSource({
+        connector: loopback.Memory
+      });
+      var m1 = dataSource.createModel('m1', {});
+      assert(m1.prototype instanceof loopback.Model);
+    });
+  });
+
+  describe('model created by loopback', function() {
+    it('should extend from Model by default', function() {
+      var m1 = loopback.createModel('m1', {});
+      assert(m1.prototype instanceof loopback.Model);
     });
   });
 


### PR DESCRIPTION
/to @bajtos 
/cc @ritch 

The PR sets up the base model class to be Model for data sources created by loopback.

See https://groups.google.com/forum/#!topic/loopbackjs/kaiUJ6zLmBA
