### PR TITLE
remove @private from jsdoc

### DIFF
--- a/server/current-context.js
+++ b/server/current-context.js
@@ -98,7 +98,6 @@ module.exports = function(loopback) {
    * context, try the parent one
    * @param {String} name Name of the context property
    * @returns {*} Value of the context property
-   * @private
    */
   ChainedContext.prototype.get = function(name) {
     var val = this.child && this.child.get(name);


### PR DESCRIPTION
`get` method is part of public api.