### PR TITLE
Remove options.template to prevent rejection by certain nodemailer transport plugins

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -420,6 +420,7 @@ module.exports = function(User) {
 
       var template = loopback.template(options.template);
       options.html = template(options);
+      delete options.template;
 
       Email.send(options, function(err, email) {
         if (err) {


### PR DESCRIPTION
Removes options.template after options.html is generated to prevent
rejection by certain nodemailer transport plugins.
