### PR TITLE
Update use of request.param(name) to request.params[name]

### DIFF
--- a/common/models/access-token.js
+++ b/common/models/access-token.js
@@ -171,7 +171,7 @@ module.exports = function(AccessToken) {
     cookies = cookies.concat(['access_token', 'authorization']);
 
     for (length = params.length; i < length; i++) {
-      id = req.param(params[i]);
+      id = req.params[params[i]];
 
       if (typeof id === 'string') {
         return id;


### PR DESCRIPTION
Express deprecated the use of request.param(name).

Signed-off-by: bradplank <brad@bradplank.com>