### PR TITLE
Replication improvements: Checkpoint

### DIFF
--- a/common/models/change.js
+++ b/common/models/change.js
@@ -428,6 +428,8 @@ module.exports = function(Change) {
   Change.getCheckpointModel = function() {
     var checkpointModel = this.Checkpoint;
     if (checkpointModel) return checkpointModel;
+    // FIXME(bajtos) This code creates multiple different models with the same
+    // model name, which is not a valid supported usage of juggler's API.
     this.Checkpoint = checkpointModel = loopback.Checkpoint.extend('checkpoint');
     assert(this.dataSource, 'Cannot getCheckpointModel(): ' + this.modelName +
       ' is not attached to a dataSource');

--- a/common/models/checkpoint.js
+++ b/common/models/checkpoint.js
@@ -41,7 +41,7 @@ module.exports = function(Checkpoint) {
       if (checkpoint) {
         cb(null, checkpoint.seq);
       } else {
-        Checkpoint.create({seq: 0}, function(err, checkpoint) {
+        Checkpoint.create({ seq: 1 }, function(err, checkpoint) {
           if (err) return cb(err);
           cb(null, checkpoint.seq);
         });

--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -844,6 +844,7 @@ PersistedModel.replicate = function(since, targetModel, options, callback) {
   var Change = this.getChangeModel();
   var TargetChange = targetModel.getChangeModel();
   var changeTrackingEnabled = Change && TargetChange;
+  var newSourceCp, newTargetCp;
 
   assert(
     changeTrackingEnabled,
@@ -889,8 +890,10 @@ PersistedModel.replicate = function(since, targetModel, options, callback) {
 
   function checkpoints() {
     var cb = arguments[arguments.length - 1];
-    sourceModel.checkpoint(function(err) {
-      targetModel.checkpoint(function(err) {
+    sourceModel.checkpoint(function(err, source) {
+      newSourceCp = source.seq;
+      targetModel.checkpoint(function(err, target) {
+        newTargetCp = target.seq;
         cb(err);
       });
     });
@@ -909,7 +912,10 @@ PersistedModel.replicate = function(since, targetModel, options, callback) {
       sourceModel.emit('conflicts', conflicts);
     }
 
-    if (callback) callback(null, conflicts);
+    if (callback) {
+      var newCheckpoints = { source: newSourceCp, target: newTargetCp };
+      callback(null, conflicts, newCheckpoints);
+    }
   }
 };
 

--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -855,7 +855,7 @@ PersistedModel.replicate = function(since, targetModel, options, callback) {
   };
 
   var tasks = [
-    checkpoint,
+    checkpoints,
     getSourceChanges,
     getDiffFromTarget,
     createSourceUpdates,
@@ -887,9 +887,13 @@ PersistedModel.replicate = function(since, targetModel, options, callback) {
     targetModel.bulkUpdate(updates, cb);
   }
 
-  function checkpoint() {
+  function checkpoints() {
     var cb = arguments[arguments.length - 1];
-    sourceModel.checkpoint(function(err) { cb(err); });
+    sourceModel.checkpoint(function(err) {
+      targetModel.checkpoint(function(err) {
+        cb(err);
+      });
+    });
   }
 
   function done(err) {

--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -855,11 +855,11 @@ PersistedModel.replicate = function(since, targetModel, options, callback) {
   };
 
   var tasks = [
+    checkpoint,
     getSourceChanges,
     getDiffFromTarget,
     createSourceUpdates,
-    bulkUpdate,
-    checkpoint
+    bulkUpdate
   ];
 
   async.waterfall(tasks, done);
@@ -889,7 +889,7 @@ PersistedModel.replicate = function(since, targetModel, options, callback) {
 
   function checkpoint() {
     var cb = arguments[arguments.length - 1];
-    sourceModel.checkpoint(cb);
+    sourceModel.checkpoint(function(err) { cb(err); });
   }
 
   function done(err) {

--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -757,7 +757,7 @@ PersistedModel.changes = function(since, filter, callback) {
 
   // TODO(ritch) this whole thing could be optimized a bit more
   Change.find({ where: {
-    checkpoint: {gt: since},
+    checkpoint: { gte: since },
     modelName: this.modelName
   }}, function(err, changes) {
     if (err) return callback(err);
@@ -832,6 +832,10 @@ PersistedModel.replicate = function(since, targetModel, options, callback) {
     since = -1;
   }
 
+  if (typeof since !== 'object') {
+    since = { source: since, target: since };
+  }
+
   options = options || {};
 
   var sourceModel = this;
@@ -861,11 +865,11 @@ PersistedModel.replicate = function(since, targetModel, options, callback) {
   async.waterfall(tasks, done);
 
   function getSourceChanges(cb) {
-    sourceModel.changes(since, options.filter, cb);
+    sourceModel.changes(since.source, options.filter, cb);
   }
 
   function getDiffFromTarget(sourceChanges, cb) {
-    targetModel.diff(since, sourceChanges, cb);
+    targetModel.diff(since.target, sourceChanges, cb);
   }
 
   function createSourceUpdates(_diff, cb) {

--- a/test/checkpoint.test.js
+++ b/test/checkpoint.test.js
@@ -14,7 +14,7 @@ describe('Checkpoint', function() {
         function(next) {
           Checkpoint.current(function(err, seq) {
             if (err) next(err);
-            expect(seq).to.equal(2);
+            expect(seq).to.equal(3);
             next();
           });
         }


### PR DESCRIPTION
A first round of `PersistedModel.replicate()` improvements described in #985 (connect to #985):

 - Support different "since" for source and target
 - Fix checkpoint-related race condition, create a remote checkpoint during replication too
 - Return new checkpoints in callback of replicate()

/to @ritch Please review, preferably today.

My next work will most likely depend on this PR, so if I don't manage to get this merged today, I'll have to add new stuff to this PR instead of opening a new one.

/cc @raymondfeng 