### PR TITLE
WIP: Allow using multi before/after functions in model

### DIFF
--- a/lib/models/model.js
+++ b/lib/models/model.js
@@ -155,9 +155,19 @@ Model.setup = function () {
     if(this.app) {
       var remotes = this.app.remotes();
       var className = self.modelName;
-      remotes.before(className + '.' + name, function (ctx, next) {
-        fn(ctx, ctx.result, next);
-      });
+      // Allow to bulk multi before hooks
+      if (Array.isArray(name)) {
+        // If multiple actions specified, add the before hook to each of them.
+        for (var i = 0, len = name.length; i < len; i++) {
+            remotes.before(className + '.' + name[i], function (ctx, next) {
+                fn(ctx, ctx.result, next);
+            });
+        }
+      } else {
+        remotes.before(className + '.' + name, function (ctx, next) {
+            fn(ctx, ctx.result, next);
+        });
+      }
     } else {
       var args = arguments;
       this.once('attached', function () {
@@ -165,16 +175,26 @@ Model.setup = function () {
       });
     }
   };
-  
+
   // after remote hook
   ModelCtor.afterRemote = function (name, fn) {
     var self = this;
     if(this.app) {
       var remotes = this.app.remotes();
       var className = self.modelName;
-      remotes.after(className + '.' + name, function (ctx, next) {
-        fn(ctx, ctx.result, next);
-      });
+      // Allow to bulk multi after hooks
+      if (Array.isArray(name)) {
+        // If multiple actions specified, add the after hook to each of them.
+        for (var i = 0, len = name.length; i < len; i++) {
+            remotes.after(className + '.' + name[i], function (ctx, next) {
+                fn(ctx, ctx.result, next);
+            });
+        }
+      } else {
+        remotes.after(className + '.' + name, function (ctx, next) {
+            fn(ctx, ctx.result, next);
+        });
+      }
     } else {
       var args = arguments;
       this.once('attached', function () {


### PR DESCRIPTION
For example:
Model,before(['create', 'upsert'], function(ctx, user, next) {
   // function is called before all 'create' and 'upsert' methods.
});

Signed-off-by: Omri Klinger omri@appstr.io
