### PR TITLE
Handling owner being a relation/function

### DIFF
--- a/common/models/role.js
+++ b/common/models/role.js
@@ -161,7 +161,8 @@ module.exports = function(Role) {
       }
       debug('Model found: %j', inst);
       var ownerId = inst.userId || inst.owner;
-      if (ownerId) {
+      // Ensure ownerId exists and is not a function/relation
+      if (ownerId && 'function' !== typeof ownerId) {
         if (callback) callback(null, matches(ownerId, userId));
         return;
       } else {


### PR DESCRIPTION
Ensures ownerId exists and is not a function/relation.

Makes $owner ACL check more flexible and able to not fail for models without a userId but with a owner relation or function. Makes it fallback to the belongsTo relation.