### PR TITLE
Emit a remoteMethodDisabled event when disabling a remote method

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -153,6 +153,11 @@ app.model = function(Model, config) {
     this.emit('modelRemoted', Model.sharedClass);
   }
 
+  self = this;
+  Model.on('remoteMethodDisabled', function(model, methodName) {
+    self.emit('remoteMethodDisabled', model, methodName);
+  });
+
   Model.shared = isPublic;
   Model.app = this;
   Model.emit('attached', this);

--- a/lib/model.js
+++ b/lib/model.js
@@ -433,6 +433,7 @@ module.exports = function(registry) {
 
   Model.disableRemoteMethod = function(name, isStatic) {
     this.sharedClass.disableMethod(name, isStatic || false);
+    this.emit('remoteMethodDisabled', this.sharedClass, name);
   };
 
   Model.belongsToRemoting = function(relationName, relation, define) {

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "loopback-boot": "^2.7.0",
     "mocha": "^2.1.0",
     "sinon": "^1.13.0",
+    "sinon-chai": "^2.8.0",
     "strong-task-emitter": "^0.0.6",
     "supertest": "^0.15.0"
   },

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -599,6 +599,22 @@ describe('app', function() {
       expect(remotedClass).to.eql(Color.sharedClass);
     });
 
+    it('emits a `remoteMethodDisabled` event', function() {
+      var Color = PersistedModel.extend('color', { name: String });
+      Color.shared = true;
+      var remoteMethodDisabledClass, disabledRemoteMethod;
+      app.on('remoteMethodDisabled', function(sharedClass, methodName) {
+        remoteMethodDisabledClass = sharedClass;
+        disabledRemoteMethod = methodName;
+      });
+      app.model(Color);
+      app.models.Color.disableRemoteMethod('findOne');
+      expect(remoteMethodDisabledClass).to.exist;
+      expect(remoteMethodDisabledClass).to.eql(Color.sharedClass);
+      expect(disabledRemoteMethod).to.exist;
+      expect(disabledRemoteMethod).to.eql('findOne');
+    });
+
     it.onServer('updates REST API when a new model is added', function(done) {
       app.use(loopback.rest());
       request(app).get('/colors').expect(404, function(err, res) {

--- a/test/helpers/loopback-testing-helper.js
+++ b/test/helpers/loopback-testing-helper.js
@@ -10,7 +10,10 @@ module.exports = helpers;
 
 var assert = require('assert');
 var request = require('supertest');
-var expect = require('chai').expect;
+var chai = require('chai');
+var expect = chai.expect;
+var sinon = require('sinon');
+chai.use(require('sinon-chai'));
 
 _beforeEach.withApp = function(app) {
   if (app.models.User) {

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -613,6 +613,20 @@ describe.onServer('Remote Methods', function() {
         'createChangeStream',
       ]);
     });
+
+    it('emits a `remoteMethodDisabled` event', function() {
+      var app = loopback();
+      var model = PersistedModel.extend('TestModelForDisablingRemoteMethod');
+      app.dataSource('db', { connector: 'memory' });
+      app.model(model, { dataSource: 'db' });
+
+      var callbackSpy = require('sinon').spy();
+      var TestModel = app.models.TestModelForDisablingRemoteMethod;
+      TestModel.on('remoteMethodDisabled', callbackSpy);
+      TestModel.disableRemoteMethod('findOne');
+
+      expect(callbackSpy).to.have.been.calledWith(TestModel.sharedClass, 'findOne');
+    });
   });
 
   describe('Model.getApp(cb)', function() {


### PR DESCRIPTION
This PR for #686 to make loopback emits a remoteMethodDisabled event. I'll make another PR for loopback-component-explorer to register for this event. 