### PR TITLE
Pass the full options object to the email send method in user verification process

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -391,15 +391,16 @@ module.exports = function(User) {
 
       options.text = options.text.replace('{href}', options.verifyHref);
 
+      options.to = options.to || user.email;
+
+      options.subject = options.subject || 'Thanks for Registering';
+
+      options.headers = options.headers || {};
+
       var template = loopback.template(options.template);
-      Email.send({
-        to: options.to || user.email,
-        from: options.from,
-        subject: options.subject || 'Thanks for Registering',
-        text: options.text,
-        html: template(options),
-        headers: options.headers || {}
-      }, function(err, email) {
+      options.html = template(options);
+
+      Email.send(options, function(err, email) {
         if (err) {
           fn(err);
         } else {


### PR DESCRIPTION
I think that there should be full flexibility for the creation of any the emails that are sent to the users. In order to achieve that the options object shouldn't be recreated. Consider this pull request that also fixes #1107.

@ritch I know that there is already PR #1106 but it only adds the attachment field to the options object. What if one needs to add alternative content or change the SMTP envelope? All these options are supported by the nodemailer library (the one that is used by loopback to send emails) so why ditch them?