### PR TITLE
Stop NPM license warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,10 +102,7 @@
     "depd": "loopback-datasource-juggler/lib/browser.depd.js",
     "bcrypt": false
   },
-  "license": {
-    "name": "Dual MIT/StrongLoop",
-    "url": "https://github.com/strongloop/loopback/blob/master/LICENSE"
-  },
+  "license": "SEE LICENSE IN LICENSE",
   "optionalDependencies": {
     "sl-blip": "http://blip.strongloop.com/loopback@2.22.0"
   }


### PR DESCRIPTION
Running `npm install` in the project gives a license warning using the latest version of NPM.

>...
>If you are using a license that hasn't been assigned an SPDX identifier, or if you are using a custom
>license, use the following valid SPDX expression:
>
>{ "license" : "SEE LICENSE IN \<filename\>" }
>...

See https://docs.npmjs.com/files/package.json.