### PR TITLE
Add attachments option to user verification email

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -372,7 +372,8 @@ module.exports = function(User) {
         subject: options.subject || 'Thanks for Registering',
         text: options.text,
         html: template(options),
-        headers: options.headers || {}
+        headers: options.headers || {},
+        attachments: options.attachments || []
       }, function(err, email) {
         if (err) {
           fn(err);


### PR DESCRIPTION
This PR allows an array of `attachments` to be sent in the `sendEmail` function of `User#verify`.

Reference: https://github.com/andris9/Nodemailer#attachments