### PR TITLE
[SEMVER-MAJOR] Make juggler a regular dependency

### DIFF
--- a/3.0-RELEASE-NOTES.md
+++ b/3.0-RELEASE-NOTES.md
@@ -4,3 +4,18 @@ All breaking changes must be described here. When adding a new entry,
 always describe the impact on users and instructions for upgrading
 applications from 2.x to 3.0.
 
+## loopback-datasource-juggler was moved from peerDependencies to dependencies
+
+Originally, we (ab)used peer dependencies to ensure there is only one instance
+of loopback-datasource-juggler in the dependency tree, so that there is only
+one singleton instance of model registry. This was very fragile and might not
+have worked in certain edge cases.
+
+We have reworked loopback-datasource-juggler and connectors to not rely on
+a single juggler instance anymore. As the last step, juggler became a regular
+dependency.
+
+https://github.com/strongloop/loopback/issues/275
+
+When upgrading application from previous loopback versions, simply remove
+loopback-datasource-juggler from your dependencies.

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "express": "^4.12.2",
     "inflection": "^1.6.0",
     "loopback-connector-remote": "^1.0.3",
+    "loopback-datasource-juggler": "^3.0.0-alpha.1",
     "loopback-phase": "^1.2.0",
     "nodemailer": "^1.3.1",
     "nodemailer-stub-transport": "^0.1.5",
@@ -56,9 +57,6 @@
     "strong-remoting": "^2.21.0",
     "uid2": "0.0.3",
     "underscore.string": "^3.0.3"
-  },
-  "peerDependencies": {
-    "loopback-datasource-juggler": "^3.0.0-alpha.1"
   },
   "devDependencies": {
     "bluebird": "^2.9.9",
@@ -84,7 +82,6 @@
     "karma-phantomjs-launcher": "^0.1.4",
     "karma-script-launcher": "^0.1.0",
     "loopback-boot": "^2.7.0",
-    "loopback-datasource-juggler": "^3.0.0-alpha.1",
     "mocha": "^2.1.0",
     "sinon": "^1.13.0",
     "strong-task-emitter": "^0.0.6",


### PR DESCRIPTION
Originally, we (ab)used peer dependencies to ensure there is only one instance
of loopback-datasource-juggler in the dependency tree, so that there is only
one singleton instance of model registry. This was very fragile and might not
have worked in certain edge cases.

We have reworked loopback-datasource-juggler and connectors to not rely on
a single juggler instance anymore. As the last step, juggler became a regular
dependency.

Connect to https://github.com/strongloop/loopback/issues/275

I tested this change by installing the new loopback version in loopback-example-app and loopback-example-offline-sync to verify it works correctly with both database and remote connector(s).

/to @raymondfeng please review
/cc @ritch 