### PR TITLE
Fix bulkUpdate to not trigger rectifyAll 

### DIFF
--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -1488,11 +1488,8 @@ module.exports = function(registry) {
   }
 
   function getIdFromWhereByModelId(Model, where) {
-    var whereKeys = Object.keys(where);
-    if (whereKeys.length != 1) return undefined;
-
     var idName = Model.getIdName();
-    if (whereKeys[0] !== idName) return undefined;
+    if (!(idName in where)) return undefined;
 
     var id = where[idName];
     // TODO(bajtos) support object values that are not LB conditions


### PR DESCRIPTION
#### Initial issue:
`bulkUpdate` was triggering `rectifyAllChanges`; now it just calls specific updated model instances through calling `rectifyChange`.

#### Related GitHub issue:

Connect to:https://github.com/strongloop/loopback/issues/1893