### PR TITLE
Remove `req.resume` from `app.enableAuth` (1.x, 2.x)

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -316,17 +316,12 @@ app.enableAuth = function() {
     }
 
     if(Model.checkAccess) {
-      // Pause the request before checking access
-      // See https://github.com/strongloop/loopback-storage-service/issues/7
-      req.pause();
       Model.checkAccess(
         req.accessToken,
         modelId,
         method,
         ctx,
         function(err, allowed) {
-          // Emit any cached data events that fired while checking access.
-          req.resume();
           if(err) {
             console.log(err);
             next(err);


### PR DESCRIPTION
Remove `req.pause` and `req.resume` from `app.enableAuth`
- they are no longer needed, the request starts paused and there is
  no other middleware that would resume it before us.
- when we resume the request after authentication, we force all
  other async operations (like sharedCtor) to call pause & resume too,
  otherwise data are lost

Close https://github.com/strongloop/strong-remoting/issues/84

See also https://github.com/strongloop/loopback-component-storage/issues/7

/to @raymondfeng @ritch please review
/cc @fabien
