### PR TITLE
[SEMVER-MAJOR] Always use bluebird as promise library

### DIFF
--- a/3.0-RELEASE-NOTES.md
+++ b/3.0-RELEASE-NOTES.md
@@ -19,3 +19,17 @@ https://github.com/strongloop/loopback/issues/275
 
 When upgrading application from previous loopback versions, simply remove
 loopback-datasource-juggler from your dependencies.
+
+## always use bluebird as promise library
+
+In version 3.0, we always use bluebird as our promise library
+instead of `global.Promise`.
+We consider Bluebird API a part of LoopBack API from now on,
+you are welcome to use any Bluebird-specific methods in your applications.
+
+If you are using LoopBack with a custom promise implementation provided
+via `global.Promise`,
+you will have to check all places where you are using non-standard promise API
+and update them to use Bluebird API instead.
+
+Please see [Related code change](https://github.com/strongloop/loopback/pull/1896) here.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,17 +1,9 @@
 exports.createPromiseCallback = createPromiseCallback;
+var Promise = require('bluebird');
 
 function createPromiseCallback() {
   var cb;
-
-  if (!global.Promise) {
-    cb = function() {};
-    cb.promise = {};
-    Object.defineProperty(cb.promise, 'then', { get: throwPromiseNotDefined });
-    Object.defineProperty(cb.promise, 'catch', { get: throwPromiseNotDefined });
-    return cb;
-  }
-
-  var promise = new global.Promise(function(resolve, reject) {
+  var promise = new Promise(function(resolve, reject) {
     cb = function(err, data) {
       if (err) return reject(err);
       return resolve(data);
@@ -19,10 +11,4 @@ function createPromiseCallback() {
   });
   cb.promise = promise;
   return cb;
-}
-
-function throwPromiseNotDefined() {
-  throw new Error(
-    'Your Node runtime does support ES6 Promises. ' +
-    'Set "global.Promise" to your preferred implementation of promises.');
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "async": "^0.9.0",
     "bcryptjs": "^2.1.0",
+    "bluebird": "^3.1.1",
     "body-parser": "^1.12.0",
     "canonical-json": "0.0.4",
     "continuation-local-storage": "^3.1.3",
@@ -59,7 +60,6 @@
     "underscore.string": "^3.0.3"
   },
   "devDependencies": {
-    "bluebird": "^2.9.9",
     "browserify": "^10.0.0",
     "chai": "^2.1.1",
     "es5-shim": "^4.1.0",

--- a/test/support.js
+++ b/test/support.js
@@ -47,7 +47,3 @@ assert.isFunc = function(obj, name) {
   assert(obj, 'cannot assert function ' + name + ' on object that doesnt exist');
   assert(typeof obj[name] === 'function', name + ' is not a function');
 };
-
-if (!('Promise' in global)) {
-  global.Promise = require('bluebird');
-}


### PR DESCRIPTION
This pr is created for updating files to use `bluebird` as promise library.
See details here:
Connect to strongloop-internal/scrum-loopback#615

Related: https://github.com/strongloop/loopback-datasource-juggler/pull/790