### PR TITLE
Replace deprecated hooks with Operation hooks

### DIFF
--- a/common/models/access-token.js
+++ b/common/models/access-token.js
@@ -65,20 +65,18 @@ module.exports = function(AccessToken) {
   /*!
    * Hook to create accessToken id.
    */
-
-  AccessToken.beforeCreate = function(next, data) {
-    data = data || {};
+  AccessToken.observe('before save', function(ctx, next) {
+    if (!ctx.instance || ctx.instance.id) {
+      // We are running a partial update or the instance already has an id
+      return next();
+    }
 
     AccessToken.createAccessTokenId(function(err, id) {
-      if (err) {
-        next(err);
-      } else {
-        data.id = id;
-
-        next();
-      }
+      if (err) return next(err);
+      ctx.instance.id = id;
+      next();
     });
-  };
+  });
 
   /**
    * Find a token for the given `ServerRequest`.

--- a/common/models/application.js
+++ b/common/models/application.js
@@ -81,8 +81,15 @@ module.exports = function(Application) {
    * A hook to generate keys before creation
    * @param next
    */
-  Application.beforeCreate = function(next) {
-    var app = this;
+  Application.observe('before save', function(ctx, next) {
+    if (!ctx.instance) {
+      // Partial update - don't generate new keys
+      // NOTE(bajtos) This also means that an atomic updateOrCreate
+      // will not generate keys when a new record is creatd
+      return next();
+    }
+
+    var app = ctx.instance;
     app.created = app.modified = new Date();
     app.id = generateKey('id', 'md5');
     app.clientKey = generateKey('client');
@@ -91,7 +98,7 @@ module.exports = function(Application) {
     app.windowsKey = generateKey('windows');
     app.masterKey = generateKey('master');
     next();
-  };
+  });
 
   /**
    * Register a new application

--- a/common/models/checkpoint.js
+++ b/common/models/checkpoint.js
@@ -49,7 +49,13 @@ module.exports = function(Checkpoint) {
     });
   };
 
-  Checkpoint.beforeSave = function(next, model) {
+  Checkpoint.observe('before save', function(ctx, next) {
+    if (!ctx.instance) {
+      // Example: Checkpoint.updateAll() and Checkpoint.updateOrCreate()
+      return next(new Error('Checkpoint does not support partial updates.'));
+    }
+
+    var model = ctx.instance;
     if (!model.getId() && model.seq === undefined) {
       model.constructor.current(function(err, seq) {
         if (err) return next(err);
@@ -59,5 +65,5 @@ module.exports = function(Checkpoint) {
     } else {
       next();
     }
-  };
+  });
 };


### PR DESCRIPTION
```
AccessToken.beforeCreate -> AccessToken.observe('before save')
Application.beforeCreate -> Application.observe('before save')
Checkpoint.beforeSave -> Checkpoint.observe('before save')
```

/to @ritch please review
/cc @raymondfeng 

Loosely related: https://github.com/strongloop/loopback/issues/838 that will implement `ctx.isNewInstance`. Although I don't think it will be very helpful in these three cases.