### PR TITLE
Verification host

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -233,7 +233,7 @@ User.prototype.verify = function(options, fn) {
   options.protocol = options.protocol || 'http';
 
   var app = userModel.app;
-  options.host = emailOptions.host || (app && app.get('verificationHost')) || (app && app.get('host')) || 'localhost';
+  options.host = options.host || (app && app.get('verificationHost')) || (app && app.get('host')) || 'localhost';
   options.port = options.port || (app && app.get('port')) || 3000;
   options.restApiRoot = options.restApiRoot || (app && app.get('restApiRoot')) || '/api';
   options.verifyHref = options.verifyHref ||


### PR DESCRIPTION
In production, the "host" that an Email Verification should be routed to will NOT be "0.0.0.0" or "localhost" but should be the domain where the production server is located.
