### PR TITLE
Allow built-in token middleware to run repeatedly

### DIFF
--- a/server/middleware/token.js
+++ b/server/middleware/token.js
@@ -108,7 +108,7 @@ function token(options) {
         rewriteUserLiteral(req, currentUserLiteral);
         return next();
       }
-      if (req.accessToken.id && !overwriteExistingToken) {
+      if (req.accessToken && req.accessToken.id && !overwriteExistingToken) {
         // req.accessToken.id is defined, which means that some other middleware has identified a valid user.
         // when overwriteExistingToken is not set to a truthy value, skip searching for credentials.
         rewriteUserLiteral(req, currentUserLiteral);

--- a/server/middleware/token.js
+++ b/server/middleware/token.js
@@ -21,7 +21,7 @@ function rewriteUserLiteral(req, currentUserLiteral) {
     var urlBeforeRewrite = req.url;
     req.url = req.url.replace(
       new RegExp('/' + currentUserLiteral + '(/|$|\\?)', 'g'),
-      '/' + req.accessToken.userId + '$1');
+        '/' + req.accessToken.userId + '$1');
     if (req.url !== urlBeforeRewrite) {
       debug('req.url has been rewritten from %s to %s', urlBeforeRewrite,
         req.url);

--- a/server/middleware/token.js
+++ b/server/middleware/token.js
@@ -96,7 +96,7 @@ function token(options) {
     assert(typeof TokenModel === 'function',
       'loopback.token() middleware requires a AccessToken model');
 
-    if (req.accessToken !== undefined) {
+    if (req.accessToken && req.accessToken.id) {
       rewriteUserLiteral(req, currentUserLiteral);
       return next();
     }

--- a/test/access-token.test.js
+++ b/test/access-token.test.js
@@ -1,7 +1,7 @@
 var loopback = require('../');
 var extend = require('util')._extend;
 var Token = loopback.AccessToken.extend('MyToken');
-var ds = loopback.createDataSource({connector: loopback.Memory});
+var ds = loopback.createDataSource({ connector: loopback.Memory });
 Token.attachTo(ds);
 var ACL = loopback.ACL;
 
@@ -32,28 +32,27 @@ describe('loopback.token(options)', function() {
   });
 
   it('should not search default keys when searchDefaultTokenKeys is false',
-  function(done) {
-    var tokenId = this.token.id;
-    var app = createTestApp(
-      this.token,
-      { token: { searchDefaultTokenKeys: false } },
-      done);
-    var agent = request.agent(app);
+    function(done) {
+      var tokenId = this.token.id;
+      var app = createTestApp(
+        this.token, { token: { searchDefaultTokenKeys: false } },
+        done);
+      var agent = request.agent(app);
 
-    // Set the token cookie
-    agent.get('/token').expect(200).end(function(err, res) {
-      if (err) return done(err);
+      // Set the token cookie
+      agent.get('/token').expect(200).end(function(err, res) {
+        if (err) return done(err);
 
-      // Make a request that sets the token in all places searched by default
-      agent.get('/check-access?access_token=' + tokenId)
-        .set('X-Access-Token', tokenId)
-        .set('authorization', tokenId)
-        // Expect 401 because there is no (non-default) place configured where
-        // the middleware should load the token from
-        .expect(401)
-        .end(done);
+        // Make a request that sets the token in all places searched by default
+        agent.get('/check-access?access_token=' + tokenId)
+          .set('X-Access-Token', tokenId)
+          .set('authorization', tokenId)
+          // Expect 401 because there is no (non-default) place configured where
+          // the middleware should load the token from
+          .expect(401)
+          .end(done);
+      });
     });
-  });
 
   it('should populate req.token from an authorization header with bearer token', function(done) {
     var token = this.token.id;
@@ -144,7 +143,7 @@ describe('loopback.token(options)', function() {
         .set('authorization', id)
         .end(function(err, res) {
           assert(!err);
-          assert.deepEqual(res.body, {userId: userId});
+          assert.deepEqual(res.body, { userId: userId });
           done();
         });
     });
@@ -159,7 +158,7 @@ describe('loopback.token(options)', function() {
         .set('authorization', id)
         .end(function(err, res) {
           assert(!err);
-          assert.deepEqual(res.body, {userId: userId, state: 1});
+          assert.deepEqual(res.body, { userId: userId, state: 1 });
           done();
         });
     });
@@ -174,51 +173,83 @@ describe('loopback.token(options)', function() {
         .set('authorization', id)
         .end(function(err, res) {
           assert(!err);
-          assert.deepEqual(res.body, {userId: userId, state: 1});
+          assert.deepEqual(res.body, { userId: userId, state: 1 });
           done();
         });
     });
 
-  it('should skip when req.token is already present', function(done) {
-    var tokenStub = { id: 'stub id' };
-    app.use(function(req, res, next) {
-      req.accessToken = tokenStub;
-      next();
-    });
-    app.use(loopback.token({ model: Token }));
-    app.get('/', function(req, res, next) {
-      res.send(req.accessToken);
-    });
-
-    request(app).get('/')
-      .set('Authorization', this.token.id)
-      .expect(200)
-      .end(function(err, res) {
-        if (err) return done(err);
-        expect(res.body).to.eql(tokenStub);
-        done();
+  describe('loading multiple instances of token middleware', function() {
+    it('should skip when req.token is already present and no further options are set', function(done) {
+      var tokenStub = { id: 'stub id' };
+      app.use(function(req, res, next) {
+        req.accessToken = tokenStub;
+        next();
       });
-  });
-
-  it('should not skip when req.accessToken is falsy', function(done) {
-    var token = this.token;
-    app.use(function(req, res, next) {
-      req.accessToken = null;
-      next();
-    });
-    app.use(loopback.token({ model: Token }));
-    app.get('/', function(req, res, next) {
-      res.send(req.accessToken);
-    });
-
-    request(app).get('/')
-      .set('Authorization', token.id)
-      .expect(200)
-      .end(function(err, res) {
-        if (err) return done(err);
-        expect(res.body.userId).to.eql(token.userId);
-        done();
+      app.use(loopback.token({ model: Token }));
+      app.get('/', function(req, res, next) {
+        res.send(req.accessToken);
       });
+
+      request(app).get('/')
+        .set('Authorization', this.token.id)
+        .expect(200)
+        .end(function(err, res) {
+          if (err) return done(err);
+          expect(res.body).to.eql(tokenStub);
+          done();
+        });
+    });
+
+    it('should not overwrite valid existing token (has "id" property) when overwriteExistingToken is falsy', function(done) {
+      var tokenStub = { id: 'stub id' };
+      app.use(function(req, res, next) {
+        req.accessToken = tokenStub;
+        next();
+      });
+      app.use(loopback.token({
+        model: Token,
+        enableDoublecheck: true,
+      }));
+      app.get('/', function(req, res, next) {
+        res.send(req.accessToken);
+      });
+
+      request(app).get('/')
+        .set('Authorization', this.token.id)
+        .expect(200)
+        .end(function(err, res) {
+          if (err) return done(err);
+          expect(res.body).to.eql(tokenStub);
+          done();
+        });
+    });
+
+    it('should overwrite existing token when enableDoublecheck and overwriteExistingToken options are truthy', function(done) {
+      var token = this.token;
+      var tokenStub = { id: 'stub id' };
+
+      app.use(function(req, res, next) {
+        req.accessToken = tokenStub;
+        next();
+      });
+      app.use(loopback.token({
+        model: Token,
+        enableDoublecheck: true,
+        overwriteExistingToken: true
+      }));
+      app.get('/', function(req, res, next) {
+        res.send(req.accessToken);
+      });
+
+      request(app).get('/')
+        .set('Authorization', token.id)
+        .expect(200)
+        .end(function(err, res) {
+          if (err) return done(err);
+          expect(res.body.userId).to.eql(token.userId);
+          done();
+        });
+    });
   });
 });
 
@@ -259,16 +290,19 @@ describe('AccessToken', function() {
     });
 
     function mockRequest(opts) {
-      return extend(
-        {
+      return extend({
           method: 'GET',
           url: '/a-test-path',
           headers: {},
           _params: {},
 
           // express helpers
-          param: function(name) { return this._params[name]; },
-          header: function(name) { return this.headers[name]; }
+          param: function(name) {
+            return this._params[name];
+          },
+          header: function(name) {
+            return this.headers[name];
+          }
         },
         opts);
     }
@@ -295,7 +329,7 @@ describe('app.enableAuth()', function() {
   });
 
   it('prevent remote call with app setting status on denied ACL', function(done) {
-    createTestAppAndRequest(this.token, {app:{aclErrorStatus:403}}, done)
+    createTestAppAndRequest(this.token, { app: { aclErrorStatus: 403 } }, done)
       .del('/tests/123')
       .expect(403)
       .set('authorization', this.token.id)
@@ -311,7 +345,7 @@ describe('app.enableAuth()', function() {
   });
 
   it('prevent remote call with app setting status on denied ACL', function(done) {
-    createTestAppAndRequest(this.token, {model:{aclErrorStatus:404}}, done)
+    createTestAppAndRequest(this.token, { model: { aclErrorStatus: 404 } }, done)
       .del('/tests/123')
       .expect(404)
       .set('authorization', this.token.id)
@@ -376,7 +410,7 @@ describe('app.enableAuth()', function() {
 
 function createTestingToken(done) {
   var test = this;
-  Token.create({userId: '123'}, function(err, token) {
+  Token.create({ userId: '123' }, function(err, token) {
     if (err) return done(err);
     test.token = token;
     done();
@@ -405,8 +439,8 @@ function createTestApp(testToken, settings, done) {
   app.use(loopback.cookieParser('secret'));
   app.use(loopback.token(tokenSettings));
   app.get('/token', function(req, res) {
-    res.cookie('authorization', testToken.id, {signed: true});
-    res.cookie('access_token', testToken.id, {signed: true});
+    res.cookie('authorization', testToken.id, { signed: true });
+    res.cookie('access_token', testToken.id, { signed: true });
     res.end();
   });
   app.get('/', function(req, res) {
@@ -422,7 +456,7 @@ function createTestApp(testToken, settings, done) {
     res.status(req.accessToken ? 200 : 401).end();
   });
   app.use('/users/:uid', function(req, res) {
-    var result = {userId: req.params.uid};
+    var result = { userId: req.params.uid };
     if (req.query.state) {
       result.state = req.query.state;
     } else if (req.url !== '/') {
@@ -438,15 +472,13 @@ function createTestApp(testToken, settings, done) {
   });
 
   var modelOptions = {
-    acls: [
-      {
-        principalType: 'ROLE',
-        principalId: '$everyone',
-        accessType: ACL.ALL,
-        permission: ACL.DENY,
-        property: 'deleteById'
-      }
-    ]
+    acls: [{
+      principalType: 'ROLE',
+      principalId: '$everyone',
+      accessType: ACL.ALL,
+      permission: ACL.DENY,
+      property: 'deleteById'
+    }]
   };
 
   Object.keys(modelSettings).forEach(function(key) {

--- a/test/access-token.test.js
+++ b/test/access-token.test.js
@@ -65,7 +65,7 @@ describe('loopback.token(options)', function() {
       .end(done);
   });
 
-  describe('populating req.toen from HTTP Basic Auth formatted authorization header', function() {
+  describe('populating req.token from HTTP Basic Auth formatted authorization header', function() {
     it('parses "standalone-token"', function(done) {
       var token = this.token.id;
       token = 'Basic ' + new Buffer(token).toString('base64');
@@ -196,6 +196,27 @@ describe('loopback.token(options)', function() {
       .end(function(err, res) {
         if (err) return done(err);
         expect(res.body).to.eql(tokenStub);
+        done();
+      });
+  });
+
+  it('should not skip when req.accessToken is falsy', function(done) {
+    var token = this.token;
+    app.use(function(req, res, next) {
+      req.accessToken = null;
+      next();
+    });
+    app.use(loopback.token({ model: Token }));
+    app.get('/', function(req, res, next) {
+      res.send(req.accessToken);
+    });
+
+    request(app).get('/')
+      .set('Authorization', token.id)
+      .expect(200)
+      .end(function(err, res) {
+        if (err) return done(err);
+        expect(res.body.userId).to.eql(token.userId);
         done();
       });
   });

--- a/test/access-token.test.js
+++ b/test/access-token.test.js
@@ -268,7 +268,12 @@ describe('loopback.token(options)', function() {
         .expect(200)
         .end(function(err, res) {
           if (err) return done(err);
-          expect(res.body.userId).to.eql(token.userId);
+          expect(res.body).to.eql({
+            id: token.id,
+            ttl: token.ttl,
+            userId: token.userId,
+            created: token.created.toJSON()
+          });
           done();
         });
     });


### PR DESCRIPTION
Add two new options:

  - When `enableDoublecheck` is true, the middleware will run
    even if a previous middleware has already set `req.accessToken`
    (possibly to `null` for anonymous requests)

  - When `overwriteExistingToken` is true (and `enableDoublecheck` too),
    the middleware will overwrite `req.accessToken` set by a previous
    middleware instances.

---

fixes #2106 
For details, please see issue description #2106 
@richardpringle 