### PR TITLE
karma conf: prevent timeouts on Travis CI

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -61,6 +61,11 @@ module.exports = function(config) {
     // If browser does not capture in given timeout [ms], kill it
     captureTimeout: 60000,
 
+    // to avoid DISCONNECTED messages
+    browserDisconnectTimeout : 10000, // default 2000
+    browserDisconnectTolerance : 1, // default 0
+    browserNoActivityTimeout : 60000, //default 10000
+
     // Continuous Integration mode
     // if true, it capture browsers, run tests and exit
     singleRun: false,


### PR DESCRIPTION
Increase the timeout values to prevent DISCONNECTED errors when
running the tests on slow machines (e.g. Travis CI).