### PR TITLE
[2.0] checkpoint: fix `current()`

### DIFF
--- a/lib/models/checkpoint.js
+++ b/lib/models/checkpoint.js
@@ -48,7 +48,7 @@ Checkpoint.current = function(cb) {
   var Checkpoint = this;
   this.find({
     limit: 1,
-    sort: 'seq DESC'
+    order: 'seq DESC'
   }, function(err, checkpoints) {
     if(err) return cb(err);
     var checkpoint = checkpoints[0];

--- a/test/checkpoint.test.js
+++ b/test/checkpoint.test.js
@@ -1,0 +1,24 @@
+var async = require('async');
+var loopback = require('../');
+
+// create a unique Checkpoint model
+var Checkpoint = require('../lib/models/checkpoint').extend('TestCheckpoint');
+Checkpoint.attachTo(loopback.memory());
+
+describe('Checkpoint', function() {
+  describe('current()', function() {
+    it('returns the highest `seq` value', function(done) {
+      async.series([
+        Checkpoint.create.bind(Checkpoint),
+        Checkpoint.create.bind(Checkpoint),
+        function(next) {
+          Checkpoint.current(function(err, seq) {
+            if (err) next(err);
+            expect(seq).to.equal(2);
+            next();
+          });
+        }
+      ], done);
+    });
+  });
+});


### PR DESCRIPTION
Fix the query in `Checkpoint.current()` to correctly specify sorting
`seq DESC`. Before this change, the first checkpoint was returned as the
current one.

/to @raymondfeng please review
/cc @ritch 
