### PR TITLE
Don't load Bluebird for createPromiseCallback

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,5 @@
 exports.createPromiseCallback = createPromiseCallback;
 
-var Promise = global.Promise = require('bluebird');
 function createPromiseCallback() {
   var cb;
 
@@ -12,7 +11,7 @@ function createPromiseCallback() {
     return cb;
   }
 
-  var promise = new Promise(function(resolve, reject) {
+  var promise = new global.Promise(function(resolve, reject) {
     cb = function(err, data) {
       if (err) return reject(err);
       return resolve(data);

--- a/test/support.js
+++ b/test/support.js
@@ -47,3 +47,7 @@ assert.isFunc = function(obj, name) {
   assert(obj, 'cannot assert function ' + name + ' on object that doesnt exist');
   assert(typeof obj[name] === 'function', name + ' is not a function');
 };
+
+if (!('Promise' in global)) {
+  global.Promise = require('bluebird');
+}


### PR DESCRIPTION
The decision which Promise implementation to use should be made by LoopBack user, not by the framework.

This commit moves Bluebird reference from lib/utils.js to test/support.js.

See also #1493 which introduced the problem.