### PR TITLE
BACKPORT Add new feature to emit a `remoteMethodDisabled` event when disabling

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -153,6 +153,11 @@ app.model = function(Model, config) {
     this.emit('modelRemoted', Model.sharedClass);
   }
 
+  var self = this;
+  Model.on('remoteMethodDisabled', function(model, methodName) {
+    self.emit('remoteMethodDisabled', model, methodName);
+  });
+
   Model.shared = isPublic;
   Model.app = this;
   Model.emit('attached', this);

--- a/lib/model.js
+++ b/lib/model.js
@@ -431,6 +431,7 @@ module.exports = function(registry) {
 
   Model.disableRemoteMethod = function(name, isStatic) {
     this.sharedClass.disableMethod(name, isStatic || false);
+    this.emit('remoteMethodDisabled', this.sharedClass, name);
   };
 
   Model.belongsToRemoting = function(relationName, relation, define) {

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "loopback-testing": "~1.1.0",
     "mocha": "^2.1.0",
     "sinon": "^1.13.0",
+    "sinon-chai": "^2.8.0",
     "strong-task-emitter": "^0.0.6",
     "supertest": "^0.15.0"
   },

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -606,6 +606,22 @@ describe('app', function() {
       expect(remotedClass).to.eql(Color.sharedClass);
     });
 
+    it('emits a `remoteMethodDisabled` event', function() {
+      var Color = PersistedModel.extend('color', { name: String });
+      Color.shared = true;
+      var remoteMethodDisabledClass, disabledRemoteMethod;
+      app.on('remoteMethodDisabled', function(sharedClass, methodName) {
+        remoteMethodDisabledClass = sharedClass;
+        disabledRemoteMethod = methodName;
+      });
+      app.model(Color);
+      app.models.Color.disableRemoteMethod('findOne');
+      expect(remoteMethodDisabledClass).to.exist;
+      expect(remoteMethodDisabledClass).to.eql(Color.sharedClass);
+      expect(disabledRemoteMethod).to.exist;
+      expect(disabledRemoteMethod).to.eql('findOne');
+    });
+
     it.onServer('updates REST API when a new model is added', function(done) {
       app.use(loopback.rest());
       request(app).get('/colors').expect(404, function(err, res) {

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -1,9 +1,13 @@
 var async = require('async');
+var chai = require('chai');
+var expect = chai.expect;
 var loopback = require('../');
 var ACL = loopback.ACL;
 var Change = loopback.Change;
 var defineModelTestsWithDataSource = require('./util/model-tests');
 var PersistedModel = loopback.PersistedModel;
+var sinonChai = require('sinon-chai');
+chai.use(sinonChai);
 
 var describe = require('./util/describe');
 
@@ -617,6 +621,20 @@ describe.onServer('Remote Methods', function() {
         'prototype.updateAttributes',
         'createChangeStream'
       ]);
+    });
+
+    it('emits a `remoteMethodDisabled` event', function() {
+      var app = loopback();
+      var model = PersistedModel.extend('TestModelForDisablingRemoteMethod');
+      app.dataSource('db', { connector: 'memory' });
+      app.model(model, { dataSource: 'db' });
+
+      var callbackSpy = require('sinon').spy();
+      var TestModel = app.models.TestModelForDisablingRemoteMethod;
+      TestModel.on('remoteMethodDisabled', callbackSpy);
+      TestModel.disableRemoteMethod('findOne');
+
+      expect(callbackSpy).to.have.been.calledWith(TestModel.sharedClass, 'findOne');
     });
   });
 


### PR DESCRIPTION
See https://github.com/strongloop/loopback/pull/2266#issuecomment-215689358