### PR TITLE
Fix issue 1769

### DIFF
--- a/common/models/access-token.js
+++ b/common/models/access-token.js
@@ -101,7 +101,7 @@ module.exports = function(AccessToken) {
         if (err) {
           cb(err);
         } else if (token) {
-          token.validate(function(err, isValid) {
+          AccessToken.validate(token, function(err, isValid) {
             if (err) {
               cb(err);
             } else if (isValid) {
@@ -132,26 +132,26 @@ module.exports = function(AccessToken) {
    * @param {Boolean} isValid
    */
 
-  AccessToken.prototype.validate = function(cb) {
+  AccessToken.validate = function(token, cb) {
     try {
       assert(
-          this.created && typeof this.created.getTime === 'function',
+          token.created && typeof token.created.getTime === 'function',
         'token.created must be a valid Date'
       );
-      assert(this.ttl !== 0, 'token.ttl must be not be 0');
-      assert(this.ttl, 'token.ttl must exist');
-      assert(this.ttl >= -1, 'token.ttl must be >= -1');
+      assert(token.ttl !== 0, 'token.ttl must be not be 0');
+      assert(token.ttl, 'token.ttl must exist');
+      assert(token.ttl >= -1, 'token.ttl must be >= -1');
 
       var now = Date.now();
-      var created = this.created.getTime();
+      var created = token.created.getTime();
       var elapsedSeconds = (now - created) / 1000;
-      var secondsToLive = this.ttl;
+      var secondsToLive = token.ttl;
       var isValid = elapsedSeconds < secondsToLive;
 
       if (isValid) {
         cb(null, isValid);
       } else {
-        this.destroy(function(err) {
+        token.destroy(function(err) {
           cb(err, isValid);
         });
       }

--- a/common/models/access-token.js
+++ b/common/models/access-token.js
@@ -103,7 +103,7 @@ module.exports = function(AccessToken) {
         } else if (token) {
           var possibleDate = new Date(token.created);
           var isAValidDate = !isNaN(possibleDate.getTime());
-          if(isAValidDate){
+          if (isAValidDate) {
             token.created = new Date(token.created);
           }
           AccessToken.validate(token, function(err, isValid) {

--- a/common/models/access-token.js
+++ b/common/models/access-token.js
@@ -101,6 +101,11 @@ module.exports = function(AccessToken) {
         if (err) {
           cb(err);
         } else if (token) {
+          var possibleDate = new Date(token.created);
+          var isAValidDate = !isNaN(possibleDate.getTime());
+          if(isAValidDate){
+            token.created = new Date(token.created);
+          }
           AccessToken.validate(token, function(err, isValid) {
             if (err) {
               cb(err);

--- a/test/access-token.test.js
+++ b/test/access-token.test.js
@@ -215,7 +215,7 @@ describe('AccessToken', function() {
   });
 
   it('should be validateable', function(done) {
-    this.token.validate(function(err, isValid) {
+    Token.validate(this.token, function(err, isValid) {
       assert(isValid);
       done();
     });


### PR DESCRIPTION
This is the explanation of the bug I found https://github.com/strongloop/loopback/issues/1769. In my PR I have a ugly patch in this commit https://github.com/danilat/loopback/commit/e028b56aad42b0828a9bdd10dcaa9e8892344c34.

Now I'm working in a workaround with some changes in connector-remote parsing all the valid date-format strings in the respose objects. What do you think about this?
