### PR TITLE
Making options argument optional per docs

### DIFF
--- a/common/models/access-token.js
+++ b/common/models/access-token.js
@@ -88,6 +88,9 @@ module.exports = function(AccessToken) {
    */
 
   AccessToken.findForRequest = function(req, options, cb) {
+    var args = Array.prototype.slice.call(arguments, 1);
+    cb = args.pop();
+    options = args.length ? args.shift() : {};
     var id = tokenIdForRequest(req, options);
 
     if (id) {


### PR DESCRIPTION
If options are not passed to the access-token.findForRequest() function, then the callback argument will be undefined.  This makes the options truly optional as the docs prescribe.
