### PR TITLE
Config option: (do not) search default token keys

### DIFF
--- a/common/models/access-token.js
+++ b/common/models/access-token.js
@@ -168,9 +168,12 @@ module.exports = function(AccessToken) {
     var length;
     var id;
 
-    params = params.concat(['access_token']);
-    headers = headers.concat(['X-Access-Token', 'authorization']);
-    cookies = cookies.concat(['access_token', 'authorization']);
+    // https://github.com/strongloop/loopback/issues/1326
+    if (options.searchDefaultTokenKeys !== false) {
+      params = params.concat(['access_token']);
+      headers = headers.concat(['X-Access-Token', 'authorization']);
+      cookies = cookies.concat(['access_token', 'authorization']);
+    }
 
     for (length = params.length; i < length; i++) {
       var param = params[i];

--- a/server/middleware/token.js
+++ b/server/middleware/token.js
@@ -61,6 +61,7 @@ function escapeRegExp(str) {
  * @property {Array} [cookies] Array of cookie names.
  * @property {Array} [headers] Array of header names.
  * @property {Array} [params] Array of param names.
+ * @property {Boolean} [searchDefaultTokenKeys] Use the default search locations for Token in request
  * @property {Function|String} [model] AccessToken model name or class to use.
  * @property {String} [currentUserLiteral] String literal for the current user.
  * @header loopback.token([options])


### PR DESCRIPTION
A follow-up for abandoned #1347.

Add a new option `searchDefaultTokenKeys` to the token middleware. Users can set this option to false to prevent AccessToken from checking default places like "access_token" in the request query string.

Connect to #1326

/to @ritch please review
/cc @OwenBrotherwood