### PR TITLE
Add fix to override afterRemote comfirm method

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -561,7 +561,7 @@ module.exports = function(User) {
         accepts: [
           {arg: 'uid', type: 'string', required: true},
           {arg: 'token', type: 'string', required: true},
-          {arg: 'redirect', type: 'string', required: true}
+          {arg: 'redirect', type: 'string'}
         ],
         http: {verb: 'get', path: '/confirm'}
       }
@@ -580,21 +580,14 @@ module.exports = function(User) {
 
     UserModel.on('attached', function() {
       UserModel.afterRemote('confirm', function(ctx, inst, next) {
-        if (ctx.req) {
-          // replacement for deprecated req.param()
-          var params = ctx.req.params;
-          var body = ctx.req.body;
-          var query = ctx.req.query;
-          var redirectUrl =
-            params && params.redirect !== undefined ? params.redirect :
-            body && body.redirect !== undefined ? body.redirect :
-            query && query.redirect !== undefined ? query.redirect :
-            undefined;
-
-          ctx.res.redirect(redirectUrl);
-        } else {
-          next(new Error('transport unsupported'));
+        if (ctx.args.redirect !== undefined) {
+          if (!ctx.res) {
+            return next(new Error('The transport does not support HTTP redirects.'));
+          }
+          ctx.res.location(ctx.args.redirect);
+          ctx.res.status(302);
         }
+        next();
       });
     });
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "nodemailer-stub-transport": "~0.1.4",
     "serve-favicon": "^2.1.6",
     "stable": "^0.1.5",
-    "strong-remoting": "^2.11.0",
+    "strong-remoting": "^2.13.2",
     "uid2": "0.0.3",
     "underscore.string": "~2.3.3"
   },

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -858,6 +858,28 @@ describe('User', function() {
         }, done);
       });
 
+      it('Should report 302 when redirect url is set', function(done) {
+        testConfirm(function(result, done) {
+          request(app)
+            .get('/users/confirm?uid=' + (result.uid) +
+              '&token=' + encodeURIComponent(result.token) +
+              '&redirect=http://foo.com/bar')
+            .expect(302)
+            .expect('Location', 'http://foo.com/bar')
+            .end(done);
+        }, done);
+      });
+
+      it('Should report 204 when redirect url is not set', function(done) {
+        testConfirm(function(result, done) {
+          request(app)
+            .get('/users/confirm?uid=' + (result.uid) +
+              '&token=' + encodeURIComponent(result.token))
+            .expect(204)
+            .end(done);
+        }, done);
+      });
+
       it('Report error for invalid user id during verification', function(done) {
         testConfirm(function(result, done) {
           request(app)


### PR DESCRIPTION
to / @bajtos -
In reference to https://github.com/strongloop/loopback/issues/416 , 

I've made changes so that redirect URL is an optional param. And in case redirect URL is specified then the response status is 302.

For this to work correctly, the strong remoting fix - https://github.com/strongloop/strong-remoting/pull/183, will have to be taken up first.

Can you please review?