### PR TITLE
express-middleware: improve error message

### DIFF
--- a/lib/express-middleware.js
+++ b/lib/express-middleware.js
@@ -13,8 +13,9 @@ function safeRequire(m) {
 
 function createMiddlewareNotInstalled(memberName, moduleName) {
   return function () {
-    throw new Error('The middleware loopback.' + memberName + ' is not installed.\n' +
-      'Please run `npm install ' + moduleName + '` to fix the problem.');
+    var msg = 'The middleware loopback.' + memberName + ' is not installed.\n' +
+      'Run `npm install --save ' + moduleName + '` to fix the problem.';
+    throw new Error(msg);
   };
 }
 


### PR DESCRIPTION
Include the flag `--save` in the npm instructions, so that the missing
module is both installed and saved in package dependencies.

/cc @ritch @raymondfeng 
