### PR TITLE
fix typo "PeristedModel"

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -109,8 +109,8 @@ Registry.prototype.createModel = function(name, properties, options) {
     if (BaseModel === undefined) {
       if (baseName === 'DataModel') {
         console.warn('Model `%s` is extending deprecated `DataModel. ' +
-          'Use `PeristedModel` instead.', name);
-        BaseModel = this.getModel('PeristedModel');
+          'Use `PersistedModel` instead.', name);
+        BaseModel = this.getModel('PersistedModel');
       } else {
         console.warn('Model `%s` is extending an unknown model `%s`. ' +
           'Using `PersistedModel` as the base.', name, baseName);


### PR DESCRIPTION
This seems to be a typo. Could not find a ``PeristedModel`` anywhere.