### PR TITLE
Fix/removes use of deprecated req.param method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .project
 .DS_Store
 *.sublime*
+*.vim*
 *.seed
 *.log
 *.csv

--- a/common/models/access-token.js
+++ b/common/models/access-token.js
@@ -165,13 +165,15 @@ module.exports = function(AccessToken) {
     var i = 0;
     var length;
     var id;
+    var param;
 
     params = params.concat(['access_token']);
     headers = headers.concat(['X-Access-Token', 'authorization']);
     cookies = cookies.concat(['access_token', 'authorization']);
 
     for (length = params.length; i < length; i++) {
-      id = req.param(params[i]);
+      param = params[i];
+      id = req.params[param] || req.query[param];
 
       if (typeof id === 'string') {
         return id;

--- a/common/models/user.js
+++ b/common/models/user.js
@@ -564,7 +564,11 @@ module.exports = function(User) {
     UserModel.on('attached', function() {
       UserModel.afterRemote('confirm', function(ctx, inst, next) {
         if (ctx.req) {
-          ctx.res.redirect(ctx.req.param('redirect'));
+          // Find redirect parameter as param or query. Not in body.
+          var redirectTo = (ctx.req.params && ctx.req.params.redirect) ||
+            (ctx.req.query && ctx.req.query.redirect);
+
+          ctx.res.redirect(redirectTo);
         } else {
           next(new Error('transport unsupported'));
         }

--- a/lib/application.js
+++ b/lib/application.js
@@ -295,13 +295,20 @@ app.enableAuth = function() {
   remotes.before('**', function(ctx, next, method) {
     var req = ctx.req;
     var Model = method.ctor;
-    var modelInstance = ctx.instance;
-    var modelId = modelInstance && modelInstance.id || req.param('id');
+    var modelInstance = ctx.instance || {};
+    // req.params and req.query default to {}. req.body can be undefined.
+    var modelId = modelInstance.id ||
+                  req.params.id    ||
+                  req.query.id     ||
+                  (req.body && req.body.id);
 
     var modelSettings = Model.settings || {};
-    var errStatusCode = modelSettings.aclErrorStatus || app.get('aclErrorStatus') || 401;
-    if (!req.accessToken) {
-      errStatusCode = 401;
+
+    var errStatusCode = 401;
+    if (req.accessToken) {
+      errStatusCode = modelSettings.aclErrorStatus ||
+                      app.get('aclErrorStatus')    ||
+                      errStatusCode;
     }
 
     if (Model.checkAccess) {

--- a/test/access-token.test.js
+++ b/test/access-token.test.js
@@ -132,6 +132,10 @@ describe('AccessToken', function() {
           headers: {},
           _params: {},
 
+          // These should always exist
+          params: {},
+          query: {},
+
           // express helpers
           param: function(name) { return this._params[name]; },
           header: function(name) { return this.headers[name]; }


### PR DESCRIPTION
Removes use of deprecated req.param() method.

req.param() would look in req.params, req.query and req.body. I tried to make logical choices on where to look for certain params (e.g. don't lookup redirect parameter in request body). Personally I would not allow an access-token in the request body and only as a query parameter or header, but people might depend on it so I kept it.