### PR TITLE
user: throw error if email is not found in reset

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -500,7 +500,10 @@ module.exports = function(User) {
             }
           });
         } else {
-          cb();
+          err = new Error('User not found by the email: ' + options.email);
+          err.statusCode = 404;
+          err.code = 'USER_NOT_FOUND';
+          cb(err);
         }
       });
     } else {


### PR DESCRIPTION
Sometimes the user needs to get if someone who wants to reset his password has typed the correct email.