### PR TITLE
Improve error handling in replication

### DIFF
--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -1038,9 +1038,8 @@ PersistedModel.createUpdates = function(deltas, cb) {
           Model.findById(change.modelId, function(err, inst) {
             if (err) return cb(err);
             if (!inst) {
-              console.error('missing data for change:', change);
               return cb &&
-                cb(new Error('missing data for change: ' + change.modelId));
+                cb(new Error('Missing data for change: ' + change.modelId));
             }
             if (inst.toObject) {
               update.data = inst.toObject();
@@ -1343,8 +1342,7 @@ PersistedModel.enableChangeTracking = function() {
   function cleanup() {
     Model.rectifyAllChanges(function(err) {
       if (err) {
-        console.error(Model.modelName + ' Change Cleanup Error:');
-        console.error(err);
+        Model.handleChangeError(err, 'cleanup');
       }
     });
   }
@@ -1359,8 +1357,7 @@ function rectifyOnSave(ctx, next) {
 
   function reportErrorAndNext(err) {
     if (err) {
-      console.error(
-        ctx.Model.modelName + '.rectifyChange(s) after save failed:' + err);
+      ctx.Model.handleChangeError(err, 'after save');
     }
     next();
   }
@@ -1378,8 +1375,7 @@ function rectifyOnDelete(ctx, next) {
 
   function reportErrorAndNext(err) {
     if (err) {
-      console.error(
-        ctx.Model.modelName + '.rectifyChange(s) after delete failed:' + err);
+      ctx.Model.handleChangeError(err, 'after delete');
     }
     next();
   }
@@ -1426,11 +1422,9 @@ PersistedModel.rectifyAllChanges = function(callback) {
  * @param {Error} err Error object; see [Error object](http://docs.strongloop.com/display/LB/Error+object).
  */
 
-PersistedModel.handleChangeError = function(err) {
-  if (err) {
-    console.error(Model.modelName + ' Change Tracking Error:');
-    console.error(err);
-  }
+PersistedModel.handleChangeError = function(err, operationName) {
+  if (!err) return;
+  this.emit('error', err, operationName);
 };
 
 /**


### PR DESCRIPTION
Deprecate `Change.handleError`, it was used inconsistenly for a subset of possible errors only. Rework all `Change` methods to always report all errors to the caller via the callback.

Rework `PersistedModel` to report change-tracking errors via the existing method `PersistedModel.handleChangeError`. This method can be customized on a per-model basis to provide different error handling.

Close #1126

/to @ritch please review
/cc @BerkeleyTrue 