### PR TITLE
Allow User.hashPassword/validatePassword to be overridden

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -454,6 +454,24 @@ module.exports = function(User) {
   };
 
   /*!
+   * Hash the plain password
+   */
+  User.hashPassword = function(plain) {
+    this.validatePassword(plain);
+    var salt = bcrypt.genSaltSync(this.settings.saltWorkFactor || SALT_WORK_FACTOR);
+    return bcrypt.hashSync(plain, salt);
+  };
+
+  User.validatePassword = function(plain) {
+    if (typeof plain === 'string' && plain) {
+      return true;
+    }
+    var err =  new Error('Invalid password: ' + plain);
+    err.statusCode = 422;
+    throw err;
+  };
+
+  /*!
    * Setup an extended user model.
    */
 
@@ -467,8 +485,7 @@ module.exports = function(User) {
     this.settings.ttl = DEFAULT_TTL;
 
     UserModel.setter.password = function(plain) {
-      var salt = bcrypt.genSaltSync(this.constructor.settings.saltWorkFactor || SALT_WORK_FACTOR);
-      this.$password = bcrypt.hashSync(plain, salt);
+      this.$password = this.constructor.hashPassword(plain);
     };
 
     // Make sure emailVerified is not set by creation

--- a/test/geo-point.test.js
+++ b/test/geo-point.test.js
@@ -22,14 +22,14 @@ describe('GeoPoint', function() {
   describe('GeoPoint()', function() {
     it('Create from string', function() {
       var point = new GeoPoint('1.234,5.678');
-      assert.equal(point.lng, 1.234);
-      assert.equal(point.lat, 5.678);
+      assert.equal(point.lat, 1.234);
+      assert.equal(point.lng, 5.678);
       var point2 = new GeoPoint('1.222,         5.333');
-      assert.equal(point2.lng, 1.222);
-      assert.equal(point2.lat, 5.333);
+      assert.equal(point2.lat, 1.222);
+      assert.equal(point2.lng, 5.333);
       var point3 = new GeoPoint('1.333, 5.111');
-      assert.equal(point3.lng, 1.333);
-      assert.equal(point3.lat, 5.111);
+      assert.equal(point3.lat, 1.333);
+      assert.equal(point3.lng, 5.111);
     });
     it('Serialize as string', function() {
       var str = '1.234,5.678';
@@ -38,8 +38,8 @@ describe('GeoPoint', function() {
     });
     it('Create from array', function() {
       var point = new GeoPoint([5.555, 6.777]);
-      assert.equal(point.lng, 5.555);
-      assert.equal(point.lat, 6.777);
+      assert.equal(point.lat, 5.555);
+      assert.equal(point.lng, 6.777);
     });
     it('Create as Model property', function() {
       var Model = loopback.createModel('geo-model', {
@@ -51,8 +51,8 @@ describe('GeoPoint', function() {
       });
 
       assert(m.geo instanceof GeoPoint);
-      assert.equal(m.geo.lng, 1.222);
-      assert.equal(m.geo.lat, 3.444);
+      assert.equal(m.geo.lat, 1.222);
+      assert.equal(m.geo.lng, 3.444);
     });
   });
 });

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -135,6 +135,45 @@ describe('User', function() {
       assert(u.password !== 'bar');
     });
 
+    describe('custom password hash', function() {
+      var defaultHashPassword;
+      var defaultValidatePassword;
+
+      beforeEach(function() {
+        defaultHashPassword = User.hashPassword;
+        defaultValidatePassword = User.defaultValidatePassword;
+
+        User.hashPassword = function(plain) {
+          return plain.toUpperCase();
+        };
+
+        User.validatePassword = function(plain) {
+          if (!plain || plain.length < 3) {
+            throw new Error('Password must have at least 3 chars');
+          }
+          return true;
+        };
+      });
+
+      afterEach(function() {
+        User.hashPassword = defaultHashPassword;
+      });
+
+      it('Reports invalid password', function() {
+        try {
+          var u = new User({username: 'foo', password: 'aa'});
+          assert(false, 'Error should have been thrown');
+        } catch (e) {
+          // Ignore
+        }
+      });
+
+      it('Hashes the given password', function() {
+        var u = new User({username: 'foo', password: 'bar'});
+        assert(u.password === 'BAR');
+      });
+    });
+
     it('Create a user over REST should remove emailVerified property', function(done) {
       request(app)
         .post('/users')


### PR DESCRIPTION
/to @ritch @bajtos 

The PR allows User.hashPassword and validatePassword methods to be overridden. It can be used as a workaround to https://github.com/strongloop/loopback/issues/251.
