### PR TITLE
Fix duplicate Id on bulkUpdate.

### DIFF
--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -943,9 +943,11 @@ PersistedModel.bulkUpdate = function(updates, callback) {
   updates.forEach(function(update) {
     switch (update.type) {
       case Change.UPDATE:
+        tasks.push(function(cb) {
+          Model.upsert(update.data, cb);
+        });
+        break;
       case Change.CREATE:
-        // var model = new Model(update.data);
-        // tasks.push(model.save.bind(model));
         tasks.push(function(cb) {
           var model = new Model(update.data);
           model.save(cb);


### PR DESCRIPTION
When using the replication algorithm, data changes with updates would cause the server to crash with duplicate id error. This PR fixes this issue.