### PR TITLE
This fixes duplicate key issue #649

### DIFF
--- a/common/models/change.js
+++ b/common/models/change.js
@@ -407,7 +407,6 @@ module.exports = function(Change) {
     this.find(function(err, changes) {
       if (err) return cb(err);
       changes.forEach(function(change) {
-        change = new Change(change);
         change.rectify();
       });
     });


### PR DESCRIPTION
change.rectify will call save without __persisted flag set.
This causes DAO to treat model as new instead of as
an existing model to update.
