### PR TITLE
Auto-configure models required by `app.enableAuth`

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -291,9 +291,36 @@ app.dataSources = app.datasources = {};
  * Enable app wide authentication.
  */
 
-app.enableAuth = function() {
+app.enableAuth = function(options) {
+  var AUTH_MODELS = ['User', 'AccessToken', 'ACL', 'Role', 'RoleMapping'];
+
   var remotes = this.remotes();
   var app = this;
+
+  if (options && options.dataSource) {
+    var appModels = app.registry.modelBuilder.models;
+    AUTH_MODELS.forEach(function(m) {
+      var Model = app.registry.findModel(m);
+      if (!Model) {
+        throw new Error(
+          'Authentication requires model ' + m + ' to be defined.');
+      }
+
+      if (m.dataSource || m.app) return;
+
+      for (var name in appModels) {
+        var candidate = appModels[name];
+        var isSubclass = candidate.prototype instanceof Model;
+        var isAttached = !!candidate.dataSource || !!candidate.app;
+        if (isSubclass && isAttached) return;
+      }
+
+      app.model(Model, {
+        dataSource: options.dataSource,
+        public: m === 'User'
+      });
+    });
+  }
 
   remotes.authorization = function(ctx, next) {
     var method = ctx.method;

--- a/lib/loopback.js
+++ b/lib/loopback.js
@@ -99,6 +99,9 @@ function createApplication(options) {
   if (loopback.localRegistry || options && options.localRegistry === true) {
     // setup the app registry
     var registry = app.registry = new Registry();
+    if (options && options.loadBuiltinModels === true) {
+      require('./builtin-models')(registry);
+    }
   } else {
     app.registry = loopback.registry;
   }

--- a/test/loopback.test.js
+++ b/test/loopback.test.js
@@ -115,6 +115,24 @@ describe('loopback', function() {
     });
   });
 
+  describe('loopback(options)', function() {
+    it('supports localRegistry:true', function() {
+      var app = loopback({ localRegistry: true });
+      expect(app.registry).to.not.equal(loopback.registry);
+    });
+
+    it('does not load builtin models into the local registry', function() {
+      var app = loopback({ localRegistry: true });
+      expect(app.registry.findModel('User')).to.equal(undefined);
+    });
+
+    it('supports loadBuiltinModels:true', function() {
+      var app = loopback({ localRegistry: true, loadBuiltinModels: true });
+      expect(app.registry.findModel('User'))
+        .to.have.property('modelName', 'User');
+    });
+  });
+
   describe('loopback.createDataSource(options)', function() {
     it('Create a data source with a connector.', function() {
       var dataSource = loopback.createDataSource({


### PR DESCRIPTION
Modify `app.enableAuth` to automaticaly setup all required models that are not attached to the app nor a datasource.

Users wishing to use this option must provide the name of the data-source to use for these models.

Example usage:

    var app = loopback();
    app.dataSource('db', { connector: 'memory' });
    app.enableAuth({ dataSource: 'db' });

    app.use(loopback.rest());
    app.listen(3000);

The purpose of this new API is to make it easier to setup authentication from code that does not use "slc loopback" project scaffolding, typically from unit-tests.

/to @ritch @raymondfeng please review

