### PR TITLE
Expose loopback.datasourceJuggler

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,12 @@ var loopback = module.exports = require('./lib/loopback');
 var datasourceJuggler = require('loopback-datasource-juggler');
 
 /**
+ * Loopback Datasource Juggler
+ */
+
+loopback.datasourceJuggler = datasourceJuggler
+
+/**
  * Connectors
  */
 


### PR DESCRIPTION
This is needed for the integration of loopback-boot and jdb's mixin
loading, but should be useful in general.

See also: https://github.com/strongloop/loopback-datasource-juggler/pull/201
