### PR TITLE
Improve error message on connector init error

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -219,11 +219,19 @@ app.models = function() {
  * @param {Object} config The data source config
  */
 app.dataSource = function(name, config) {
-  var ds = dataSourcesFromConfig(name, config, this.connectors, this.registry);
-  this.dataSources[name] =
-  this.dataSources[classify(name)] =
-  this.dataSources[camelize(name)] = ds;
-  return ds;
+  try {
+    var ds = dataSourcesFromConfig(name, config, this.connectors, this.registry);
+    this.dataSources[name] =
+    this.dataSources[classify(name)] =
+    this.dataSources[camelize(name)] = ds;
+    return ds;
+  } catch (err) {
+    if (err.message) {
+      err.message = 'Cannot create data source ' + JSON.stringify(name) +
+        ': ' + err.message;
+    }
+    throw err;
+  }
 };
 
 /**
@@ -410,6 +418,8 @@ function dataSourcesFromConfig(name, config, connectorRegistry, registry) {
         config.connector = require(connectorPath);
       }
     }
+    if (!config.connector.name)
+      config.connector.name = name;
   }
 
   return registry.createDataSource(config);

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -732,6 +732,16 @@ describe('app', function() {
       app.dataSource('custom', { connector: 'custom' });
       expect(app.dataSources.custom.name).to.equal(loopback.Memory.name);
     });
+
+    it('adds data source name to error messages', function() {
+      app.connector('throwing', {
+        initialize: function() { throw new Error('expected test error'); },
+      });
+
+      expect(function() {
+        app.dataSource('bad-ds', { connector: 'throwing' });
+      }).to.throw(/bad-ds.*throwing/);
+    });
   });
 
   describe.onServer('listen()', function() {


### PR DESCRIPTION
Before this change, after adding a Cloudant-backed datasource to an app, node . will fail with

```
AssertionError: url is not valid
  (...stack trace...)
```

Now:
```
AssertionError: Cannot create data source "cds": Cannot initialize connector "cloudant": url is not valid
  (...stack trace...)
```

Requires https://github.com/strongloop/loopback-datasource-juggler/pull/859

/to @ritch please review