### PR TITLE
Allow custom relation path (http) - enable hasOne remoting access

### DIFF
--- a/lib/models/model.js
+++ b/lib/models/model.js
@@ -345,7 +345,7 @@ Model.remoteMethod = function(name, options) {
 
 Model.belongsToRemoting = function(relationName, relation, define) {
   var fn = this.prototype[relationName];
-  var pathName = relation.options.path || relationName;
+  var pathName = (relation.options.http && relation.options.http.path) || relationName;
   define('__get__' + relationName, {
     isStatic: false,
     http: {verb: 'get', path: '/' + pathName},
@@ -357,7 +357,7 @@ Model.belongsToRemoting = function(relationName, relation, define) {
 
 Model.hasOneRemoting = function(relationName, relation, define) {
   var fn = this.prototype[relationName];
-  var pathName = relation.options.path || relationName;
+  var pathName = (relation.options.http && relation.options.http.path) || relationName;
   define('__get__' + relationName, {
     isStatic: false,
     http: {verb: 'get', path: '/' + pathName},
@@ -368,7 +368,7 @@ Model.hasOneRemoting = function(relationName, relation, define) {
 }
 
 Model.hasManyRemoting = function (relationName, relation, define) {
-  var pathName = relation.options.path || relationName;
+  var pathName = (relation.options.http && relation.options.http.path) || relationName;
   var toModelName = relation.modelTo.modelName;
   
   var findByIdFunc = this.prototype['__findById__' + relationName];
@@ -463,7 +463,7 @@ Model.hasManyRemoting = function (relationName, relation, define) {
 };
 
 Model.scopeRemoting = function(relationName, relation, define) {
-  var pathName = relation.options.path || relationName;
+  var pathName = (relation.options.http && relation.options.http.path) || relationName;
   var toModelName = relation.modelTo.modelName;
 
   define('__get__' + relationName, {

--- a/test/relations.integration.js
+++ b/test/relations.integration.js
@@ -657,7 +657,9 @@ describe('relations - integration', function () {
       );
       recipe.referencesMany(ingredient);
       // contrived example for test:
-      recipe.hasOne(photo, { as: 'picture', options: { path: 'image' } });
+      recipe.hasOne(photo, { as: 'picture', options: { 
+        http: { path: 'image' } 
+      } });
     });
 
     before(function createRecipe(done) {


### PR DESCRIPTION
Specify `options: { path: 'plural-name' }` to set custom relation paths, regardless of `as`:

``` javascript
// Relation path setting - final api: /users/1/public-photos
User.hasMany('Photo', { 
  as: 'publicPhotos', 
  scope: { where: { public: true } }, 
  options: { path: 'public-photos' }
});
```

See also: https://github.com/strongloop/loopback-datasource-juggler/pull/199
