### PR TITLE
test: remove errant console.log from test

### DIFF
--- a/test/user.test.js
+++ b/test/user.test.js
@@ -1042,7 +1042,6 @@ describe('User', function() {
 
           user.verify(options)
             .then(function(result) {
-              console.log('here in then function');
               assert(result.email);
               assert(result.email.response);
               assert(result.token);


### PR DESCRIPTION
Using console.log like this can result in invalid xml when the xunit
reporter is used.