### PR TITLE
Add an ACL to User, to allow everyone to execute User.passwordReset().

### DIFF
--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -85,6 +85,13 @@ var options = {
       principalId: Role.EVERYONE,
       permission: ACL.ALLOW,
       property: "confirm"
+    },
+    {
+      principalType: ACL.ROLE,
+      principalId: Role.EVERYONE,
+      permission: ACL.ALLOW,
+      property: "resetPassword",
+      accessType: ACL.EXECUTE
     }
   ],
   relations: {
@@ -93,13 +100,6 @@ var options = {
       model: 'AccessToken',
       foreignKey: 'userId'
     }
-  },
-  {
-    principalType: ACL.ROLE,
-    principalId: Role.EVERYONE,
-    permission: ACL.ALLOW,
-    property: "resetPassword",
-    accessType: ACL.EXECUTE
   }
 };
 


### PR DESCRIPTION
This is intended to permit users who have forgotten their
password, and are thus unauthenticated, to request a reset.

Credit goes to John Murphy who proposed the ACL in Google Groups here:
https://groups.google.com/forum/#!searchin/loopbackjs/passwordReset$20ACL/loopbackjs/UPyhg7KS-9k/_M_9-YpUKmIJ

Signed-off-by: Carey Richard Murphey rich@murphey.org
