### PR TITLE
Static ACL support array of properties now

### DIFF
--- a/common/models/acl.js
+++ b/common/models/acl.js
@@ -256,10 +256,14 @@ module.exports = function(ACL) {
     var staticACLs = [];
     if (modelClass && modelClass.settings.acls) {
       modelClass.settings.acls.forEach(function(acl) {
-        if (!acl.property || acl.property === ACL.ALL || property === acl.property) {
+        var prop = acl.property;
+        // We support static ACL property with array of string values.
+        if (Array.isArray(prop) && prop.indexOf(property) >= 0)
+          prop = property;
+        if (!prop || prop === ACL.ALL || property === prop) {
           staticACLs.push(new ACL({
             model: model,
-            property: acl.property || ACL.ALL,
+            property: prop || ACL.ALL,
             principalType: acl.principalType,
             principalId: acl.principalId, // TODO: Should it be a name?
             accessType: acl.accessType || ACL.ALL,

--- a/test/acl.test.js
+++ b/test/acl.test.js
@@ -266,6 +266,8 @@ describe('security ACLs', function() {
         {principalType: ACL.USER, principalId: 'u001', property: 'name',
           accessType: ACL.ALL, permission: ACL.ALLOW},
         {principalType: ACL.USER, principalId: 'u002', property: 'findOne',
+          accessType: ACL.ALL, permission: ACL.ALLOW},
+        {principalType: ACL.USER, principalId: 'u003', property: ['findOne', 'findById'],
           accessType: ACL.ALL, permission: ACL.ALLOW}
       ]
     });
@@ -274,7 +276,11 @@ describe('security ACLs', function() {
     assert(staticACLs.length === 3);
 
     staticACLs = ACL.getStaticACLs('Model1', 'findOne');
+    assert(staticACLs.length === 2);
+
+    staticACLs = ACL.getStaticACLs('Model1', 'findById');
     assert(staticACLs.length === 1);
+    assert(staticACLs[0].property === 'findById');
   });
 
   it('should check access against LDL, ACL, and Role', function() {


### PR DESCRIPTION
to make the acl rule reusable for multiple properties. now the static acl in model json support array of string to setup acl in batch for group of properties.