### PR TITLE
Fix for remote calls to PersistedModel.diff

### DIFF
--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -699,7 +699,8 @@ module.exports = function(registry) {
         description: 'Get a set of deltas and conflicts since the given checkpoint.',
         accessType: 'READ',
         accepts: [
-          { arg: 'since', type: 'number', description: 'Find deltas since this checkpoint' },
+          { arg: 'since', type: 'number', description: 'Find deltas since this checkpoint',
+            http: { source: 'body' }},
           { arg: 'remoteChanges', type: 'array', description: 'an array of change objects',
            http: { source: 'body' }},
         ],


### PR DESCRIPTION
A remote POST call to diff never received the 'since' parameter. By specifying that it is in the request body it works again