### PR TITLE
Updated ACL for user model

### DIFF
--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -78,7 +78,7 @@ var options = {
       principalType: ACL.ROLE,
       principalId: Role.OWNER,
       permission: ACL.ALLOW,
-      property: "updateAttributes"
+      property: "upsert"
     },
     {
       principalType: ACL.ROLE,


### PR DESCRIPTION
Current ACL property for user has wrong value.

It should be upsert to allow owners to update their models. REST doesn't support updateAttributes
