### PR TITLE
Fixes duplicate Id on bulkUpdate.

### DIFF
--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -924,11 +924,8 @@ PersistedModel.bulkUpdate = function(updates, callback) {
     switch (update.type) {
       case Change.UPDATE:
       case Change.CREATE:
-        // var model = new Model(update.data);
-        // tasks.push(model.save.bind(model));
         tasks.push(function(cb) {
-          var model = new Model(update.data);
-          model.save(cb);
+          Model.upsert(update.data, cb);
         });
         break;
       case Change.DELETE:


### PR DESCRIPTION
When using the replication algorithm, data changes with updates would cause the server to crash with duplicate id error. This PR fixes this issue.