### PR TITLE
Correct JSDoc findOrCreate() callback in PersistedModel

### DIFF
--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -135,9 +135,10 @@ module.exports = function(registry) {
    * <br/>See
    * [Where filter](https://docs.strongloop.com/display/LB/Where+filter#Wherefilter-Whereclauseforqueries).
    * @param {Object} data Data to insert if object matching the `where` filter is not found.
-   * @callback {Function} callback Callback function called with `cb(err, instance)` arguments.  Required.
+   * @callback {Function} callback Callback function called with `cb(err, instance, created)` arguments.  Required.
    * @param {Error} err Error object; see [Error object](http://docs.strongloop.com/display/LB/Error+object).
    * @param {Object} instance Model instance matching the `where` filter, if found.
+   * @param {Boolean} created True if the instance matching the `where` filter was created.
    */
 
   PersistedModel.findOrCreate = function findOrCreate(query, data, callback) {


### PR DESCRIPTION
Update PersistedModel.findOrCreate() JSDoc to reflect the callback accepts an additional created boolean parameter.