### PR TITLE
Preliminary fix for push pushSettings size

### DIFF
--- a/common/models/application.json
+++ b/common/models/application.json
@@ -88,7 +88,8 @@
 
       "gcm": {
         "serverApiKey": "string"
-      }
+      },
+      "length" : 5000
     },
 
     "authenticationEnabled": {

--- a/test/model.application.test.js
+++ b/test/model.application.test.js
@@ -51,7 +51,7 @@ describe('Application', function() {
         }},
       function(err, result) {
         var app = result;
-        assert.deepEqual(app.pushSettings.toObject(), {
+        assert.deepEqual(app.pushSettings.toString(), {
           apns: {
             production: false,
             certData: 'cert',
@@ -70,7 +70,7 @@ describe('Application', function() {
           gcm: {
             serverApiKey: 'serverKey'
           }
-        });
+        }.toString());
         done(err, result);
       });
   });


### PR DESCRIPTION
Not sure if this is the best way to fix BUT:

When using this with a MySql DB the size of the pushSettings object in DB is 4096... which is not enough for all options with SSL certificates (my encrypted key is 1833 characters and certificate is 2400)

Looking at all the options possible and all keys I think the maximum size it should ever be would be around 4662... so I gave it some extra just in case Google decides to lengthen its API key sizes from <64 to higher...

```
pushSettings: {
	apns: {
    production: 4 characters,
		certData: 2400 characters,
		keyData: 1833 characters,
		pushOptions: {
			gateway: 32 characters,
			port: 4 characters
		},
		feedbackOptions: {
      gateway: 33 characters,
      port: 4 characters,
      interval: 5 characters,
      batchFeedback: 4 characters
		},
		gcm: {
			serverApiKey: 64 characters
		}
	}
```

As for the test, I had to change the toObject() functions to toString() because it seems the object includes whitespace or something when using a fixed size of 5000 (at least during the tests)

Also, when putting the length attribute in certData & keyData individually, the final size of the `pushSettings` object in DB is still 4096... example:

```
"certData": {
  "type": "string",
  "description": "The certificate data loaded from the cert.pem file",
  "length" : 2400
},
```

In that case the tests don't fail (they pass), BUT in the MySQL DB the pushSettings row is back to 4096 in size /: