### PR TITLE
models/change: fix `id` property definition

### DIFF
--- a/lib/models/change.js
+++ b/lib/models/change.js
@@ -15,7 +15,7 @@ var PersistedModel = require('./persisted-model')
  */
 
 var properties = {
-  id: {type: String, generated: true, id: true},
+  id: {type: String, id: true},
   rev: {type: String},
   prev: {type: String},
   checkpoint: {type: Number},

--- a/test/change.test.js
+++ b/test/change.test.js
@@ -84,6 +84,7 @@ describe('Change', function(){
       it('should create an entry', function (done) {
         var test = this;
         Change.findById(this.result.id, function(err, change) {
+          if (err) return done(err);
           assert.equal(change.id, test.result.id);
           done();
         });


### PR DESCRIPTION
Remove the flag `generated:true`, as it does not work together with a custom `getter.id` function.

This fixes a problem surfaced by https://github.com/strongloop/loopback-datasource-juggler/pull/323 and https://github.com/strongloop/loopback-datasource-juggler/pull/322.

See also https://github.com/strongloop/loopback-datasource-juggler/issues/326.

/to @ritch please review. Do you remember what was your original intention, why did you enable this flag in the first place?
/cc @raymondfeng 
