### PR TITLE
Mailconnector transports issue460

### DIFF
--- a/lib/connectors/mail.js
+++ b/lib/connectors/mail.js
@@ -18,18 +18,23 @@ module.exports = MailConnector;
  */
 
 function MailConnector(settings) {
+
   assert(typeof settings === 'object', 'cannot initialize MailConnector without a settings object');
 
-  if(!settings.transport){
-      settings.transport = [];
-  }else{
-      settings.transport = [settings.transport];
+  var transports = settings.transports;
+
+  //if transports is not in settings object AND settings.transport exists
+  if(!transports && settings.transport){
+    //then wrap single transport in an array and assign to transports
+    transports = [settings.transport];
   }
 
-  var transports = settings.transports || settings.transport;
+  if(!transports){
+    transports = [];
+  }
 
   this.transportsIndex = {};
-  this.transports =  [];
+  this.transports = [];
 
   if(loopback.isServer) {
     transports.forEach(this.setupTransport.bind(this));

--- a/test/email.test.js
+++ b/test/email.test.js
@@ -24,6 +24,17 @@ describe('Email connector', function () {
     ]});
     assert(connector.transportForName('stub'));
   });
+
+
+  it('should set up a single transport for SMTP' , function () {
+    var connector = new MailConnector({transport:
+        {type: 'smtp', service: 'gmail'}
+    });
+
+    assert(connector.transportForName('smtp'));
+  });
+
+
 });
 
 describe('Email and SMTP', function () {
@@ -71,6 +82,8 @@ describe('Email and SMTP', function () {
         assert(mail.messageId);
         done(err);
       });
-    });      
-  }); 
+    });
+  });
 });
+
+


### PR DESCRIPTION
This commit will resolve the issue #460 regarding using single or multiple transports within the config file.  I have tested with the existing mocha tests and all are passing.  This PR does not resolve issue https://github.com/strongloop/loopback-boot/issues/4 as the `user` and `pass` properties that are part of the nodemailer transport object are not environment variables. 
