### PR TITLE
Custom Password Reset Token Generator

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -463,7 +463,6 @@ module.exports = function(User) {
 
     // Set the email to the user if it is not set
     options.to = options.to || user.email;
-    console.log('Email: ' + options.to);
 
     // Set default token generator function if one is not provided
     var tokenGenerator = options.generateVerificationToken || userModel.generateVerificationToken;
@@ -474,8 +473,6 @@ module.exports = function(User) {
       }
       // create a short lived access token for temp login to change password
       // TODO(ritch) - eventually this should only allow password change
-      console.log('User:');
-      console.dir(user.accessTokens);
       user.accessTokens.create({
         id: token,
         ttl: ttl
@@ -586,7 +583,6 @@ module.exports = function(User) {
         return cb(err);
       }
 
-      console.dir(user.accessTokens);
       user.requestPasswordReset({
         to: options.email
       }, cb);

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -1447,6 +1447,39 @@ describe('User', function() {
           });
       });
     });
+
+    describe('User.prototype.requestPasswordReset(options, cb)', function() {
+      it('Creates a temp accessToken using options.generateVerificationToken', function(done) {
+        User.create({email: 'foo@bar.com', password: 'bar'}, function(err, u) {
+          var calledBack = false;
+
+          var token = 'token';
+          var genToken = function(user, cb) {
+            cb(null, token);
+          };
+
+          u.requestPasswordReset({
+            generateVerificationToken: genToken
+          }, function() {
+            calledBack = true;
+          });
+
+          User.once('resetPasswordRequest', function(info) {
+            console.dir(info);
+            assert(info.email);
+            assert(info.accessToken);
+            assert.equal(info.accessToken.id, token);
+            assert.equal(info.accessToken.ttl / 60, 15);
+            assert(calledBack);
+            info.accessToken.user(function(err, user) {
+              if (err) return done(err);
+              assert.equal(user.email, u.email);
+              done();
+            });
+          });
+        });
+      });
+    });
   });
 
   describe('ctor', function() {

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -1450,7 +1450,7 @@ describe('User', function() {
 
     describe('User.prototype.requestPasswordReset(options, cb)', function() {
       it('Creates a temp accessToken using options.generateVerificationToken', function(done) {
-        User.create({email: 'foo@bar.com', password: 'bar'}, function(err, u) {
+        User.create({email: 'bar@foo.com', password: 'bar'}, function(err, u) {
           var calledBack = false;
 
           var token = 'token';
@@ -1465,7 +1465,6 @@ describe('User', function() {
           });
 
           User.once('resetPasswordRequest', function(info) {
-            console.dir(info);
             assert(info.email);
             assert(info.accessToken);
             assert.equal(info.accessToken.id, token);


### PR DESCRIPTION
I am using the custom token generator for email verification and I need to do the same for the password reset token. So I created this PR to address the issue.

I added a prototype function `requestPasswordReset` to user.
The format and options follow that of the `verify` prototype which allows for consistency when implementing the verify and reset features.
