### PR TITLE
ability to disalbe /models /routes routes

### DIFF
--- a/server/middleware/rest.js
+++ b/server/middleware/rest.js
@@ -4,6 +4,7 @@
 
 var loopback = require('../../lib/loopback');
 var async = require('async');
+var deprecate = require('depd')('loopback');
 
 /*!
  * Export the middleware.
@@ -28,10 +29,17 @@ function rest() {
   return function restApiHandler(req, res, next) {
     var app = req.app;
 
-    if (req.url === '/routes') {
-      return res.send(app.handler('rest').adapter.allRoutes());
-    } else if (req.url === '/models') {
-      return res.send(app.remotes().toJSON());
+    // added for https://github.com/strongloop/loopback/issues/1134
+    if (app.get('legacyExplorer') !== false) {
+      deprecate(
+        'Routes "/methods" and "/models" are considered dangerous and should not be used.\n' +
+        'Disable them by setting "legacyExplorer=false" in "server/config.json" or via "app.set()".'
+      );
+      if (req.url === '/routes') {
+        return res.send(app.handler('rest').adapter.allRoutes());
+      } else if (req.url === '/models') {
+        return res.send(app.remotes().toJSON());
+      }
     }
 
     if (!handlers) {

--- a/test/rest.middleware.test.js
+++ b/test/rest.middleware.test.js
@@ -164,6 +164,44 @@ describe('loopback.rest', function() {
     }, done);
   });
 
+  it('should report 200 for legacy explorer route /routes', function(done) {
+    app.use(loopback.rest());
+    request(app).get('/routes')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) return done(err);
+        expect(res.body).to.eql([]);
+        done();
+      });
+  });
+
+  it('should report 200 for legacy explorer route /models', function(done) {
+    app.use(loopback.rest());
+    request(app).get('/models')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) return done(err);
+        expect(res.body).to.eql({});
+        done();
+      });
+  });
+
+  it('should report 404 for disabled legacy explorer route /routes', function(done) {
+    app.set('legacyExplorer', false);
+    app.use(loopback.rest());
+    request(app).get('/routes')
+      .expect(404)
+      .end(done);
+  });
+
+  it('should report 404 for disabled legacy explorer route /models', function(done) {
+    app.set('legacyExplorer', false);
+    app.use(loopback.rest());
+    request(app).get('/models')
+      .expect(404)
+      .end(done);
+  });
+
   describe('context propagation', function() {
     var User;
 


### PR DESCRIPTION
PR for #1134 

WIP though feedback ok for existing work.

[Suggested Functionality](https://github.com/strongloop/loopback/issues/1134#issuecomment-76024882)
* [x] Enabled by default to preserve backwards compatibility.
* [x] Deprecated from the beginning, so that users are warned about this problem. Use depd for deprecation, that's what express uses too.

Also:
* [x] Tests to ensure `/models` `/routes` can be disabled