### PR TITLE
Should use copy of remotes.listenerTree?

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -806,8 +806,8 @@ module.exports = function(registry) {
         listenerTree.before = listenerTree.before || {};
         listenerTree.after = listenerTree.after || {};
 
-        var beforeListeners = remotes.listenerTree.before[toModelName] || {};
-        var afterListeners = remotes.listenerTree.after[toModelName] || {};
+        var beforeListeners = listenerTree.before[toModelName] || {};
+        var afterListeners = listenerTree.after[toModelName] || {};
 
         sharedClass.methods().forEach(function(method) {
           var delegateTo = method.rest && method.rest.delegateTo;


### PR DESCRIPTION
Hi,

_This is my first ever pull request (apologies if it sucks)..._

As part of investigating [Loopback issue #1951] (https://github.com/strongloop/loopback/issues/1951) with @gunjpan's assitance (whereby creating models/relations programatically appears to cause `model.nestRemoting()` to throw a TypeError in the absence of a remotes listenerTree) I think I found something here:

https://github.com/strongloop/loopback/blob/master/lib/model.js#L805-L810

* From what I can tell, a local copy has been made of  `remotes.listenerTree`, which has been defaulted to handle the absence of a `listenerTree`, but shortly-after the original un-defaulted value is used, and not the local copy. That's when I hit the `TypeError`.

A quick change to use the local copy (as per the PR) fixes the immediate issues I was facing in #1951.

Hope this helps?

Tim