### PR TITLE
Emit a 'modelRemoted' event by app.model()

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -152,9 +152,11 @@ app.model = function (Model, config) {
 
   if (isPublic && Model.sharedClass) {
     this.remotes().addClass(Model.sharedClass);
-    if (Model.settings.trackChanges && Model.Change)
+    if (Model.settings.trackChanges && Model.Change) {
       this.remotes().addClass(Model.Change.sharedClass);
+    }
     clearHandlerCache(this);
+    this.emit('modelRemoted', Model.sharedClass);
   }
 
   Model.shared = isPublic;

--- a/lib/browser-express.js
+++ b/lib/browser-express.js
@@ -1,3 +1,6 @@
+var EventEmitter = require('events').EventEmitter;
+var util = require('util');
+
 module.exports = browserExpress;
 
 function browserExpress() {
@@ -9,6 +12,8 @@ browserExpress.errorHandler = {};
 function BrowserExpress() {
   this.settings = {};
 }
+
+util.inherits(BrowserExpress, EventEmitter);
 
 BrowserExpress.prototype.set = function(key, value) {
   if (arguments.length == 1) {

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -47,6 +47,18 @@ describe('app', function() {
       expect(app.models.Color).to.equal(Color);
     });
 
+    it("emits a `modelRemoted` event", function() {
+      var Color = PersistedModel.extend('color', {name: String});
+      Color.shared = true;
+      var remotedClass;
+      app.on('modelRemoted', function(sharedClass) {
+        remotedClass = sharedClass;
+      });
+      app.model(Color);
+      expect(remotedClass).to.exist;
+      expect(remotedClass).to.eql(Color.sharedClass);
+    });
+
     it.onServer('updates REST API when a new model is added', function(done) {
       app.use(loopback.rest());
       request(app).get('/colors').expect(404, function(err, res) {


### PR DESCRIPTION
/to @ritch or @bajtos 

This event will be listened by loopback-explorer so that models remoted
after the explorer is initiated will be added to the api specs
