### PR TITLE
Revert "rest handler options"

### DIFF
--- a/lib/middleware/rest.js
+++ b/lib/middleware/rest.js
@@ -12,21 +12,20 @@ module.exports = rest;
 
 /**
  * Expose models over REST.
- *
+ * 
  * For example:
  * ```js
  * app.use(loopback.rest());
  * ```
  * For more information, see [Exposing models over a REST API](http://docs.strongloop.com/display/DOC/Exposing+models+over+a+REST+API).
  * @header loopback.rest()
- * @param {Object} options REST handler options.
  */
 
-function rest(options) {
+function rest() {
   var tokenParser = null;
   return function (req, res, next) {
     var app = req.app;
-    var handler = app.handler('rest', options);
+    var handler = app.handler('rest');
 
     if(req.url === '/routes') {
       res.send(handler.adapter.allRoutes());

--- a/test/rest.middleware.test.js
+++ b/test/rest.middleware.test.js
@@ -75,16 +75,6 @@ describe('loopback.rest', function() {
     });
   });
 
-  it('should support options', function(done) {
-    app.model(MyModel);
-    var supportedTypes = ['json', 'application/javascript', 'text/javascript'];
-    app.use(loopback.rest({supportedTypes: supportedTypes}));
-    request(app).get('/mymodels')
-      .set('Accept', 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8')
-      .expect('Content-Type', 'application/json; charset=utf-8')
-      .expect(200, done);
-  });
-
   it('includes loopback.token when necessary', function(done) {
     givenUserModelWithAuth();
     app.enableAuth();


### PR DESCRIPTION
I am afraid I misunderstood how the remoting options are implemented and gave a wrong advice on how to implement this whole feature :(

At the moment, all other remoting options are read from `remotes.options`, which are set from `app.get('remoting')` the first time `app.remotes()` is called (typically when a first model is attached to the app).

I don't want to introduce a new inconsistent way of configuring the remoting adapters, thus I have to revert strongloop/loopback#708
