### PR TITLE
User: fix `confirm` permissions

### DIFF
--- a/common/models/user.json
+++ b/common/models/user.json
@@ -75,7 +75,7 @@
     {
       "principalType": "ROLE",
       "principalId": "$everyone",
-      "permission": "ACL.ALLOW",
+      "permission": "ALLOW",
       "property": "confirm"
     },
     {

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -28,6 +28,7 @@ describe('User', function(){
   });
   
   beforeEach(function (done) {
+    app.enableAuth();
     app.use(loopback.token());
     app.use(loopback.rest());
     app.model(User);


### PR DESCRIPTION
Enable authentication for all User unit-tests to ensure the ACLs are
correctly configured.

Fix the rule for `confirm` - the correct permission is `ALLOW`, not
`ACL.ALLOW`.

Fix #677

/cc @raymondfeng @ritch I'll merge the patch without review, the change is trivial while the bug is critical.
