### PR TITLE
Skip hashing password if it's already hashed

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -501,7 +501,13 @@ module.exports = function(User) {
     this.settings.ttl = this.settings.ttl || DEFAULT_TTL;
 
     UserModel.setter.password = function(plain) {
-      this.$password = this.constructor.hashPassword(plain);
+      if (plain.indexOf('$2a$') === 0 && plain.length === 60) {
+        // The password is already hashed. It can be the case
+        // when the instance is loaded from DB
+        this.$password = plain;
+      } else {
+        this.$password = this.constructor.hashPassword(plain);
+      }
     };
 
     // Make sure emailVerified is not set by creation

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -137,6 +137,13 @@ describe('User', function() {
       assert(u.password !== 'bar');
     });
 
+    it('does not hash the password if it\'s already hashed', function() {
+      var u1 = new User({username: 'foo', password: 'bar'});
+      assert(u1.password !== 'bar');
+      var u2 = new User({username: 'foo', password: u1.password});
+      assert(u2.password === u1.password);
+    });
+
     describe('custom password hash', function() {
       var defaultHashPassword;
       var defaultValidatePassword;


### PR DESCRIPTION
/to @ritch 

`User.setter.password` is evil. It's triggered when a user record is loaded from the DB too. The `bcrypt` is very expensive.

See https://github.com/strongloop/loopback-datasource-juggler/issues/471