### PR TITLE
Emit options to resetPasswordRequest handlers

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -516,7 +516,8 @@ module.exports = function(User) {
               UserModel.emit('resetPasswordRequest', {
                 email: options.email,
                 accessToken: accessToken,
-                user: user
+                user: user,
+                options: options
               });
             }
           });


### PR DESCRIPTION
In my use case, I want the different consumers of my API to be able to supply a "callback" url which displays the client's own interface to the password reset flow.
