### PR TITLE
Add a workaround to avoid conflicts with NewRelic

### DIFF
--- a/lib/server-app.js
+++ b/lib/server-app.js
@@ -161,12 +161,49 @@ proto.middleware = function(name, paths, handler) {
 
   this._skipLayerSorting = true;
   this.use(paths, handler);
-  this._router.stack[this._router.stack.length - 1].phase = fullPhaseName;
+
+  var layer = this._findLayerByHandler(handler);
+  if (layer) {
+    // Set the phase name for sorting
+    layer.phase = fullPhaseName;
+  } else {
+    debug('No matching layer is found for %s %s', fullPhaseName, handlerName);
+  }
+
   this._skipLayerSorting = false;
 
   this._sortLayersByPhase();
 
   return this;
+};
+
+/*
+ * Find the corresponding express layer by handler
+ *
+ * This is needed because monitoring agents such as NewRelic can add handlers
+ * to the stack. For example, NewRelic adds sentinel handler. We need to search
+ * the stackto find the correct layer.
+ */
+proto._findLayerByHandler = function(handler) {
+  // Other handlers can be added to the stack, for example,
+  // NewRelic adds sentinel handler. We need to search the stack
+  for (var k = this._router.stack.length - 1; k >= 0; k--) {
+    if (this._router.stack[k].handle === handler ||
+      // NewRelic replaces the handle and keeps it as __NR_original
+      this._router.stack[k].handle['__NR_original'] === handler
+      ) {
+      return this._router.stack[k];
+    } else {
+      // Aggressively check if the original handler has been wrapped
+      // into a new function with a property pointing to the original handler
+      for (var p in this._router.stack[k].handle) {
+        if (this._router.stack[k].handle[p] === handler) {
+          return this._router.stack[k];
+        }
+      }
+    }
+  }
+  return null;
 };
 
 // Install our custom PhaseList-based handler into the app


### PR DESCRIPTION
/to @bajtos 

NewRelic intercepts express `app.use` and injects its middleware. It also wraps middleware handlers. This monkey-patching trick breaks the assumption in LoopBack that the last item in the router stack is the one being added. As a result, the phase name is not set to the correct handler and middleware ordering is broken.

See https://github.com/bstar/newrelic_test to reproduce the problem.