### PR TITLE
Fix inconsistencies in JSDoc

### DIFF
--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -87,7 +87,7 @@ module.exports = function(registry) {
   /**
    * Create new instance of Model, and save to database.
    *
-   * @param {Object}|[{Object}] data Optional data argument.  Can be either a single model instance or an array of instances.
+   * @param {Object|Array.<Object>} [data] Optional data argument.  Can be either a single model instance or an array of instances.
    *
    * @callback {Function} callback Callback function called with `cb(err, obj)` signature.
    * @param {Error} err Error object; see [Error object](http://docs.strongloop.com/display/LB/Error+object).
@@ -924,8 +924,8 @@ module.exports = function(registry) {
    * @param {Object} [options.filter] Replicate models that match this filter
    * @callback {Function} [callback] Callback function called with `(err, conflicts)` arguments.
    * @param {Error} err Error object; see [Error object](http://docs.strongloop.com/display/LB/Error+object).
-   * @param {Conflict[]} conflicts A list of changes that could not be replicated due to conflicts.
-   * @param {Object] checkpoints The new checkpoints to use as the "since"
+   * @param {Array.<Conflict>} conflicts A list of changes that could not be replicated due to conflicts.
+   * @param {Object} checkpoints The new checkpoints to use as the "since"
    * argument for the next replication.
    */
 

--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -87,7 +87,7 @@ module.exports = function(registry) {
   /**
    * Create new instance of Model, and save to database.
    *
-   * @param {Object|Array.<Object>} [data] Optional data argument.  Can be either a single model instance or an array of instances.
+   * @param {Object|Object[]} [data] Optional data argument.  Can be either a single model instance or an array of instances.
    *
    * @callback {Function} callback Callback function called with `cb(err, obj)` signature.
    * @param {Error} err Error object; see [Error object](http://docs.strongloop.com/display/LB/Error+object).
@@ -924,7 +924,7 @@ module.exports = function(registry) {
    * @param {Object} [options.filter] Replicate models that match this filter
    * @callback {Function} [callback] Callback function called with `(err, conflicts)` arguments.
    * @param {Error} err Error object; see [Error object](http://docs.strongloop.com/display/LB/Error+object).
-   * @param {Array.<Conflict>} conflicts A list of changes that could not be replicated due to conflicts.
+   * @param {Conflict[]} conflicts A list of changes that could not be replicated due to conflicts.
    * @param {Object} checkpoints The new checkpoints to use as the "since"
    * argument for the next replication.
    */


### PR DESCRIPTION
1. Method: PersistedModel.create
Location: lib/persisted-model.js
JSDoc:
* @param {Object}|[{Object}] data Optional data argument.  Can be either a single model instance or an array of instances.

Correction:
* @param {Object|Array.<Object>} [data] Optional data argument.  Can be either a single model instance or an array of instances.

Reasoning:
Make the object type consistent with the rest of the JSDocs

2. Method: PersistedModel.replicate([since], targetModel, [options], [callback])
Location: lib/persisted-model.js
JSDoc:
* @param {Object] checkpoints The new checkpoints to use as the "since"

Correction:
* @param {Object} checkpoints The new checkpoints to use as the "since"

Reasoning:
The curly braces on Object needs to end with a curly braces, not a square bracket

3. Method: PersistedModel.replicate([since], targetModel, [options], [callback])
Location: lib/persisted-model.js
JSDoc:
@param {Conflict[]} conflicts A list of changes that could not be replicated due to conflicts.

Correction:
@param {Array.<Conflict>} conflicts A list of changes that could not be replicated due to conflicts.

Reasoning:
In other parts of the JSDoc, typed arrays are represented by Array.<Conflict>. This format is the only case that uses Conflict[].