### PR TITLE
Remove `app.docs()`

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -9,7 +9,6 @@ var DataSource = require('loopback-datasource-juggler').DataSource
   , extend = require('util')._extend
   , _ = require('underscore')
   , RemoteObjects = require('strong-remoting')
-  , swagger = require('strong-remoting/ext/swagger')
   , stringUtils = require('underscore.string')
   , path = require('path');
 
@@ -264,34 +263,6 @@ app.remoteObjects = function () {
   });
     
   return result;
-}
-
-/**
- * Enable swagger REST API documentation.
- *
- * **Note**: This method is deprecated.  Use [loopback-explorer](http://npmjs.org/package/loopback-explorer) instead.
- *
- * **Options**
- *
- * - `basePath` The basepath for your API - eg. 'http://localhost:3000'.
- *
- * **Example**
- *
- * ```js
- * // enable docs
- * app.docs({basePath: 'http://localhost:3000'});
- * ```
- *
- * Run your app then navigate to
- * [the API explorer](http://petstore.swagger.wordnik.com/).
- * Enter your API basepath to view your generated docs.
- *
- * @deprecated
- */
- 
-app.docs = function (options) {
-  var remotes = this.remotes();
-  swagger(remotes, options);
 }
 
 /*!


### PR DESCRIPTION
The swagger integration was moved to loopback-explorer (see https://github.com/strongloop/strong-remoting/pull/83).

/to @raymondfeng or @ritch please review
