### PR TITLE
Import subset of underscore.string scripts only

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -8,7 +8,8 @@ var assert = require('assert');
 var fs = require('fs');
 var extend = require('util')._extend;
 var RemoteObjects = require('strong-remoting');
-var stringUtils = require('underscore.string');
+var classify = require('underscore.string/classify');
+var camelize = require('underscore.string/camelize');
 var path = require('path');
 
 /**
@@ -360,14 +361,6 @@ app.boot = function(options) {
   throw new Error(
     '`app.boot` was removed, use the new module loopback-boot instead');
 };
-
-function classify(str) {
-  return stringUtils.classify(str);
-}
-
-function camelize(str) {
-  return stringUtils.camelize(str);
-}
 
 function dataSourcesFromConfig(config, connectorRegistry) {
   var connectorPath;

--- a/lib/model.js
+++ b/lib/model.js
@@ -6,7 +6,6 @@ var assert = require('assert');
 var RemoteObjects = require('strong-remoting');
 var SharedClass = require('strong-remoting').SharedClass;
 var extend = require('util')._extend;
-var stringUtils = require('underscore.string');
 
 /**
  * The base class for **all models**.


### PR DESCRIPTION
Require individual methods like `classify` instead of the whole module. This reduces the size of underscore.string browser bundle from ~27kb down to ~2kb.

See https://github.com/strongloop/loopback/issues/989

/to @ritch please review