### PR TITLE
Feature/mandrill template

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -406,7 +406,8 @@ module.exports = function(User) {
         if (options.template.name) {
           // if template is object with name attribute then is expected that email transport connector is converting template to html itselfs
           // Following code is adapted to use options attributes (e.g. verifyHref) in mandrill templates via nodemailer-mandrill-transport
-          var options_clone = extend({}, options);
+          // NOTE: all atribute names in options in camelCase format will be converted to lowercase format, i.e. options.verifyHref to options.verifyhref
+          var options_clone = JSON.parse(JSON.stringify(options)); // to prevent error "converting circular structure to JSON"
           options.global_merge_vars = [{
             name: 'options',
             content: options_clone

--- a/common/models/user.js
+++ b/common/models/user.js
@@ -397,8 +397,19 @@ module.exports = function(User) {
 
       options.headers = options.headers || {};
 
-      var template = loopback.template(options.template);
-      options.html = template(options);
+      if (options.template) {
+        // only if template is defined
+        if (options.template.name) {
+          // if template is object with name attribute then is expected that email transport connector is converting it to html itselfs, e.g. nodemailer-mandrill-transport
+          // template content should have reference to all attributes already filled in the options object 
+          options.template.content = options; 
+        } else {
+          var template = loopback.template(options.template);
+          options.html = template(options);
+          // due to nodemailer-mandrill-transport, which use template different way, attribute template is removed if template was already locally converted to html
+          delete options.template;
+        }
+      }
 
       Email.send(options, function(err, email) {
         if (err) {


### PR DESCRIPTION
Support for sending user verify emails with templates also via lb-connector-mandrill to Mandrill API.
It allows to use local EJS templates or remote Mandrill templates.
- If template attribute is string, then is expected that it is file name of local EJS template. 
- If template is object with name attribute then is expected that email transport connector is converting template to html itselfs, so in case of lb-connector-mandrill it could be for example Handlebars Mandril template.
  - NOTE: All atribute names in options in camelCase format will be converted to lowercase format, i.e. options.verifyHref to options.verifyhref
