### PR TITLE
#794 - Scope app middleware to a list of paths

### DIFF
--- a/lib/server-app.js
+++ b/lib/server-app.js
@@ -3,6 +3,7 @@ var express = require('express');
 var merge = require('util')._extend;
 var PhaseList = require('loopback-phase').PhaseList;
 var debug = require('debug')('loopback:app');
+var pathToRegexp = require('path-to-regexp');
 
 var proto = {};
 
@@ -31,13 +32,15 @@ module.exports = function loopbackExpress() {
  * @param {function} factory The factory function creating a middleware handler.
  *   Typically a result of `require()` call, e.g. `require('compression')`.
  * @options {Object} config The configuration.
- * @property {String} phase The phase to register the middelware in.
+ * @property {String} phase The phase to register the middleware in.
  * @property {Boolean} [enabled] Whether the middleware is enabled.
  *   Default: `true`.
  * @property {Array|*} [params] The arguments to pass to the factory
  *   function. Either an array of arguments,
  *   or the value of the first argument when the factory expects
  *   a single argument only.
+ * @property {Array|string|RegExp} [paths] Optional list of paths limiting
+ *   the scope of the middleware.
  *
  * @returns {object} this (fluent API)
  *
@@ -60,7 +63,7 @@ proto.middlewareFromConfig = function(factory, config) {
   }
 
   var handler = factory.apply(null, params);
-  this.middleware(config.phase, handler);
+  this.middleware(config.phase, config.paths || [], handler);
 
   return this;
 };
@@ -112,6 +115,10 @@ proto.defineMiddlewarePhases = function(nameOrArray) {
 /**
  * Register a middleware handler to be executed in a given phase.
  * @param {string} name The phase name, e.g. "init" or "routes".
+ * @param {Array|string|RegExp} [paths] Optional list of paths limiting
+ *   the scope of the middleware.
+ *   String paths are interpreted as expressjs path patterns,
+ *   regular expressions are used as-is.
  * @param {function} handler The middleware handler, one of
  *   `function(req, res, next)` or
  *   `function(err, req, res, next)`
@@ -119,11 +126,21 @@ proto.defineMiddlewarePhases = function(nameOrArray) {
  *
  * @header app.middleware(name, handler)
  */
-proto.middleware = function(name, handler) {
+proto.middleware = function(name, paths, handler) {
   this.lazyrouter();
+
+  if (handler === undefined && typeof paths === 'function') {
+    handler = paths;
+    paths = [];
+  }
+
+  if (typeof paths === 'string' || paths instanceof RegExp) {
+    paths = [paths];
+  }
 
   assert(typeof name === 'string' && name, '"name" must be a non-empty string');
   assert(typeof handler === 'function', '"handler" must be a function');
+  assert(Array.isArray(paths), '"paths" must be an array');
 
   var fullName = name;
   var handlerName = handler.name || '(anonymous)';
@@ -139,13 +156,15 @@ proto.middleware = function(name, handler) {
   if (!phase)
     throw new Error('Unknown middleware phase ' + name);
 
+  var matches = createRequestMatcher(paths);
+
   var wrapper;
   if (handler.length === 4) {
     // handler is function(err, req, res, next)
     debug('Add error handler %j to phase %j', handlerName, fullName);
 
     wrapper = function errorHandler(ctx, next) {
-      if (ctx.err) {
+      if (ctx.err && matches(ctx.req)) {
         var err = ctx.err;
         ctx.err = undefined;
         handler(err, ctx.req, ctx.res, storeErrorAndContinue(ctx, next));
@@ -157,7 +176,7 @@ proto.middleware = function(name, handler) {
     // handler is function(req, res, next)
     debug('Add middleware %j to phase %j', handlerName , fullName);
     wrapper = function regularHandler(ctx, next) {
-      if (ctx.err) {
+      if (ctx.err || !matches(ctx.req)) {
         next();
       } else {
         handler(ctx.req, ctx.res, storeErrorAndContinue(ctx, next));
@@ -168,6 +187,26 @@ proto.middleware = function(name, handler) {
   phase[hook](wrapper);
   return this;
 };
+
+function createRequestMatcher(paths) {
+  if (!paths.length) {
+    return function requestMatcher(req) { return true; };
+  }
+
+  var checks = paths.map(function(p) {
+    return pathToRegexp(p, {
+      sensitive: true,
+      strict: false,
+      end: false
+    });
+  });
+
+  return function requestMatcher(req) {
+    return checks.some(function(regex) {
+      return regex.test(req.url);
+    });
+  };
+}
 
 function storeErrorAndContinue(ctx, next) {
   return function(err) {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "loopback-phase": "^1.0.1",
     "nodemailer": "~1.3.0",
     "nodemailer-stub-transport": "~0.1.4",
+    "path-to-regexp": "^1.0.1",
     "strong-remoting": "^2.4.0",
     "uid2": "0.0.3",
     "underscore": "~1.7.0",


### PR DESCRIPTION
Add a new argument to `app.middleware` allowing developers
to restrict the middleware to a list of paths or regular expresions.

Modify `app.middlewareFromConfig` to pass `config.paths` as the second
arg of `app.middleware`.

Examples:

```
// A string path (interpreted via path-to-regexp)
app.middleware('auth', '/admin', ldapAuth);

// A regular expression
app.middleware('initial', /^\/~(admin|root)/, rejectWith404);

// A list of scopes
app.middleware('routes', ['/api', /^\/assets/.*\.json$/], foo);

// From config
app.middlewareFromConfig(
  handlerFactory,
  {
    phase: 'initial',
    paths: ['/scope', /^\/(a|b)/]
  });
```

Close #794

/to @raymondfeng @ritch please review
