### PR TITLE
Skip static ACL entries that don't match the property

### DIFF
--- a/lib/models/acl.js
+++ b/lib/models/acl.js
@@ -255,14 +255,17 @@ ACL.getStaticACLs = function getStaticACLs(model, property) {
   var staticACLs = [];
   if (modelClass && modelClass.settings.acls) {
     modelClass.settings.acls.forEach(function (acl) {
-      staticACLs.push(new ACL({
-        model: model,
-        property: acl.property || ACL.ALL,
-        principalType: acl.principalType,
-        principalId: acl.principalId, // TODO: Should it be a name?
-        accessType: acl.accessType || ACL.ALL,
-        permission: acl.permission
-      }));
+      if (!acl.property || acl.property === ACL.ALL
+        || property === acl.property) {
+        staticACLs.push(new ACL({
+          model: model,
+          property: acl.property || ACL.ALL,
+          principalType: acl.principalType,
+          principalId: acl.principalId, // TODO: Should it be a name?
+          accessType: acl.accessType || ACL.ALL,
+          permission: acl.permission
+        }));
+      }
     });
   }
   var prop = modelClass &&

--- a/test/acl.test.js
+++ b/test/acl.test.js
@@ -229,6 +229,33 @@ describe('security ACLs', function () {
 
   });
 
+  it("should filter static ACLs by model/property", function() {
+    var Model1 = ds.createModel('Model1', {
+      name: {
+        type: String,
+        acls: [
+          {principalType: ACL.USER, principalId: 'u001',
+            accessType: ACL.WRITE, permission: ACL.DENY},
+          {principalType: ACL.USER, principalId: 'u001',
+            accessType: ACL.ALL, permission: ACL.ALLOW}
+        ]
+      }
+    }, {
+      acls: [
+        {principalType: ACL.USER, principalId: 'u001', property: 'name',
+          accessType: ACL.ALL, permission: ACL.ALLOW},
+        {principalType: ACL.USER, principalId: 'u002', property: 'findOne',
+          accessType: ACL.ALL, permission: ACL.ALLOW}
+      ]
+    });
+
+    var staticACLs = ACL.getStaticACLs('Model1', 'name');
+    assert(staticACLs.length === 3);
+
+    staticACLs = ACL.getStaticACLs('Model1', 'findOne');
+    assert(staticACLs.length === 1);
+  });
+
   it("should check access against LDL, ACL, and Role", function () {
     // var log = console.log;
     var log = function() {};


### PR DESCRIPTION
/to @ritch 
/cc @superkhau 

The PR optimizes the ACL matching by skipping static entries that don't apply to the property.
