### PR TITLE
Use isemail for email validation in user model

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -7,6 +7,7 @@ var utils = require('../../lib/utils');
 var path = require('path');
 var SALT_WORK_FACTOR = 10;
 var crypto = require('crypto');
+var isEmail = require('isemail');
 
 var bcrypt;
 try {
@@ -678,10 +679,10 @@ module.exports = function(User) {
     assert(loopback.AccessToken, 'AccessToken model must be defined before User model');
     UserModel.accessToken = loopback.AccessToken;
 
-    // email validation regex
-    var re = /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
-
-    UserModel.validatesFormatOf('email', {with: re, message: 'Must provide a valid email'});
+    UserModel.validate('email', emailValidator, {message: 'Must provide a valid email'});
+    function emailValidator(err) {
+      if (typeof (this.email) !== 'string' || !isEmail(this.email)) err('isemail');
+    }
 
     // FIXME: We need to add support for uniqueness of composite keys in juggler
     if (!(UserModel.settings.realmRequired || UserModel.settings.realmDelimiter)) {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "errorhandler": "^1.3.4",
     "express": "^4.12.2",
     "inflection": "^1.6.0",
+    "isemail": "^1.2.0",
     "loopback-connector-remote": "^1.0.3",
     "loopback-phase": "^1.2.0",
     "nodemailer": "^1.3.1",

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -91,7 +91,7 @@ describe('User', function() {
         assert.equal(err.details.context, User.modelName);
         assert.deepEqual(err.details.codes.email, [
           'presence',
-          'format.null'
+          'custom.isemail'
         ]);
 
         done();


### PR DESCRIPTION
instead of the regular expression that did not correctly validate all
email addresses (both false positives and false negatives).

Should fix issue #1723