### PR TITLE
Fix places using undefined variables

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -8,6 +8,5 @@
 "maxlen": 80,
 "trailing": true,
 "newcap": true,
-"nonew": true,
-"undef": false
+"nonew": true
 }

--- a/common/models/role-mapping.js
+++ b/common/models/role-mapping.js
@@ -1,3 +1,5 @@
+var loopback = require('../../lib/loopback');
+
 /**
  * The `RoleMapping` model extends from the built in `loopback.Model` type.
  *
@@ -59,7 +61,8 @@ module.exports = function(RoleMapping) {
    */
   RoleMapping.prototype.childRole = function (callback) {
     if (this.principalType === RoleMapping.ROLE) {
-      var roleModel = this.constructor.Role || loopback.getModelByType(Role);
+      var roleModel = this.constructor.Role ||
+        loopback.getModelByType(loopback.Role);
       roleModel.findById(this.principalId, callback);
     } else {
       process.nextTick(function () {

--- a/common/models/scope.js
+++ b/common/models/scope.js
@@ -1,4 +1,5 @@
 var assert = require('assert');
+var loopback = require('../../lib/loopback');
 
 /**
  * Resource owner grants/delegates permissions to client applications

--- a/common/models/user.js
+++ b/common/models/user.js
@@ -473,7 +473,7 @@ User.setup = function() {
       if (ctx.req) {
         ctx.res.redirect(ctx.req.param('redirect'));
       } else {
-        fn(new Error('transport unsupported'));
+        next(new Error('transport unsupported'));
       }
     });
   });

--- a/index.js
+++ b/index.js
@@ -19,4 +19,4 @@ loopback.Remote = require('loopback-connector-remote');
  */
 
 loopback.GeoPoint = require('loopback-datasource-juggler/lib/geo').GeoPoint;
-loopback.ValidationError = datasourceJuggler.ValidationError;
+loopback.ValidationError = loopback.Model.ValidationError;

--- a/lib/access-context.js
+++ b/lib/access-context.js
@@ -1,3 +1,4 @@
+var assert = require('assert');
 var loopback = require('./loopback');
 var debug = require('debug')('loopback:security:access-context');
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -250,7 +250,7 @@ Model._ACL = function getACL(ACL) {
   if(_aclModel) {
     return _aclModel;
   }
-  var aclModel = loopback.ACL;
+  var aclModel = registry.getModel('ACL');
   _aclModel = registry.getModelByType(aclModel);
   return _aclModel;
 };
@@ -268,7 +268,7 @@ Model._ACL = function getACL(ACL) {
  */
 
 Model.checkAccess = function(token, modelId, sharedMethod, ctx, callback) {
-  var ANONYMOUS = loopback.AccessToken.ANONYMOUS;
+  var ANONYMOUS = registry.getModel('AccessToken').ANONYMOUS;
   token = token || ANONYMOUS;
   var aclModel = Model._ACL();
 
@@ -713,6 +713,8 @@ Model.nestRemoting = function(relationName, options, cb) {
     throw new Error('Relation `' + relationName + '` does not exist for model `' + this.modelName + '`');
   }
 };
+
+Model.ValidationError = require('loopback-datasource-juggler').ValidationError;
 
 // setup the initial model
 Model.setup();

--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -3,6 +3,7 @@
  */
 
 var Model = require('./model');
+var registry = require('./registry');
 var runtime = require('./runtime');
 var assert = require('assert');
 var async = require('async');
@@ -322,7 +323,7 @@ PersistedModel.prototype.save = function (options, callback) {
     if (valid) {
       save();
     } else {
-      var err = new ValidationError(inst);
+      var err = new Model.ValidationError(inst);
       // throws option is dangerous for async usage
       if (options.throws) {
         throw err;
@@ -700,13 +701,13 @@ PersistedModel.changes = function(since, filter, callback) {
     checkpoint: {gt: since},
     modelName: this.modelName
   }, function(err, changes) {
-    if(err) return cb(err);
+    if(err) return callback(err);
     var ids = changes.map(function(change) {
       return change.getModelId();
     });
     filter.where[idName] = {inq: ids};
     model.find(filter, function(err, models) {
-      if(err) return cb(err);
+      if(err) return callback(err);
       var modelIds = models.map(function(m) {
         return m[idName].toString();
       });
@@ -1016,7 +1017,7 @@ PersistedModel.enableChangeTracking = function() {
 }
 
 PersistedModel._defineChangeModel = function() {
-  var BaseChangeModel = loopback.Change;
+  var BaseChangeModel = registry.getModel('Change');
   assert(BaseChangeModel,
     'Change model must be defined before enabling change replication');
 


### PR DESCRIPTION
Also enable jshint option "undefined" in order to catch these kind of errors in the future.

Contrary to what I said in #585, I decided to fix the problems without writing unit-tests to reproduce them. Some of the issues cannot be caught at the moment, because `test/support.js` defines global variables like `loopback` and `assert`.

This patch fixes loopback-workspace unit tests that are failing when run using the current loopback master.

/to @ritch or @raymondfeng please review
/cc @rhalff
