### PR TITLE
don't send queries to the DB when no changes are detected

### DIFF
--- a/common/models/change.js
+++ b/common/models/change.js
@@ -344,6 +344,9 @@ module.exports = function(Change) {
    */
 
   Change.diff = function(modelName, since, remoteChanges, callback) {
+    if (!Array.isArray(remoteChanges) || remoteChanges.length === 0) {
+      return callback(null, {deltas: [], conflicts: []});
+    }
     var remoteChangeIndex = {};
     var modelIds = [];
     remoteChanges.forEach(function(ch) {

--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -728,6 +728,7 @@ PersistedModel.changes = function(since, filter, callback) {
     modelName: this.modelName
   }, function(err, changes) {
     if (err) return callback(err);
+    if (!Array.isArray(changes) || changes.length === 0) return callback(null, []);
     var ids = changes.map(function(change) {
       return change.getModelId();
     });


### PR DESCRIPTION
This modifies the 'changes' and 'diff' endpoints for replication.  This should be considered a performance optimization - no functionality should have changed.

It also revealed a defect in the MSSQL driver, but that will be fixed separately.

https://github.com/strongloop/loopback-connector-mssql/issues/19