### PR TITLE
Fix replication performance

### DIFF
--- a/common/models/change.js
+++ b/common/models/change.js
@@ -175,24 +175,31 @@ module.exports = function(Change) {
       if (err) throw new Error(err);
     };
 
-    async.parallel([
-      function getCurrentCheckpoint(next) {
-        change.constructor.getCheckpointModel().current(next);
-      },
-      function getCurrentRevision(next) {
-        change.currentRevision(next);
-      }
-    ], doRectify);
-
-    function doRectify(err, results) {
+    change.currentRevision(function(err, rev) {
       if (err) return cb(err);
-      var checkpoint = results[0];
-      var rev = results[1];
 
+      // avoid setting rev and prev to the same value
+      if (currentRev === rev) {
+        change.debug('rev and prev are equal (not updating anything)');
+        return cb(null, change);
+      }
+
+      // FIXME(@bajtos) Allo callers to pass in the checkpoint value
+      // (or even better - a memoized async function to get the cp value)
+      // That will enable `rectifyAll` to cache the checkpoint value
+      change.constructor.getCheckpointModel().current(
+        function(err, checkpoint) {
+          if (err) return cb(err);
+          doRectify(checkpoint, rev);
+        }
+      );
+    });
+
+    function doRectify(checkpoint, rev) {
       if (rev) {
-        // avoid setting rev and prev to the same value
         if (currentRev === rev) {
-          change.debug('rev and prev are equal (not updating anything)');
+          change.debug('ASSERTION FAILED: Change currentRev==rev ' +
+            'should have been already handled');
           return cb(null, change);
         } else {
           change.rev = rev;

--- a/common/models/change.js
+++ b/common/models/change.js
@@ -192,7 +192,8 @@ module.exports = function(Change) {
       if (rev) {
         // avoid setting rev and prev to the same value
         if (currentRev === rev) {
-          change.debug('rev and prev are equal (not updating rev)');
+          change.debug('rev and prev are equal (not updating anything)');
+          return cb(null, change);
         } else {
           change.rev = rev;
           change.debug('updated revision (was ' + currentRev + ')');

--- a/test/change.test.js
+++ b/test/change.test.js
@@ -200,6 +200,23 @@ describe('Change', function() {
         });
       }
     });
+
+    it('should not change checkpoint when rev is the same', function(done) {
+      var test = this;
+      var originalCheckpoint = change.checkpoint;
+      var originalRev = change.rev;
+
+      TestModel.checkpoint(function(err, inst) {
+        if (err) return done(err);
+
+        change.rectify(function(err, c) {
+          if (err) return done(err);
+          expect(c.rev, 'rev').to.equal(originalRev); // sanity check
+          expect(c.checkpoint, 'checkpoint').to.equal(originalCheckpoint);
+          done();
+        });
+      });
+    });
   });
 
   describe('change.currentRevision(callback)', function() {


### PR DESCRIPTION
1) Modify `Change.rectify()` to not make any changes to the Change instance
(most notably to not modify the `checkpoint` field) when the tracked
model instance was not changed.

This should improve the performance of change replication as it reduces
the number of unnecessary replications.

For example, before this commit, every run of `rectifyAll` would
trigger a full sync of all clients, because all change instances would
be moved to the current checkpoint.

2) Modify `Change.rectify` to look up the current checkpoint only when
there was actually some change made.

This should improve the performance of `rectifyAll` when called from a
regular timer and there were no changes made since the last call.
Before this commit, `rectifyAll` would perform N calls of
`Checkpoint.current` where N is the number of model instances. With
this commit in place, no call is made.

Connect to strongloop-internal/scrum-cs/issues/397

/to @ritch please review