### PR TITLE
Expose path to the built-in favicon file

### DIFF
--- a/lib/loopback.js
+++ b/lib/loopback.js
@@ -126,6 +126,25 @@ if (loopback.isServer) {
     });
 }
 
+/*
+ * Expose path to the default favicon file
+ *
+ * ***only in node***
+ */
+
+if (loopback.isServer) {
+  /**
+   * Path to a default favicon shipped with LoopBack.
+   *
+   * **Example**
+   *
+   * ```js
+   * app.use(require('serve-favicon')(loopback.faviconFile));
+   * ```
+   */
+  loopback.faviconFile = path.resolve(__dirname, '../favicon.ico');
+}
+
 /*!
  * Error handler title
  */

--- a/test/loopback.test.js
+++ b/test/loopback.test.js
@@ -1,3 +1,5 @@
+var it = require('./util/it');
+
 describe('loopback', function() {
   var nameCounter = 0;
   var uniqueModelName;
@@ -10,6 +12,13 @@ describe('loopback', function() {
     it('ValidationError', function() {
       expect(loopback.ValidationError).to.be.a('function')
         .and.have.property('name', 'ValidationError');
+    });
+
+    it.onServer('includes `faviconFile`', function() {
+      var file = loopback.faviconFile;
+      expect(file, 'faviconFile').to.not.equal(undefined);
+      expect(require('fs').existsSync(loopback.faviconFile), 'file exists')
+        .to.equal(true);
     });
   });
 
@@ -68,11 +77,11 @@ describe('loopback', function() {
   describe('loopback.remoteMethod(Model, fn, [options]);', function() {
     it("Setup a remote method.", function() {
       var Product = loopback.createModel('product', {price: Number});
-      
+
       Product.stats = function(fn) {
         // ...
       }
-      
+
       loopback.remoteMethod(
         Product.stats,
         {
@@ -80,7 +89,7 @@ describe('loopback', function() {
           http: {path: '/info', verb: 'get'}
         }
       );
-      
+
       assert.equal(Product.stats.returns.arg, 'stats');
       assert.equal(Product.stats.returns.type, 'array');
       assert.equal(Product.stats.http.path, '/info');


### PR DESCRIPTION
The path is available via `loopback.faviconFile`.

This change makes it possible to use the `serve-favicon` middleware directly:

``` js
// before
app.use(loopback.favicon());
// now
app.use(require('serve-favicon')(loopback.faviconPath));
```

/to @ritch @raymondfeng please review
