### PR TITLE
Prevent more kinds of false replication conflicts

### DIFF
--- a/common/models/change.js
+++ b/common/models/change.js
@@ -141,10 +141,6 @@ module.exports = function(Change) {
 
   Change.prototype.rectify = function(cb) {
     var change = this;
-    var tasks = [
-      updateRevision,
-      updateCheckpoint
-    ];
     var currentRev = this.rev;
 
     change.debug('rectify change');
@@ -153,8 +149,53 @@ module.exports = function(Change) {
       if (err) throw new Error(err);
     };
 
-    async.parallel(tasks, function(err) {
+    async.parallel([
+      function getCurrentCheckpoint(next) {
+        change.constructor.getCheckpointModel().current(next);
+      },
+      function getCurrentRevision(next) {
+        change.currentRevision(next);
+      }
+    ], doRectify);
+
+    function doRectify(err, results) {
       if (err) return cb(err);
+      var checkpoint = results[0];
+      var rev = results[1];
+
+      if (rev) {
+        // avoid setting rev and prev to the same value
+        if (currentRev === rev) {
+          change.debug('rev and prev are equal (not updating rev)');
+        } else {
+          change.rev = rev;
+          change.debug('updated revision (was ' + currentRev + ')');
+          if (change.checkpoint !== checkpoint) {
+            // previous revision is updated only across checkpoints
+            change.prev = currentRev;
+            change.debug('updated prev');
+          }
+        }
+      } else {
+        change.rev = null;
+        change.debug('updated revision (was ' + currentRev + ')');
+        if (change.checkpoint !== checkpoint) {
+          // previous revision is updated only across checkpoints
+          if (currentRev) {
+            change.prev = currentRev;
+          } else if (!change.prev) {
+            change.debug('ERROR - could not determing prev');
+            change.prev = Change.UNKNOWN;
+          }
+          change.debug('updated prev');
+        }
+      }
+
+      if (change.checkpoint != checkpoint) {
+        debug('update checkpoint to', checkpoint);
+        change.checkpoint = checkpoint;
+      }
+
       if (change.prev === Change.UNKNOWN) {
         // this occurs when a record of a change doesn't exist
         // and its current revision is null (not found)
@@ -162,41 +203,6 @@ module.exports = function(Change) {
       } else {
         change.save(cb);
       }
-    });
-
-    function updateRevision(cb) {
-      // get the current revision
-      change.currentRevision(function(err, rev) {
-        if (err) return Change.handleError(err, cb);
-        if (rev) {
-          // avoid setting rev and prev to the same value
-          if (currentRev !== rev) {
-            change.rev = rev;
-            change.prev = currentRev;
-          } else {
-            change.debug('rev and prev are equal (not updating rev)');
-          }
-        } else {
-          change.rev = null;
-          if (currentRev) {
-            change.prev = currentRev;
-          } else if (!change.prev) {
-            change.debug('ERROR - could not determing prev');
-            change.prev = Change.UNKNOWN;
-          }
-        }
-        change.debug('updated revision (was ' + currentRev + ')');
-        cb();
-      });
-    }
-
-    function updateCheckpoint(cb) {
-      change.constructor.getCheckpointModel().current(function(err, checkpoint) {
-        if (err) return Change.handleError(err);
-        debug('updated checkpoint to', checkpoint);
-        change.checkpoint = checkpoint;
-        cb();
-      });
     }
   };
 

--- a/common/models/change.js
+++ b/common/models/change.js
@@ -446,10 +446,13 @@ module.exports = function(Change) {
   Change.prototype.debug = function() {
     if (debug.enabled) {
       var args = Array.prototype.slice.call(arguments);
+      args[0] = args[0] + ' %s';
+      args.push(this.modelName);
       debug.apply(this, args);
       debug('\tid', this.id);
       debug('\trev', this.rev);
       debug('\tprev', this.prev);
+      debug('\tcheckpoint', this.checkpoint);
       debug('\tmodelName', this.modelName);
       debug('\tmodelId', this.modelId);
       debug('\ttype', this.type());

--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -840,18 +840,6 @@ PersistedModel.replicate = function(since, targetModel, options, callback) {
   options = options || {};
 
   var sourceModel = this;
-  var diff;
-  var updates;
-  var Change = this.getChangeModel();
-  var TargetChange = targetModel.getChangeModel();
-  var changeTrackingEnabled = Change && TargetChange;
-  var newSourceCp, newTargetCp;
-
-  assert(
-    changeTrackingEnabled,
-    'You must enable change tracking before replicating'
-  );
-
   callback = callback || function defaultReplicationCallback(err) {
     if (err) throw err;
   };
@@ -864,6 +852,52 @@ PersistedModel.replicate = function(since, targetModel, options, callback) {
   if (options.filter) {
     debug('\twith filter %j', options.filter);
   }
+
+  // In order to avoid a race condition between the replication and
+  // other clients modifying the data, we must create the new target
+  // checkpoint as the first step of the replication process.
+  // As a side-effect of that, the replicated changes are associated
+  // with the new target checkpoint. This is actually desired behaviour,
+  // because that way clients replicating *from* the target model
+  // since the new checkpoint will pick these changes up.
+  // However, it increases the likelihood of (false) conflicts being detected.
+  // In order to prevent that, we run the replication multiple times,
+  // until no changes were replicated, but at most MAX_ATTEMPTS times
+  // to prevent starvation. In most cases, the second run will find no changes
+  // to replicate and we are done.
+  var MAX_ATTEMPTS = 3;
+
+  run(1, since);
+
+  function run(attempt, since) {
+    debug('\titeration #%s', attempt);
+    tryReplicate(sourceModel, targetModel, since, options, next);
+
+    function next(err, conflicts, cps, updates) {
+      var finished = err || conflicts.length ||
+        !updates || updates.length === 0 ||
+        attempt >= MAX_ATTEMPTS;
+
+      if (finished)
+        return callback(err, conflicts, cps);
+      run(attempt + 1, cps);
+    }
+  }
+};
+
+function tryReplicate(sourceModel, targetModel, since, options, callback) {
+  var Change = sourceModel.getChangeModel();
+  var TargetChange = targetModel.getChangeModel();
+  var changeTrackingEnabled = Change && TargetChange;
+
+  assert(
+    changeTrackingEnabled,
+    'You must enable change tracking before replicating'
+  );
+
+  var diff;
+  var updates;
+  var newSourceCp, newTargetCp;
 
   var tasks = [
     checkpoints,
@@ -956,10 +990,10 @@ PersistedModel.replicate = function(since, targetModel, options, callback) {
 
     if (callback) {
       var newCheckpoints = { source: newSourceCp, target: newTargetCp };
-      callback(null, conflicts, newCheckpoints);
+      callback(null, conflicts, newCheckpoints, updates);
     }
   }
-};
+}
 
 /**
  * Create an update list (for `Model.bulkUpdate()`) from a delta list

--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -8,6 +8,7 @@ var runtime = require('./runtime');
 var assert = require('assert');
 var async = require('async');
 var deprecated = require('depd')('loopback');
+var debug = require('debug')('loopback:persisted-model');
 
 /**
  * Extends Model with basic query and CRUD support.
@@ -855,6 +856,15 @@ PersistedModel.replicate = function(since, targetModel, options, callback) {
     if (err) throw err;
   };
 
+  debug('replicating %s since %s to %s since %s',
+    sourceModel.modelName,
+    since.source,
+    targetModel.modelName,
+    since.target);
+  if (options.filter) {
+    debug('\twith filter %j', options.filter);
+  }
+
   var tasks = [
     checkpoints,
     getSourceChanges,
@@ -866,17 +876,38 @@ PersistedModel.replicate = function(since, targetModel, options, callback) {
   async.waterfall(tasks, done);
 
   function getSourceChanges(cb) {
-    sourceModel.changes(since.source, options.filter, cb);
+    sourceModel.changes(since.source, options.filter, debug.enabled ? log : cb);
+
+    function log(err, result) {
+      if (err) return cb(err);
+      debug('\tusing source changes');
+      result.forEach(function(it) { debug('\t\t%j', it); });
+      cb(err, result);
+    }
   }
 
   function getDiffFromTarget(sourceChanges, cb) {
-    targetModel.diff(since.target, sourceChanges, cb);
+    targetModel.diff(since.target, sourceChanges, debug.enabled ? log : cb);
+
+    function log(err, result) {
+      if (err) return cb(err);
+      if (result.conflicts && result.conflicts.length) {
+        debug('\tdiff conflicts');
+        result.conflicts.forEach(function(d) { debug('\t\t%j', d); });
+      }
+      if (result.deltas && result.deltas.length) {
+        debug('\tdiff deltas');
+        result.deltas.forEach(function(it) { debug('\t\t%j', it); });
+      }
+      cb(err, result);
+    }
   }
 
   function createSourceUpdates(_diff, cb) {
     diff = _diff;
     diff.conflicts = diff.conflicts || [];
     if (diff && diff.deltas && diff.deltas.length) {
+      debug('\tbuilding a list of updates');
       sourceModel.createUpdates(diff.deltas, cb);
     } else {
       // nothing to replicate
@@ -884,7 +915,9 @@ PersistedModel.replicate = function(since, targetModel, options, callback) {
     }
   }
 
-  function bulkUpdate(updates, cb) {
+  function bulkUpdate(_updates, cb) {
+    debug('\tstarting bulk update');
+    updates = _updates;
     targetModel.bulkUpdate(updates, cb);
   }
 
@@ -894,6 +927,9 @@ PersistedModel.replicate = function(since, targetModel, options, callback) {
       newSourceCp = source.seq;
       targetModel.checkpoint(function(err, target) {
         newTargetCp = target.seq;
+        debug('\tcreated checkpoints');
+        debug('\t\t%s for source model %s', newSourceCp, sourceModel.modelName);
+        debug('\t\t%s for target model %s', newTargetCp, targetModel.modelName);
         cb(err);
       });
     });
@@ -901,6 +937,12 @@ PersistedModel.replicate = function(since, targetModel, options, callback) {
 
   function done(err) {
     if (err) return callback(err);
+
+    debug('\treplication finished');
+    debug('\t\t%s conflict(s) detected', diff.conflicts.length);
+    debug('\t\t%s change(s) applied', updates && updates.length);
+    debug('\t\tnew checkpoints: { source: %j, target: %j }',
+      newSourceCp, newTargetCp);
 
     var conflicts = diff.conflicts.map(function(change) {
       return new Change.Conflict(


### PR DESCRIPTION
 - Rework the Change model to merge changes made within the same Checkpoint.

 - Rework `replicate()` to run multiple iteration until there were no changes replicated. This ensures that the target model is left in a clean state with no pending changes associated with the latest (current) checkpoint.

Here is the test that was failing before this patch:

```
it('replicates multiple updates within the same CP', function(done) {
   async.series([
     replicateExpectingSuccess(),
     verifyModelsAreEqual(),

     updateSourceInstanceNameTo('updated'),
     updateSourceInstanceNameTo('again'),
     replicateExpectingSuccess(),
     verifyModelsAreEqual()
   ], done);
});
```

Connect to #985

/to @ritch please review