### PR TITLE
Allow user to hook the confirm method

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -549,6 +549,7 @@ module.exports = function(User) {
       UserModel.afterRemote('confirm', function(ctx, inst, next) {
         if (ctx.req) {
           ctx.res.redirect(ctx.req.param('redirect'));
+          next();
         } else {
           next(new Error('transport unsupported'));
         }


### PR DESCRIPTION
If a user overrides the User model, they might want to hook the confirm method so they can perform some action in addition to the redirect like maybe send a confirmation email.