### PR TITLE
Fix coercion for remoting on vanilla models

### DIFF
--- a/lib/models/model.js
+++ b/lib/models/model.js
@@ -3,6 +3,7 @@
  */
 var registry = require('../registry');
 var assert = require('assert');
+var RemoteObjects = require('strong-remoting');
 var SharedClass = require('strong-remoting').SharedClass;
 var extend = require('util')._extend;
 var stringUtils = require('underscore.string');
@@ -85,6 +86,7 @@ var Model = module.exports = registry.modelBuilder.define('Model');
 Model.setup = function () {
   var ModelCtor = this;
   var options = this.settings;
+  var typeName = this.modelName;
 
   // create a sharedClass
   var sharedClass = ModelCtor.sharedClass = new SharedClass(
@@ -92,6 +94,11 @@ Model.setup = function () {
     ModelCtor,
     options.remoting
   );
+
+  // setup a remoting type converter for this model
+  RemoteObjects.convert(typeName, function(val) {
+    return val ? new ModelCtor(val) : val;
+  });
 
   // support remoting prototype methods
   ModelCtor.sharedCtor = function (data, id, fn) {

--- a/lib/models/persisted-model.js
+++ b/lib/models/persisted-model.js
@@ -4,7 +4,6 @@
 
 var Model = require('./model');
 var runtime = require('../runtime');
-var RemoteObjects = require('strong-remoting');
 var assert = require('assert');
 var async = require('async');
 
@@ -37,12 +36,6 @@ PersistedModel.setup = function setupPersistedModel() {
   Model.setup.call(this);
 
   var PersistedModel = this;
-  var typeName = this.modelName;
-
-  // setup a remoting type converter for this model
-  RemoteObjects.convert(typeName, function(val) {
-    return val ? new PersistedModel(val) : val;
-  });
 
   // enable change tracking (usually for replication)
   if(this.settings.trackChanges) {

--- a/test/remoting-coercion.test.js
+++ b/test/remoting-coercion.test.js
@@ -1,0 +1,34 @@
+var loopback = require('loopback');
+var request = require('supertest');
+
+describe('remoting coercion', function() {
+  it('should coerce arguments based on the type', function(done) {
+    var called = false;
+    var app = loopback();
+    app.use(loopback.rest());
+
+    var TestModel = app.model('TestModel', {base: 'Model', dataSource: null, public: true});
+    TestModel.test = function(inst, cb) {
+      called = true;
+      assert(inst instanceof TestModel);
+      assert(inst.foo === 'bar');
+      cb();
+    }
+    TestModel.remoteMethod('test', {
+      accepts: {arg: 'inst', type: 'TestModel', http: {source: 'body'}},
+      http: {path: '/test', verb: 'post'}
+    });
+
+    request(app)
+      .post('/TestModels/test')
+      .set('Content-Type', 'application/json')
+      .send({
+        foo: 'bar'
+      })
+      .end(function(err) {
+        if(err) return done(err);
+        assert(called);
+        done();
+      });
+  });
+})


### PR DESCRIPTION
This moves type conversion from `PersistedModel` to `Model`. All models should support coercion not just `PersistedModel`s.

/to @raymondfeng @bajtos 
/cc @kraman 
