### PR TITLE
Fix typo in Model.nestRemoting

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -806,8 +806,8 @@ module.exports = function(registry) {
         listenerTree.before = listenerTree.before || {};
         listenerTree.after = listenerTree.after || {};
 
-        var beforeListeners = remotes.listenerTree.before[toModelName] || {};
-        var afterListeners = remotes.listenerTree.after[toModelName] || {};
+        var beforeListeners = listenerTree.before[toModelName] || {};
+        var afterListeners = listenerTree.after[toModelName] || {};
 
         sharedClass.methods().forEach(function(method) {
           var delegateTo = method.rest && method.rest.delegateTo;


### PR DESCRIPTION
Prevent apps from crashing when using `Model.nestRemoting` without `{ hooks: false }` option.

Note that it is not possible to reproduce this bug using our current Mocha test suite, because other tests modify the global state in such way that the bug no longer occurs.

This supersedes #1966 and fixes #1951.

/cc @timneedham