### PR TITLE
Implement Model.nestRemoting

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -269,6 +269,7 @@ app.remoteObjects = function () {
 
 /*!
  * Get a handler of the specified type from the handler cache.
+ * @triggers `mounted` events on shared class constructors (models) 
  */
  
 app.handler = function (type) {
@@ -279,6 +280,11 @@ app.handler = function (type) {
   
   var remotes = this.remotes();
   var handler = this._handlers[type] = remotes.handler(type);
+  
+  remotes.classes().forEach(function(sharedClass) {
+    sharedClass.ctor.emit('mounted', app, sharedClass, remotes);
+  });
+  
   return handler;
 }
 

--- a/lib/models/model.js
+++ b/lib/models/model.js
@@ -538,6 +538,7 @@ Model.nestRemoting = function(relationName, options, cb) {
         opts.returns = [].concat(method.returns || []);
         opts.description = method.description;
         opts.rest = extend({}, method.rest || {});
+        opts.rest.delegateTo = method.name;
         
         opts.http = [];
         var routes = [].concat(method.http || []);
@@ -551,35 +552,66 @@ Model.nestRemoting = function(relationName, options, cb) {
         
         if (relation.multiple) {
           sharedClass.defineMethod(methodName, opts, function(fkId) {
-             var args = Array.prototype.slice.call(arguments, 1);
-             var last = args[args.length - 1];
-             var cb = typeof last === 'function' ? last : null;
-             this[getterName](fkId, function(err, inst) {
-               if (err && cb) return cb(err);
-               if (inst instanceof relation.modelTo) {
-                 nestedFn.apply(inst, args);
-               } else if (cb) {
-                 cb(err, null);
-               }
-             });
+            var args = Array.prototype.slice.call(arguments, 1);
+            var last = args[args.length - 1];
+            var cb = typeof last === 'function' ? last : null;
+            this[getterName](fkId, function(err, inst) {
+              if (err && cb) return cb(err);
+              if (inst instanceof relation.modelTo) {
+                nestedFn.apply(inst, args);
+              } else if (cb) {
+                cb(err, null);
+              }
+            });
           }, method.isStatic);
         } else {
           sharedClass.defineMethod(methodName, opts, function() {
-             var args = Array.prototype.slice.call(arguments);
-             var last = args[args.length - 1];
-             var cb = typeof last === 'function' ? last : null;
-             this[getterName](function(err, inst) {
-               if (err && cb) return cb(err);
-               if (inst instanceof relation.modelTo) {
-                 nestedFn.apply(inst, args);
-               } else if (cb) {
-                 cb(err, null);
-               }
-             });
+            var args = Array.prototype.slice.call(arguments);
+            var last = args[args.length - 1];
+            var cb = typeof last === 'function' ? last : null;
+            this[getterName](function(err, inst) {
+              if (err && cb) return cb(err);
+              if (inst instanceof relation.modelTo) {
+                nestedFn.apply(inst, args);
+              } else if (cb) {
+                cb(err, null);
+              }
+            });
           }, method.isStatic);
         }
       }
     });
+    
+    if (options.hooks === false) return; // don't inherit before/after hooks
+    
+    self.once('mounted', function(app, sc, remotes) {
+      var listenerTree = extend({}, remotes.listenerTree || {});
+      listenerTree.before = listenerTree.before || {};
+      listenerTree.after = listenerTree.after || {};
+      
+      var beforeListeners = remotes.listenerTree.before[toModelName] || {};
+      var afterListeners = remotes.listenerTree.after[toModelName] || {};
+      
+      sharedClass.methods().forEach(function(method) {
+        var delegateTo = method.rest && method.rest.delegateTo;
+        if (delegateTo) {
+          var before = method.isStatic ? beforeListeners : beforeListeners['prototype'];
+          var after = method.isStatic ? afterListeners : afterListeners['prototype'];
+          var m = method.isStatic ? method.name : 'prototype.' + method.name;
+          if (before[delegateTo]) {
+            self.beforeRemote(m, function(ctx, result, next) {
+              before[delegateTo]._listeners.call(null, ctx, next);
+            });
+          }
+          if (after[delegateTo]) {
+            self.afterRemote(m, function(ctx, result, next) {
+              after[delegateTo]._listeners.call(null, ctx, next);
+            });
+          }
+        }
+      });
+    });
+    
   } else {
     throw new Error('Relation `' + relationName + '` does not exist for model `' + this.modelName + '`');
   }


### PR DESCRIPTION
Explicitly enable another level of nesting/accessing relations; currently limited to a depth of 2 levels.

This should also help with multi-tenancy, by scoping to the first model, and then still have the usual relationships available from that level down. The first model is the authenticated entry point.

``` javascript
// Models: Book, Page, Image, Note
Book.hasMany(Page);
Page.hasMany(Note);
Image.belongsTo(Book);

Book.nestRemoting('pages');
Image.nestRemoting('book');

// Urls
/api/books/2/pages/8/notes
/api/books/2/pages/8/notes/4
...
/api/images/6/book/pages
/api/images/6/book/pages/1
...
```

For this to work, the models and relationships should already be setup. 
It would be nice to be able to just do:

``` javascript
Book.hasMany(Page, { options: { nest: true } });
Image.belongsTo(Book, { options: { nest: { ... } });
```

@raymondfeng - I can't seem to get this to work, thoughts? Can this be delayed (to some event) for example?
