### PR TITLE
Replace all the "{href}" placeholders in verify email template

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -417,7 +417,7 @@ module.exports = function(User) {
 
       options.text = options.text || 'Please verify your email by opening this link in a web browser:\n\t{href}';
 
-      options.text = options.text.replace('{href}', options.verifyHref);
+      options.text = options.text.replace(/\{href\}/gm, options.verifyHref);
 
       options.to = options.to || user.email;
 


### PR DESCRIPTION
Hello,

I needed to send an email with the link in a button and an alternative link in plain text.
So I used a regex to replace all the "{href}" placeholders in verify email template.

Regards