### PR TITLE
Fix regression in Model.getApp()

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -388,9 +388,11 @@ module.exports = function(registry) {
    */
 
   Model.getApp = function(callback) {
-    this._runWhenAttachedToApp(function(app) {
-      assert(Model.app);
-      callback(null, Model.app);
+    var self = this;
+    self._runWhenAttachedToApp(function(app) {
+      assert(self.app);
+      assert.equal(app, self.app);
+      callback(null, app);
     });
   };
 

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -618,4 +618,33 @@ describe.onServer('Remote Methods', function() {
       ]);
     });
   });
+
+  describe('Model.getApp(cb)', function() {
+    var app, TestModel;
+    beforeEach(function setup() {
+      app = loopback();
+      TestModel = loopback.createModel('TestModelForGetApp'); // unique name
+      app.dataSource('db', { connector: 'memory' });
+    });
+
+    it('calls the callback when already attached', function(done) {
+      app.model(TestModel, { dataSource: 'db' });
+      TestModel.getApp(function(err, a) {
+        if (err) return done(err);
+        expect(a).to.equal(app);
+        done();
+      });
+      // fails on time-out when not implemented correctly
+    });
+
+    it('calls the callback after attached', function(done) {
+      TestModel.getApp(function(err, a) {
+        if (err) return done(err);
+        expect(a).to.equal(app);
+        done();
+      });
+      app.model(TestModel, { dataSource: 'db' });
+      // fails on time-out when not implemented correctly
+    });
+  });
 });


### PR DESCRIPTION
This patch fixes the method `Model.getApp()` that started to report the following error after b61fae5 was landed:

```
assert.js:88
  throw new assert.AssertionError({
        ^
AssertionError: undefined == true
    at loopback/loopback/lib/model.js:392:7
    at EventEmitter.<anonymous> (loopback/loopback/lib/model.js:222:9)
    at EventEmitter.g (events.js:257:16)
    at emitOne (events.js:77:13)
    at EventEmitter.emit (events.js:166:7)
    at EventEmitter.app.model (loopback/loopback/lib/application.js:157:9)
```

Fix #1324

/to @ritch please review
/cc @jmls 