### PR TITLE
Implement app.middlewareFromConfig

### DIFF
--- a/lib/server-app.js
+++ b/lib/server-app.js
@@ -1,3 +1,4 @@
+var assert = require('assert');
 var express = require('express');
 var merge = require('util')._extend;
 var PhaseList = require('loopback-phase').PhaseList;
@@ -13,6 +14,47 @@ module.exports = function loopbackExpress() {
 };
 
 /**
+ * Register a middleware using a factory function and a JSON config.
+ *
+ * **Example**
+ *
+ * ```js
+ * app.middlewareFromConfig(compression, {
+ *   enabled: true,
+ *   phase: 'initial',
+ *   config: {
+ *     threshold: 128
+ *   }
+ * });
+ * ```
+ *
+ * @param {function} factory The factory function creating a middleware handler.
+ *   Typically a result of `require()` call, e.g. `require('compression')`.
+ * @param {Array|*} config The configuration. Either an array of arguments
+ *   to pass to the factory function, or the value of the first argument
+ *   when the factory expects a single argument only.
+ */
+proto.middlewareFromConfig = function(factory, config) {
+  assert(typeof factory === 'function', '"factory" must be a function');
+  assert(typeof config === 'object', '"config" must be an object');
+  assert(typeof config.phase === 'string' && config.phase,
+    '"config.phase" must be a non-empty string');
+
+  if (config.enabled === false)
+    return;
+
+  var args = config.config;
+  if (args === undefined) {
+    args = [];
+  } else if (!Array.isArray(args)) {
+    args = [args];
+  }
+
+  var handler = factory.apply(null, args);
+  this.middleware(config.phase, handler);
+};
+
+/**
  * Register a middleware handler to be executed in a given phase.
  * @param {string} name The phase name, e.g. "init" or "routes".
  * @param {function} handler The middleware handler, one of
@@ -22,6 +64,9 @@ module.exports = function loopbackExpress() {
  */
 proto.middleware = function(name, handler) {
   this.lazyrouter();
+
+  assert(typeof name === 'string' && name, '"name" must be a non-empty string');
+  assert(typeof handler === 'function', '"handler" must be a function');
 
   var fullName = name;
   var handlerName = handler.name || '(anonymous)';


### PR DESCRIPTION
Implement a function registering a middleware using a factory function
and a JSON config.

Example:

```
app.middlewareFromConfig(compression, {
  enabled: true,
  phase: 'initial',
  config: {
    threshold: 128
  }
});
```

The API is more or less consistent with `app.model(ModelCtor, config)` and `loopback.configureModel(ModelCtor, config)`.

See also my [comment](https://github.com/strongloop/loopback-boot/issues/44#issuecomment-62569432) in https://github.com/strongloop/loopback-boot/issues/44

/to @ritch @raymondfeng please review
