### PR TITLE
Remove unnecessary allocations from rest handler

### DIFF
--- a/server/middleware/rest.js
+++ b/server/middleware/rest.js
@@ -23,6 +23,8 @@ module.exports = rest;
  */
 
 function rest() {
+  var preHandlers;
+
   return function restApiHandler(req, res, next) {
     var app = req.app;
     var restHandler = app.handler('rest');
@@ -32,8 +34,6 @@ function rest() {
     } else if (req.url === '/models') {
       return res.send(app.remotes().toJSON());
     }
-
-    var preHandlers;
 
     if (!preHandlers) {
       preHandlers = [];
@@ -58,8 +58,14 @@ function rest() {
       }
     }
 
-    async.eachSeries(preHandlers.concat(restHandler), function(handler, done) {
-      handler(req, res, done);
-    }, next);
+    async.eachSeries(
+      preHandlers,
+      function(handler, done) {
+        handler(req, res, done);
+      },
+      function(err) {
+        if (err) return next(err);
+        restHandler(req, res, next);
+      });
   };
 }


### PR DESCRIPTION
Correctly cache the list of `preHandlers` so that they are built only once in application lifetime.

Remove array concatenation, use a new callback function instead.

/to @raymondfeng please review

Note: the problem addressed by this patch was pointed out in strongloop/loopback-benchmarks#1 as a possible improvement. I run the benchmark again with the patched version of loopback, but I did not observe any performance improvement greater that the variations in the measured data.