### PR TITLE
Implement `app.defineMiddlewarePhases`

### DIFF
--- a/lib/server-app.js
+++ b/lib/server-app.js
@@ -55,6 +55,77 @@ proto.middlewareFromConfig = function(factory, config) {
 };
 
 /**
+ * Register (new) middleware phases.
+ *
+ * If all names are new, then the phases are added just before "routes" phase.
+ * Otherwise the provided list of names is merged with the existing phases
+ * in such way that the order of phases is preserved.
+ *
+ * **Examples**
+ *
+ * ```js
+ * // built-in phases:
+ * // initial, session, auth, parse, routes, files, final
+ *
+ * app.defineMiddlewarePhases('custom');
+ * // new list of phases
+ * // initial, session, auth, parse, custom, routes, files, final
+ *
+ * app.defineMiddlewarePhases([
+ *   'initial', 'postinit', 'preauth', 'routes', 'subapps'
+ * ]);
+ * // new list of phases
+ * // initial, postinit, preauth, session, auth, parse, custom,
+ * // routes, subapps, files, final
+ * ```
+ *
+ * @param {string|Array.<string>} nameOrArray A phase name or a list of phase
+ *   names to add.
+ */
+proto.defineMiddlewarePhases = function(nameOrArray) {
+  this.lazyrouter();
+  if (!Array.isArray(nameOrArray)) {
+    this._requestHandlingPhases.addBefore('routes', nameOrArray);
+    return;
+  }
+
+  var sourcePhases = nameOrArray;
+  if (!sourcePhases.length) return;
+
+  var targetPhases = this._requestHandlingPhases.getPhaseNames();
+  var targetIx = targetPhases.indexOf(nameOrArray[0]);
+
+  if (targetIx === -1) {
+    // the first new phase does not match any existing one
+    // add all phases before "routes"
+    sourcePhases.forEach(function(it) {
+      this._requestHandlingPhases.addBefore('routes', it);
+    }, this);
+    return;
+  }
+
+  // merge (zip) two arrays of phases
+  for (var sourceIx = 1; sourceIx < sourcePhases.length; sourceIx++) {
+    var nameToAdd = sourcePhases[sourceIx];
+    var previousPhase = sourcePhases[sourceIx - 1];
+    var existingIx = targetPhases.indexOf(nameToAdd, targetIx);
+    if (existingIx === -1) {
+      // A new phase - try to add it after the last one,
+      // unless it was already registered
+      if (targetPhases.indexOf(nameToAdd) !== -1) {
+        throw new Error('Phase ordering conflict: cannot add "' + nameToAdd +
+        '" after "' + previousPhase + '", because the opposite order was ' +
+        ' already specified');
+      }
+      this._requestHandlingPhases.addAfter(previousPhase, nameToAdd);
+    } else {
+      // An existing phase - move the pointer
+      targetIx = existingIx;
+    }
+  }
+};
+
+/**
  * Register a middleware handler to be executed in a given phase.
  * @param {string} name The phase name, e.g. "init" or "routes".
  * @param {function} handler The middleware handler, one of


### PR DESCRIPTION
Implement method for registering (new) middleware phases.
- If all names are new, then the phases are added just before
  the "routes" phase.
  - Otherwise the provided list of names is merged with the existing
    phases in such way that the order of phases is preserved.

Example

```
// built-in phases:
// initial, session, auth, parse, routes, files, final

app.defineMiddlewarePhases('custom');
// new list of phases
//   initial, session, auth, parse,
//   custom,
//   routes, files, final

app.defineMiddlewarePhases([
  'initial', 'postinit', 'preauth', 'routes', 'subapps'
]);
// new list of phases
//   initial,
//   postinit, preauth,
//   session, auth, parse, custom,
//   routes,
//   subapps,
//   files, final
```

A part of #739, requires https://github.com/strongloop/loopback-phase/pull/5

/to @ritch please review
/cc @raymondfeng 
