### PR TITLE
Rework global registry to be per-module-instance

### DIFF
--- a/lib/global-registry.js
+++ b/lib/global-registry.js
@@ -1,8 +1,0 @@
-module.exports = function() {
-  var Registry = require('./registry');
-  var registry = global.__LOOPBACK_GLOBAL_REGISTRY__;
-  if (!registry) {
-    registry = global.__LOOPBACK_GLOBAL_REGISTRY__ = new Registry();
-  }
-  return registry;
-};

--- a/lib/loopback.js
+++ b/lib/loopback.js
@@ -11,7 +11,6 @@ var path = require('path');
 var merge = require('util')._extend;
 var assert = require('assert');
 var Registry = require('./registry');
-var getGlobalRegistry = require('./global-registry');
 var juggler = require('loopback-datasource-juggler');
 
 /**
@@ -49,10 +48,9 @@ loopback.version = require('../package.json').version;
 
 loopback.mime = express.mime;
 
+loopback.registry = new Registry();
+
 Object.defineProperties(loopback, {
-  registry: {
-    get: getGlobalRegistry
-  },
   Model: {
     get: function() { return this.registry.getModel('Model'); }
   },


### PR DESCRIPTION
Fix a regression introduced by b917075 where two loopback projects,
each one using a different instance of loopback module, were
sharing the global registry and thus not working correctly.

The issue was discovered by unit-tests in loopback-workspace.

/to @ritch please review 