### PR TITLE
fix: exit early when password is non-string

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -544,6 +544,9 @@ module.exports = function(User) {
     this.settings.ttl = this.settings.ttl || DEFAULT_TTL;
 
     UserModel.setter.password = function(plain) {
+      if (typeof plain !== 'string') {
+        return;
+      }
       if (plain.indexOf('$2a$') === 0 && plain.length === 60) {
         // The password is already hashed. It can be the case
         // when the instance is loaded from DB


### PR DESCRIPTION
prevent errors when plain is non-string by using call on indexOf method
closes #1437