### PR TITLE
Fix remoting metadata for User.login#include

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -567,7 +567,7 @@ module.exports = function(User) {
         description: 'Login a user with username/email and password.',
         accepts: [
           {arg: 'credentials', type: 'object', required: true, http: {source: 'body'}},
-          {arg: 'include', type: 'string', http: {source: 'query' },
+          {arg: 'include', type: ['string'], http: {source: 'query' },
             description: 'Related objects to include in the response. ' +
             'See the description of return value for more details.'}
         ],


### PR DESCRIPTION
Change the type of the "include" argument to "string array".

The type used to be "string" before and thus requests sending multiple
include items were technically incorrect.

See https://github.com/strongloop/strong-remoting/pull/207

Connect to strongloop-internal/scrum-loopback#243

/to @ritch please review