### PR TITLE
Force principalId to be a string in Role.getRoles Fix #676

### DIFF
--- a/common/models/role.js
+++ b/common/models/role.js
@@ -353,9 +353,9 @@ module.exports = function(Role) {
     context.principals.forEach(function(p) {
       // Check against the role mappings
       var principalType = p.type || undefined;
-      var principalId = p.id || undefined;
+      var principalId = p.id == null ? undefined : p.id;
       
-      if(typeof principalId !== 'string' && typeof principalId !== 'undefined') {
+      if(typeof principalId !== 'string' && principalId != null) {
         principalId = principalId.toString();
       }
 


### PR DESCRIPTION
Added a defensive check for undefined to avoid problems
when converting to a string.
