### PR TITLE
status middleware: add `scopeToGetRoot` option

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "loopback-datasource-juggler": "^2.8.0",
     "loopback-testing": "~0.2.0",
     "mocha": "~1.21.4",
-    "serve-favicon": "~2.1.3",
     "strong-task-emitter": "0.0.x",
     "supertest": "~0.13.0"
   },

--- a/server/middleware/status.js
+++ b/server/middleware/status.js
@@ -5,8 +5,9 @@
 module.exports = status;
 
 /**
- * Return [HTTP response](http://expressjs.com/4x/api.html#res.send) with basic application status information:
- * date the application was started and uptime, in JSON format.
+ * Return [HTTP response](http://expressjs.com/4x/api.html#res.send) with basic
+ * application status information: date the application was started and uptime,
+ * in JSON format.
  * For example:
  * ```js
  * {
@@ -15,12 +16,21 @@ module.exports = status;
  * }
  * ```
  *
+ * @options {Object} [config] Middleware configuration
+ * @property {Boolean} [scopeToGetRoot] Whether the middleware should handle
+ * only `GET /` requests. By default, the middleware responds to all requests.
+ * @end
  * @header loopback.status()
  */
-function status() {
+function status(config) {
   var started = new Date();
 
-  return function(req, res) {
+  return function(req, res, next) {
+    if (config && config.scopeToGetRoot &&
+        (req.method !== 'GET' || req.path !== '/')) {
+      return next();
+    }
+
     res.send({
       started: started,
       uptime: (Date.now() - Number(started)) / 1000

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -763,6 +763,23 @@ describe('app', function() {
           done();
         });
     });
+
+    it('should respond only to `GET /` when configured', function(done) {
+      // see https://github.com/strongloop/generator-loopback/issues/80
+      var app = loopback();
+      app.use('/', loopback.status({ scopeToGetRoot: true }));
+      request(app)
+        .get('/url-does-not-exist')
+        .expect(404, done);
+    });
+
+    it('should respond to `GET /` when scopeToGetRoot is set', function(done) {
+      var app = loopback();
+      app.use('/', loopback.status({ scopeToGetRoot: true }));
+      request(app)
+        .get('/')
+        .expect(200, done);
+    });
   });
 
   describe('app.connectors', function() {


### PR DESCRIPTION
Before this change, the status middleware was implemented as a route,
i.e. it was always handling all requests.

This commit introduces a new config option `scopeToGetRoot`. When the
option is set, the middleware handler will respond only to `GET /`
and pass any other request down the middleware chain.

See strongloop/generator-loopback#80

/to @ritch or @raymondfeng please review