### PR TITLE
Fix Change.getCheckpointModel() giving new models each call

### DIFF
--- a/common/models/change.js
+++ b/common/models/change.js
@@ -419,7 +419,7 @@ module.exports = function(Change) {
   Change.getCheckpointModel = function() {
     var checkpointModel = this.Checkpoint;
     if (checkpointModel) return checkpointModel;
-    this.checkpoint = checkpointModel = loopback.Checkpoint.extend('checkpoint');
+    this.Checkpoint = checkpointModel = loopback.Checkpoint.extend('checkpoint');
     assert(this.dataSource, 'Cannot getCheckpointModel(): ' + this.modelName
       + ' is not attached to a dataSource');
     checkpointModel.attachTo(this.dataSource);

--- a/test/change.test.js
+++ b/test/change.test.js
@@ -28,6 +28,12 @@ describe('Change', function() {
     });
   });
 
+  describe('Change.getCheckpointModel()', function() {
+    it('Shouldnt create two models if called twice', function() {
+      assert.equal(Change.getCheckpointModel(), Change.getCheckpointModel());
+    });
+  });
+
   describe('change.id', function() {
     it('should be a hash of the modelName and modelId', function() {
       var change = new Change({


### PR DESCRIPTION
This was a huge memory leak in our app... About more than 120MB per hour!