### PR TITLE
change password to string if it is detected as number

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -544,6 +544,10 @@ module.exports = function(User) {
     this.settings.ttl = this.settings.ttl || DEFAULT_TTL;
 
     UserModel.setter.password = function(plain) {
+      //change password to string if it is a number
+      if ((typeof plain) == 'number') {
+        plain = plain.toString();
+      }
       if (plain.indexOf('$2a$') === 0 && plain.length === 60) {
         // The password is already hashed. It can be the case
         // when the instance is loaded from DB


### PR DESCRIPTION
server get break down if i give password as numeric in reset password case because it is handled as number so number.indexOf() get break