### PR TITLE
Fix change detection & tracking

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -8,6 +8,7 @@
      "try",
      "catch"
   ],
+  "disallowMultipleVarDecl": "exceptUndefined",
   "disallowSpacesInsideObjectBrackets": null,
   "maximumLineLength": {
      "value": 150,

--- a/common/models/change.js
+++ b/common/models/change.js
@@ -189,6 +189,7 @@ module.exports = function(Change) {
     function updateCheckpoint(cb) {
       change.constructor.getCheckpointModel().current(function(err, checkpoint) {
         if (err) return Change.handleError(err);
+        debug('updated checkpoint to', checkpoint);
         change.checkpoint = checkpoint;
         cb();
       });
@@ -408,9 +409,10 @@ module.exports = function(Change) {
     // this should be optimized
     this.find(function(err, changes) {
       if (err) return cb(err);
-      changes.forEach(function(change) {
-        change.rectify();
-      });
+      async.each(
+        changes,
+        function(c, next) { c.rectify(next); },
+        cb);
     });
   };
 

--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -755,10 +755,10 @@ PersistedModel.changes = function(since, filter, callback) {
   filter.fields[idName] = true;
 
   // TODO(ritch) this whole thing could be optimized a bit more
-  Change.find({
+  Change.find({ where: {
     checkpoint: {gt: since},
     modelName: this.modelName
-  }, function(err, changes) {
+  }}, function(err, changes) {
     if (err) return callback(err);
     if (!Array.isArray(changes) || changes.length === 0) return callback(null, []);
     var ids = changes.map(function(change) {
@@ -1044,15 +1044,9 @@ PersistedModel.enableChangeTracking = function() {
   Change.attachTo(this.dataSource);
   Change.getCheckpointModel().attachTo(this.dataSource);
 
-  Model.afterSave = function afterSave(next) {
-    Model.rectifyChange(this.getId(), next);
-  };
+  Model.observe('after save', rectifyOnSave);
 
-  Model.afterDestroy = function afterDestroy(next) {
-    Model.rectifyChange(this.getId(), next);
-  };
-
-  Model.on('deletedAll', cleanup);
+  Model.observe('after delete', rectifyOnDelete);
 
   if (runtime.isServer) {
     // initial cleanup
@@ -1071,6 +1065,54 @@ PersistedModel.enableChangeTracking = function() {
     });
   }
 };
+
+function rectifyOnSave(ctx, next) {
+  if (ctx.instance) {
+    ctx.Model.rectifyChange(ctx.instance.getId(), reportErrorAndNext);
+  } else {
+    ctx.Model.rectifyAllChanges(reportErrorAndNext);
+  }
+
+  function reportErrorAndNext(err) {
+    if (err) {
+      console.error(
+        ctx.Model.modelName + '.rectifyChange(s) after save failed:' + err);
+    }
+    next();
+  }
+}
+
+function rectifyOnDelete(ctx, next) {
+  var id = getIdFromWhereByModelId(ctx.Model, ctx.where);
+  if (id) {
+    ctx.Model.rectifyChange(id, reportErrorAndNext);
+  } else {
+    ctx.Model.rectifyAllChanges(reportErrorAndNext);
+  }
+
+  function reportErrorAndNext(err) {
+    if (err) {
+      console.error(
+        ctx.Model.modelName + '.rectifyChange(s) after delete failed:' + err);
+    }
+    next();
+  }
+}
+
+function getIdFromWhereByModelId(Model, where) {
+  var whereKeys = Object.keys(where);
+  if (whereKeys.length != 1) return undefined;
+
+  var idName = Model.getIdName();
+  if (whereKeys[0] !== idName) return undefined;
+
+  var id = where[idName];
+  // TODO(bajtos) support object values that are not LB conditions
+  if (typeof id === 'string' || typeof id === 'number') {
+    return id;
+  }
+  return undefined;
+}
 
 PersistedModel._defineChangeModel = function() {
   var BaseChangeModel = registry.getModel('Change');


### PR DESCRIPTION
Add unit-tests to verify that all DAO methods correctly create change records.

Rework the change detection to use the new operation hooks, this fixes the bugs where operations like "updateOrCreate" did not update change records.

Close #1048 

/to @ritch please review
/cc @raymondfeng @BerkeleyTrue