### PR TITLE
allow for unencoded access token for oauth2.0 using options.unencoded…

### DIFF
--- a/test/access-token.test.js
+++ b/test/access-token.test.js
@@ -41,6 +41,17 @@ describe('loopback.token(options)', function() {
       .end(done);
   });
 
+  it('should populate req.token from an authorization header with an unencoded base64 bearer token', function(done) {
+    var token = this.token.id;
+    token = 'Bearer ' + token;
+    createTestAppAndRequest(this.token, {unencodedTokenReferers: ['localhost:3000']}, done)
+      .get('/')
+      .set('authorization', token)
+      .set('referrer', 'http://localhost:3000/')
+      .expect(200)
+      .end(done);
+  });
+
   describe('populating req.toen from HTTP Basic Auth formatted authorization header', function() {
     it('parses "standalone-token"', function(done) {
       var token = this.token.id;
@@ -354,7 +365,12 @@ function createTestApp(testToken, settings, done) {
   var app = loopback();
 
   app.use(loopback.cookieParser('secret'));
-  app.use(loopback.token({model: Token, currentUserLiteral: 'me'}));
+  app.use(loopback.token({
+    model: Token,
+    currentUserLiteral: 'me',
+    unencodedTokenReferers: settings.unencodedTokenReferers
+  }));
+
   app.get('/token', function(req, res) {
     res.cookie('authorization', testToken.id, {signed: true});
     res.end();


### PR DESCRIPTION
…TokenReferers

Signed-off-by: Brandon Cooper cooperjbrandon@gmail.com

This allows for the access bearer token to not be base64 encoded...Some front-end libraries don't base64 encode the auth token. For example, ember-simple-auth-oauth2 does not base64 encode the token: 
https://github.com/simplabs/ember-simple-auth/blob/master/packages/ember-simple-auth-oauth2/lib/simple-auth-oauth2/authorizers/oauth2.js#L33

The user would pass in an array of referers that it would not expect to encode the token, like so:

```
app.use(loopback.token({
  unencodedTokenReferers: ['localhost:4200', 'someotherurl.com']
}));
```
