### PR TITLE
Remove redundant dev-dep serve-favicon

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "loopback-datasource-juggler": "^2.17.0",
     "loopback-testing": "~0.2.0",
     "mocha": "~1.21.4",
-    "serve-favicon": "~2.1.3",
     "strong-task-emitter": "0.0.x",
     "supertest": "~0.13.0"
   },


### PR DESCRIPTION
`serve-favicon` is already a regular dependency.