### PR TITLE
Conflict resolution and Access control

### DIFF
--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -705,6 +705,37 @@ module.exports = function(registry) {
         accepts: {arg: 'updates', type: 'array'},
         http: {verb: 'post', path: '/bulk-update'}
       });
+
+      setRemoting(PersistedModel, 'findLastChange', {
+        description: 'Get the most recent change record for this instance.',
+        accessType: 'READ',
+        accepts: {
+          arg: 'id', type: 'any', required: true, http: { source: 'path' },
+          description: 'Model id'
+        },
+        returns: { arg: 'result', type: this.Change.modelName, root: true },
+        http: { verb: 'get', path: '/:id/changes/last' }
+      });
+
+      setRemoting(PersistedModel, 'updateLastChange', {
+        description: [
+          'Update the properties of the most recent change record',
+          'kept for this instance.'
+        ],
+        accessType: 'WRITE',
+        accepts: [
+          {
+            arg: 'id', type: 'any', required: true, http: { source: 'path' },
+            description: 'Model id'
+          },
+          {
+            arg: 'data', type: 'object', http: {source: 'body'},
+            description: 'An object of Change property name/value pairs'
+          },
+        ],
+        returns: { arg: 'result', type: this.Change.modelName, root: true },
+        http: { verb: 'put', path: '/:id/changes/last' }
+      });
     }
 
     if (options.trackChanges) {
@@ -1467,6 +1498,26 @@ module.exports = function(registry) {
   PersistedModel.rectifyChange = function(id, callback) {
     var Change = this.getChangeModel();
     Change.rectifyModelChanges(this.modelName, [id], callback);
+  };
+
+  PersistedModel.findLastChange = function(id, cb) {
+    var Change = this.getChangeModel();
+    Change.findOne({ where: { modelId: id } }, cb);
+  };
+
+  PersistedModel.updateLastChange = function(id, data, cb) {
+    var self = this;
+    this.findLastChange(id, function(err, inst) {
+      if (err) return cb(err);
+      if (!inst) {
+        err = new Error('No change record found for ' +
+          self.modelName + ' with id ' + id);
+        err.statusCode = 404;
+        return cb(err);
+      }
+
+      inst.updateAttributes(data, cb);
+    });
   };
 
   PersistedModel.setup();

--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -1423,9 +1423,14 @@ module.exports = function(registry) {
 
     if (this.dataSource) {
       attachRelatedModels(this);
-    } else {
-      this.once('dataSourceAttached', attachRelatedModels);
     }
+
+    // We have to attach related model whenever the datasource changes,
+    // this is a workaround for autoAttach called by loopback.createModel
+    var self = this;
+    this.on('dataSourceAttached', function() {
+      attachRelatedModels(self);
+    });
 
     return this.Change;
 


### PR DESCRIPTION
**Fix PersistedModel._defineChangeModel** (the first commit)

 - Correctly handle the case when the model is attached multiple times during the lifecycle, this happens because `loopback.createModel` always makes an attempt to auto-attach.

**Conflict resolution and Access control** (the second commit)

- Add end-to-end unit-tests verifying enforcement of access control during conflict resolution.

- Implement two facade methods providing REST API for Change methods used
by conflict resolution:

        PersistedModel.findLastChange
        GET /api/{model.pluralName}/{id}/changes/last

        PersistedModel.updateLastChange
        PUT /api/{model.pluralName}/{id}/changes/last

  By providing these two methods on PersistedModel, replication users don't have to expose the Change model via the REST API. What's even more important, these two methods use the same set of ACL rules as other (regular) PersistedModel methods.

- Rework `Conflict.prototype.changes()` and `Conflict.prototype.resolve()` to use these new facade methods.

- Implement a new method `Conflict.prototype.swapParties()` that provides better API for the situation when a conflict detected in Remote->Local replication should be resolved locally (i.e. in the replication target).

Connect to strongloop/loopback#1166

/to @ritch please review