### PR TITLE
Update registry.js

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -284,7 +284,7 @@ Registry.prototype._defineRemoteMethods = function(ModelCtor, methods) {
  * @header loopback.findModel(modelName)
  */
 Registry.prototype.findModel = function(modelName) {
-  if (typeof modelType === 'function') return modelName;
+  if (typeof modelName === 'function') return modelName;
   return this.modelBuilder.models[modelName];
 };
 


### PR DESCRIPTION
findModel checked the type of 'modelType' which is undefined. All calls with typeof modelName === 'function' would result in an error "Model not found". Changing modelType to modelName makes it work.