### PR TITLE
Use `ctx.instance` provided by "after delete" hook

### DIFF
--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -1362,7 +1362,9 @@ function rectifyOnSave(ctx, next) {
 }
 
 function rectifyOnDelete(ctx, next) {
-  var id = getIdFromWhereByModelId(ctx.Model, ctx.where);
+  var id = ctx.instance ? ctx.instance.getId() :
+    getIdFromWhereByModelId(ctx.Model, ctx.where);
+
   if (id) {
     ctx.Model.rectifyChange(id, reportErrorAndNext);
   } else {


### PR DESCRIPTION
Use the recently added context property `ctx.instance` (see #488) to improve the accuracy of the algorithm detecting whether a single or multiple models were deleted.

/to @ritch