### PR TITLE
Fix perf of rectification after updateAttributes

### DIFF
--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -1419,8 +1419,12 @@ module.exports = function(registry) {
   };
 
   function rectifyOnSave(ctx, next) {
-    if (ctx.instance) {
-      ctx.Model.rectifyChange(ctx.instance.getId(), reportErrorAndNext);
+    var instance = ctx.instance || ctx.currentInstance;
+    var id = instance ? instance.getId() :
+      getIdFromWhereByModelId(ctx.Model, ctx.where);
+
+    if (id) {
+      ctx.Model.rectifyChange(id, reportErrorAndNext);
     } else {
       ctx.Model.rectifyAllChanges(reportErrorAndNext);
     }


### PR DESCRIPTION
Improve the id-detection algorithm in the "after save" hook to correctly handle "updateAttributes" as a single-model change and DO NOT trigger full "rectify all" scan.

/to @ritch please review