### PR TITLE
Allow 'where' argument for scoped count API

### DIFF
--- a/lib/models/model.js
+++ b/lib/models/model.js
@@ -507,9 +507,11 @@ Model.scopeRemoting = function(scopeName, scope, define) {
   define('__count__' + scopeName, {
     isStatic: isStatic,
     http: {verb: 'get', path: '/' + pathName + '/count'},
+    accepts: {arg: 'where', type: 'object', description: 'Criteria to match model instances'},
     description: 'Counts ' + scopeName + ' of ' + this.modelName + '.',
-    returns: {arg: 'count',  type: 'number', root: true} 
+    returns: {arg: 'count',  type: 'number'} 
   });
+  
 };
 
 Model.nestRemoting = function(relationName, options, cb) {

--- a/test/relations.integration.js
+++ b/test/relations.integration.js
@@ -113,6 +113,48 @@ describe('relations - integration', function () {
       });
     });
   });
+  
+  describe('/store/:id/widgets/count', function () {
+    beforeEach(function() {
+      this.url = '/api/stores/' + this.store.id + '/widgets/count';
+    });
+    lt.describe.whenCalledRemotely('GET', '/api/stores/:id/widgets/count', function() {
+      it('should succeed with statusCode 200', function() {
+        assert.equal(this.res.statusCode, 200);
+      });
+      it('should return the count', function() {
+        assert.equal(this.res.body.count, 1);
+      });
+    });
+  });
+  
+  describe('/store/:id/widgets/count - filtered (matches)', function () {
+    beforeEach(function() {
+      this.url = '/api/stores/' + this.store.id + '/widgets/count?where[name]=foo';
+    });
+    lt.describe.whenCalledRemotely('GET', '/api/stores/:id/widgets/count?where[name]=foo', function() {
+      it('should succeed with statusCode 200', function() {
+        assert.equal(this.res.statusCode, 200);
+      });
+      it('should return the count', function() {
+        assert.equal(this.res.body.count, 1);
+      });
+    });
+  });
+  
+  describe('/store/:id/widgets/count - filtered (no matches)', function () {
+    beforeEach(function() {
+      this.url = '/api/stores/' + this.store.id + '/widgets/count?where[name]=bar';
+    });
+    lt.describe.whenCalledRemotely('GET', '/api/stores/:id/widgets/count?where[name]=bar', function() {
+      it('should succeed with statusCode 200', function() {
+        assert.equal(this.res.statusCode, 200);
+      });
+      it('should return the count', function() {
+        assert.equal(this.res.body.count, 0);
+      });
+    });
+  });
 
   describe('/widgets/:id/store', function () {
     beforeEach(function (done) {


### PR DESCRIPTION
Note that the return value will be non-rooted, which is actually what
the non-scoped /count method returns as well - fixes inconsistency.

This depends on https://github.com/strongloop/loopback-datasource-juggler/pull/257
