### PR TITLE
travis.yml: drop 0.11, add 0.12 and iojs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
 node_js:
-  - "0.11"
   - "0.10"
+  - "0.12"
+  - "iojs"
+


### PR DESCRIPTION
This patch fixes the configuration of Travis CI to run the tests on stable major versions.

@rmg @ritch @raymondfeng I'd like to use this opportunity to consider whether we want to continue using Travis CI for loopback. The browser (Karma) tests are failing there due to a timing issue. The only benefit of Travis CI compared to our Jenkins CI is the openness, meaning that the result of a CI build in is visible to anonymous users in Travis CI, but they are protected by (StrongLoop) login in Jenkins CI.

Thoughts?

@rmg How much work does is required to make all PR jobs for public GH repos readable to anonymous users?