### PR TITLE
[SEMVER-MAJOR] Remove "loopback.DataModel"

### DIFF
--- a/lib/loopback.js
+++ b/lib/loopback.js
@@ -400,14 +400,6 @@ loopback.autoAttachModel = function(ModelCtor) {
   return this.registry.autoAttachModel.apply(this.registry, arguments);
 };
 
-// temporary alias to simplify migration of code based on <=2.0.0-beta3
-// TODO(bajtos) Remove this in v3.0
-Object.defineProperty(loopback, 'DataModel', {
-  get: function() {
-    return this.registry.DataModel;
-  }
-});
-
 /*!
  * Built in models / services
  */

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -107,14 +107,8 @@ Registry.prototype.createModel = function(name, properties, options) {
     BaseModel = this.getModel(BaseModel);
 
     if (BaseModel === undefined) {
-      if (baseName === 'DataModel') {
-        console.warn('Model `%s` is extending deprecated `DataModel. ' +
-          'Use `PersistedModel` instead.', name);
-        BaseModel = this.getModel('PersistedModel');
-      } else {
-        console.warn('Model `%s` is extending an unknown model `%s`. ' +
-          'Using `PersistedModel` as the base.', name, baseName);
-      }
+      console.warn('Model `%s` is extending an unknown model `%s`. ' +
+        'Using `PersistedModel` as the base.', name, baseName);
     }
   }
 
@@ -457,15 +451,3 @@ Registry.prototype.autoAttachModel = function(ModelCtor) {
     ModelCtor.attachTo(ds);
   }
 };
-
-// temporary alias to simplify migration of code based on <=2.0.0-beta3
-Object.defineProperty(Registry.prototype, 'DataModel', {
-  get: function() {
-    var stackLines = new Error().stack.split('\n');
-    console.warn('loopback.DataModel is deprecated, ' +
-      'use loopback.PersistedModel instead.');
-    // Log the location where loopback.DataModel was called
-    console.warn(stackLines[2]);
-    return this.PersistedModel;
-  }
-});

--- a/test/loopback.test.js
+++ b/test/loopback.test.js
@@ -36,7 +36,6 @@ describe('loopback', function() {
         'Change',
         'Checkpoint',
         'Connector',
-        'DataModel',
         'DataSource',
         'Email',
         'GeoPoint',


### PR DESCRIPTION
The model was just a temporary alias to simplify migration of code based on <=2.0.0-beta3

/cc @raymondfeng @ritch 