### PR TITLE
Expose more loopback middleware for require

### DIFF
--- a/lib/express-middleware.js
+++ b/lib/express-middleware.js
@@ -1,4 +1,3 @@
-var express = require('express');
 var path = require('path');
 
 var middlewares = exports;

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "nodemailer": "~1.3.0",
     "nodemailer-stub-transport": "~0.1.4",
     "path-to-regexp": "^1.0.1",
+    "serve-favicon": "^2.1.6",
     "strong-remoting": "^2.4.0",
     "uid2": "0.0.3",
     "underscore": "~1.7.0",

--- a/server/middleware/favicon.js
+++ b/server/middleware/favicon.js
@@ -1,0 +1,1 @@
+module.exports = require('../../lib/express-middleware').favicon;


### PR DESCRIPTION
/to @bajtos 

We need a way to reference loopback.favicon and other middleware from middleware.json. 
