### PR TITLE
Extend AccessToken to parse Basic auth headers

### DIFF
--- a/common/models/access-token.js
+++ b/common/models/access-token.js
@@ -189,6 +189,20 @@ module.exports = function(AccessToken) {
           // Decode from base64
           var buf = new Buffer(id, 'base64');
           id = buf.toString('utf8');
+        } else if (/^Basic /i.test(id)) {
+          id = id.substring(6);
+          id = (new Buffer(id, 'base64')).toString('utf8');
+          // The spec says the string is user:pass, so if we see both parts
+          // we will assume the longer of the two is the token, so we will
+          // extract "a2b2c3" from:
+          //   "a2b2c3"
+          //   "a2b2c3:"   (curl http://a2b2c3@localhost:3000/)
+          //   "token:a2b2c3" (curl http://token:a2b2c3@localhost:3000/)
+          //   ":a2b2c3"
+          var parts = /^([^:]*):(.*)$/.exec(id);
+          if (parts) {
+            id = parts[2].length > parts[1].length ? parts[2] : parts[1];
+          }
         }
         return id;
       }

--- a/test/access-token.test.js
+++ b/test/access-token.test.js
@@ -34,7 +34,7 @@ describe('loopback.token(options)', function() {
     token = 'Bearer ' + new Buffer(token).toString('base64');
     createTestAppAndRequest(this.token, done)
       .get('/')
-      .set('authorization', this.token.id)
+      .set('authorization', token)
       .expect(200)
       .end(done);
   });

--- a/test/access-token.test.js
+++ b/test/access-token.test.js
@@ -39,6 +39,48 @@ describe('loopback.token(options)', function() {
       .end(done);
   });
 
+  describe('populating req.toen from HTTP Basic Auth formatted authorization header', function() {
+    it('parses "standalone-token"', function(done) {
+      var token = this.token.id;
+      token = 'Basic ' + new Buffer(token).toString('base64');
+      createTestAppAndRequest(this.token, done)
+        .get('/')
+        .set('authorization', this.token.id)
+        .expect(200)
+        .end(done);
+    });
+
+    it('parses "token-and-empty-password:"', function(done) {
+      var token = this.token.id + ':';
+      token = 'Basic ' + new Buffer(token).toString('base64');
+      createTestAppAndRequest(this.token, done)
+        .get('/')
+        .set('authorization', this.token.id)
+        .expect(200)
+        .end(done);
+    });
+
+    it('parses "ignored-user:token-is-password"', function(done) {
+      var token = 'username:' + this.token.id;
+      token = 'Basic ' + new Buffer(token).toString('base64');
+      createTestAppAndRequest(this.token, done)
+        .get('/')
+        .set('authorization', this.token.id)
+        .expect(200)
+        .end(done);
+    });
+
+    it('parses "token-is-username:ignored-password"', function(done) {
+      var token = this.token.id + ':password';
+      token = 'Basic ' + new Buffer(token).toString('base64');
+      createTestAppAndRequest(this.token, done)
+        .get('/')
+        .set('authorization', this.token.id)
+        .expect(200)
+        .end(done);
+    });
+  });
+
   it('should populate req.token from a secure cookie', function(done) {
     var app = createTestApp(this.token, done);
 

--- a/test/e2e/remote-connector.e2e.js
+++ b/test/e2e/remote-connector.e2e.js
@@ -8,7 +8,7 @@ describe('RemoteConnector', function() {
   before(function() {
     // setup the remote connector
     var ds = loopback.createDataSource({
-      url: 'http://localhost:3000/api',
+      url: 'http://127.0.0.1:3000/api',
       connector: loopback.Remote
     });
     TestModel.attachTo(ds);

--- a/test/e2e/replication.e2e.js
+++ b/test/e2e/replication.e2e.js
@@ -11,7 +11,7 @@ describe('Replication', function() {
   before(function() {
     // setup the remote connector
     var ds = loopback.createDataSource({
-      url: 'http://localhost:3000/api',
+      url: 'http://127.0.0.1:3000/api',
       connector: loopback.Remote
     });
     TestModel.attachTo(ds);


### PR DESCRIPTION
Allow convenient URLs for curl and browsers such as:
 - http://some-long-token@localhost:3000/
 - http://token:some-long-token@localhost:3000/

Basic Auth specifies a 'Basic' scheme for the Authorization header
similar to how OAuth specifies 'Bearer' as an auth scheme.

Following a similar convention, extract the access token from the
Authorization header when it specifies the 'Basic' scheme, assuming
it is the larger of the \<user\>:\<pass\> segments.