### PR TITLE
Checkpoint speedup

### DIFF
--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -898,12 +898,7 @@ module.exports = function(registry) {
 
   PersistedModel.checkpoint = function(cb) {
     var Checkpoint = this.getChangeModel().getCheckpointModel();
-    this.getSourceId(function(err, sourceId) {
-      if (err) return cb(err);
-      Checkpoint.create({
-        sourceId: sourceId
-      }, cb);
-    });
+    Checkpoint.bumpLastSeq(cb);
   };
 
   /**

--- a/test/checkpoint.test.js
+++ b/test/checkpoint.test.js
@@ -1,20 +1,22 @@
 var async = require('async');
 var loopback = require('../');
+var expect = require('chai').expect;
 
-// create a unique Checkpoint model
 var Checkpoint = loopback.Checkpoint.extend('TestCheckpoint');
 
-var memory = loopback.createDataSource({
-  connector: loopback.Memory
-});
-Checkpoint.attachTo(memory);
-
 describe('Checkpoint', function() {
-  describe('current()', function() {
+  describe('bumpLastSeq() and current()', function() {
+    beforeEach(function() {
+      var memory = loopback.createDataSource({
+        connector: loopback.Memory
+      });
+      Checkpoint.attachTo(memory);
+    });
+
     it('returns the highest `seq` value', function(done) {
       async.series([
-        Checkpoint.create.bind(Checkpoint),
-        Checkpoint.create.bind(Checkpoint),
+        Checkpoint.bumpLastSeq.bind(Checkpoint),
+        Checkpoint.bumpLastSeq.bind(Checkpoint),
         function(next) {
           Checkpoint.current(function(err, seq) {
             if (err) next(err);
@@ -23,6 +25,60 @@ describe('Checkpoint', function() {
           });
         }
       ], done);
+    });
+
+    it('Should be no race condition for current() when calling in parallel', function(done) {
+      async.parallel([
+        function(next) { Checkpoint.current(next); },
+        function(next) { Checkpoint.current(next); }
+      ], function(err, list) {
+        if (err) return done(err);
+        Checkpoint.find(function(err, data) {
+          if (err) return done(err);
+          expect(data).to.have.length(1);
+          done();
+        });
+      });
+    });
+
+    it('Should be no race condition for bumpLastSeq() when calling in parallel', function(done) {
+      async.parallel([
+        function(next) { Checkpoint.bumpLastSeq(next); },
+        function(next) { Checkpoint.bumpLastSeq(next); }
+      ], function(err, list) {
+        if (err) return done(err);
+        Checkpoint.find(function(err, data) {
+          if (err) return done(err);
+          // The invariant "we have at most 1 checkpoint instance" is preserved
+          // even when multiple calls are made in parallel
+          expect(data).to.have.length(1);
+          // There is a race condition here, we could end up with both 2 or 3 as the "seq".
+          // The current implementation of the memory connector always yields 2 though.
+          expect(data[0].seq).to.equal(2);
+          // In this particular case, since the new last seq is always 2, both results
+          // should be 2.
+          expect(list.map(function(it) {return it.seq;}))
+            .to.eql([2, 2]);
+          done();
+        });
+      });
+    });
+
+    it('Checkpoint.current() for non existing checkpoint should initialize checkpoint', function(done) {
+      Checkpoint.current(function(err, seq) {
+        expect(seq).to.equal(1);
+        done(err);
+      });
+    });
+
+    it('bumpLastSeq() works when singleton instance does not exists yet', function(done) {
+      Checkpoint.bumpLastSeq(function(err, cp) {
+        // We expect `seq` to be 2 since `checkpoint` does not exist and
+        // `bumpLastSeq` for the first time not only initializes it to one,
+        // but also increments the initialized value by one.
+        expect(cp.seq).to.equal(2);
+        done(err);
+      });
     });
   });
 });


### PR DESCRIPTION
@bajtos This is still a WIP. Please let me know if I'm going the right direction.

#### Problem:
The previous checkpoint implementation was storing all of the previous checkpoints in DB and every time we needed to get the current checkpoint we needed to query all the checkpoints, sort them in descending order and finally get the first checkpoint; in other words, the algorithm was naive and very slow, for every time we needed to query all the checkpoints, which are not indexed nor are they all needed.

#### Fix:
Now we just save one global variable in DB for checkpoint and update it whenever needed. 


Connect to strongloop/loopback#1864


#### Other notes:
We obviously expect the test cases to fail since findOrCreate for memory connector is implemented in another PR under `loopback-datasource-juggler` - see https://github.com/strongloop/loopback-datasource-juggler/pull/815

Thanks!