### PR TITLE
Allow 'me' literal to represent the current user in url

### DIFF
--- a/server/middleware/token.js
+++ b/server/middleware/token.js
@@ -4,12 +4,34 @@
 
 var loopback = require('../../lib/loopback');
 var assert = require('assert');
+var debug = require('debug')('loopback:middleware:token');
 
 /*!
  * Export the middleware.
  */
 
 module.exports = token;
+
+/*
+ * Rewrite the url to replace current user literal with the logged in user id
+ */
+function rewriteUserLiteral(req, currentUserLiteral) {
+  if (req.accessToken && req.accessToken.userId && currentUserLiteral) {
+    // Replace /me/ with /current-user-id/
+    var urlBeforeRewrite = req.url;
+    req.url = req.url.replace(
+      new RegExp('/' + currentUserLiteral + '(/|$|\\?)', 'g'),
+        '/' + req.accessToken.userId + '$1');
+    if (req.url !== urlBeforeRewrite) {
+      debug('req.url has been rewritten from %s to %s', urlBeforeRewrite,
+        req.url);
+    }
+  }
+}
+
+function escapeRegExp(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
 
 /**
  * Check for an access token in cookies, headers, and query string parameters.
@@ -39,19 +61,37 @@ module.exports = token;
  * @property {Array} [cookies] Array of cookie names.
  * @property {Array} [headers] Array of header names.
  * @property {Array} [params] Array of param names.
- * @property {Array} [model] An AccessToken object to use.
+ * @property {Function|String} [model] AccessToken model name or class to use.
+ * @property {String} [currentUserLiteral] String literal for the current user.
  * @header loopback.token([options])
  */
 
 function token(options) {
   options = options || {};
   var TokenModel = options.model || loopback.AccessToken;
-  assert(TokenModel, 'loopback.token() middleware requires a AccessToken model');
+  if (typeof TokenModel === 'string') {
+    // Make it possible to configure the model in middleware.json
+    TokenModel = loopback.getModel(TokenModel);
+  }
+  var currentUserLiteral = options.currentUserLiteral;
+  if (currentUserLiteral && (typeof currentUserLiteral !== 'string')) {
+    debug('Set currentUserLiteral to \'me\' as the value is not a string.');
+    currentUserLiteral = 'me';
+  }
+  if (typeof currentUserLiteral === 'string') {
+    currentUserLiteral = escapeRegExp(currentUserLiteral);
+  }
+  assert(typeof TokenModel === 'function',
+    'loopback.token() middleware requires a AccessToken model');
 
   return function(req, res, next) {
-    if (req.accessToken !== undefined) return next();
+    if (req.accessToken !== undefined) {
+      rewriteUserLiteral(req, currentUserLiteral);
+      return next();
+    }
     TokenModel.findForRequest(req, options, function(err, token) {
       req.accessToken = token || null;
+      rewriteUserLiteral(req, currentUserLiteral);
       var ctx = loopback.getCurrentContext();
       if (ctx) ctx.set('accessToken', token);
       next(err);


### PR DESCRIPTION
/to @ritch @bajtos 

This PR adds the ability to use `me` or a custom literal to represent the current user in req url. For example,

GET /api/users/me

The token middleware will replace `me` with the current user id for downstream handlers.

It adds an option to loopback.token middleware as `currentUserLiteral`. 