### PR TITLE
Fix test broken by recent juggler changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "underscore.string": "~2.3.3"
   },
   "peerDependencies": {
-    "loopback-datasource-juggler": "^2.8.0"
+    "loopback-datasource-juggler": "^2.17.0"
   },
   "devDependencies": {
     "browserify": "~4.2.3",
@@ -79,7 +79,7 @@
     "karma-phantomjs-launcher": "~0.1.4",
     "karma-script-launcher": "~0.1.0",
     "loopback-boot": "^1.1.0",
-    "loopback-datasource-juggler": "^2.8.0",
+    "loopback-datasource-juggler": "^2.17.0",
     "loopback-testing": "~0.2.0",
     "mocha": "~1.21.4",
     "serve-favicon": "~2.1.3",

--- a/test/loopback.test.js
+++ b/test/loopback.test.js
@@ -344,6 +344,8 @@ describe('loopback', function() {
         emailVerificationRequired: false
       });
 
+      var baseName = model.settings.base.name;
+
       loopback.configureModel(model, {
         dataSource: null,
         options: {
@@ -357,7 +359,9 @@ describe('loopback', function() {
       expect(model.settings).to.have.property('emailVerificationRequired',
         false);
       expect(model.settings).to.have.property('realmRequired', true);
-      expect(model.settings).to.not.have.property('base');
+
+      // configureModel MUST NOT change Model's base class
+      expect(model.settings.base.name).to.equal(baseName);
     });
   });
 


### PR DESCRIPTION
The patch strongloop/loopback-datasource-juggler#436 changed the way how `Model.extend` works, which broke a loopback test relying on the old behaviour.

This commit fixes the failing test. The test is checking now that the model base was not changed, instead of checking that the base is undefined.

/cc @raymondfeng @PradnyaBaviskar 