### PR TITLE
Fix CI builds on io.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -111,6 +111,14 @@ module.exports = function(grunt) {
         junitReporter: {
           outputFile: 'karma-xunit.xml'
         },
+
+        browserify: {
+          // Disable sourcemaps to prevent
+          // Fatal error: Maximum call stack size exceeded
+          debug: false,
+          // Disable watcher, grunt will exit after the first run
+          watch: false
+        }
       },
       unit: {
         configFile: 'test/karma.conf.js',

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "loopback-datasource-juggler": "^2.19.0"
   },
   "devDependencies": {
-    "browserify": "^9.0.3",
+    "browserify": "^10.0.0",
     "chai": "^2.1.1",
     "cookie-parser": "^1.3.4",
     "errorhandler": "^1.3.4",
@@ -65,7 +65,7 @@
     "grunt-browserify": "^3.5.0",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-jshint": "^0.11.0",
-    "grunt-contrib-uglify": "^0.8.0",
+    "grunt-contrib-uglify": "^0.9.1",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-jscs": "^1.5.0",
     "grunt-karma": "^0.10.1",


### PR DESCRIPTION
- Update devDependencies to the latest versions
- Gruntfile: disable debug & watch for CI builds 