### PR TITLE
Remove usages of deprecated `req.param()`

### DIFF
--- a/common/models/access-token.js
+++ b/common/models/access-token.js
@@ -172,7 +172,12 @@ module.exports = function(AccessToken) {
     cookies = cookies.concat(['access_token', 'authorization']);
 
     for (length = params.length; i < length; i++) {
-      id = req.param(params[i]);
+      var param = params[i];
+      // replacement for deprecated req.param()
+      id = req.params && req.params[param] !== undefined ? req.params[param] :
+        req.body && req.body[param] !== undefined ? req.body[param] :
+        req.query && req.query[param] !== undefined ? req.query[param] :
+        undefined;
 
       if (typeof id === 'string') {
         return id;

--- a/common/models/user.js
+++ b/common/models/user.js
@@ -570,7 +570,17 @@ module.exports = function(User) {
     UserModel.on('attached', function() {
       UserModel.afterRemote('confirm', function(ctx, inst, next) {
         if (ctx.req) {
-          ctx.res.redirect(ctx.req.param('redirect'));
+          // replacement for deprecated req.param()
+          var params = ctx.req.params;
+          var body = ctx.req.body;
+          var query = ctx.req.query;
+          var redirectUrl =
+            params && params.redirect !== undefined ? params.redirect :
+            body && body.redirect !== undefined ? body.redirect :
+            query && query.redirect !== undefined ? query.redirect :
+            undefined;
+
+          ctx.res.redirect(redirectUrl);
         } else {
           next(new Error('transport unsupported'));
         }

--- a/lib/application.js
+++ b/lib/application.js
@@ -296,7 +296,14 @@ app.enableAuth = function() {
     var req = ctx.req;
     var Model = method.ctor;
     var modelInstance = ctx.instance;
-    var modelId = modelInstance && modelInstance.id || req.param('id');
+
+    var modelId = modelInstance && modelInstance.id ||
+      // replacement for deprecated req.param()
+      (req.params && req.params.id !== undefined ? req.params.id :
+       req.body && req.body.id !== undefined ? req.body.id :
+       req.query && req.query.id !== undefined ? req.query.id :
+       undefined);
+
     var modelName = Model.modelName;
 
     var modelSettings = Model.settings || {};


### PR DESCRIPTION
Express has recently deprecated `req.param()` to force developers to be explicit about the source of the value. To avoid deprecation warnings, this commit replaces all calls of `req.param()` with a simplified inline version.

This supersedes a community-contributed PR https://github.com/strongloop/loopback/pull/1008 that is suboptimal.

/to @raymondfeng or @ritch please review