### PR TITLE
lib/registry: fix findModel for model ctor

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -284,7 +284,7 @@ Registry.prototype._defineRemoteMethods = function(ModelCtor, methods) {
  * @header loopback.findModel(modelName)
  */
 Registry.prototype.findModel = function(modelName) {
-  if (typeof modelType === 'function') return modelName;
+  if (typeof modelName === 'function') return modelName;
   return this.modelBuilder.models[modelName];
 };
 

--- a/test/loopback.test.js
+++ b/test/loopback.test.js
@@ -245,6 +245,7 @@ describe('loopback', function() {
         assert(loopback.getModel('MyModel') === MyModel);
         assert(loopback.getModel('MyCustomModel') === MyCustomModel);
         assert(loopback.findModel('Invalid') === undefined);
+        assert(loopback.getModel(MyModel) === MyModel);
       });
       it('should be able to get model by type', function() {
         var MyModel = loopback.createModel('MyModel', {}, {


### PR DESCRIPTION
Fix `registry.findModel(arg)` to support the case when `arg` is already a model constructor.

/cc @ritch IMO this typo is so obvious that it does not require a code review.