### PR TITLE
Separate error-checking and next/done logic from other logic

### DIFF
--- a/test/access-control.integration.js
+++ b/test/access-control.integration.js
@@ -127,6 +127,7 @@ describe('access control - integration', function() {
     var userCounter;
     function newUserData() {
       userCounter = userCounter ? ++userCounter : 1;
+
       return {
         email: 'new-' + userCounter + '@test.test',
         password: 'test',
@@ -204,6 +205,7 @@ describe('access control - integration', function() {
           balance: 100,
         }, function(err, act) {
           self.url = '/api/accounts/' + act.id;
+
           done();
         });
       });

--- a/test/access-token.test.js
+++ b/test/access-token.test.js
@@ -150,6 +150,7 @@ describe('loopback.token(options)', function() {
         .end(function(err, res) {
           assert(!err);
           assert.deepEqual(res.body, { userId: userId });
+
           done();
         });
     });
@@ -165,6 +166,7 @@ describe('loopback.token(options)', function() {
         .end(function(err, res) {
           assert(!err);
           assert.deepEqual(res.body, { userId: userId, state: 1 });
+
           done();
         });
     });
@@ -180,6 +182,7 @@ describe('loopback.token(options)', function() {
         .end(function(err, res) {
           assert(!err);
           assert.deepEqual(res.body, { userId: userId, state: 1 });
+
           done();
         });
     });
@@ -188,6 +191,7 @@ describe('loopback.token(options)', function() {
     var tokenStub = { id: 'stub id' };
     app.use(function(req, res, next) {
       req.accessToken = tokenStub;
+
       next();
     });
     app.use(loopback.token({ model: Token }));
@@ -200,7 +204,9 @@ describe('loopback.token(options)', function() {
       .expect(200)
       .end(function(err, res) {
         if (err) return done(err);
+
         expect(res.body).to.eql(tokenStub);
+
         done();
       });
   });
@@ -211,6 +217,7 @@ describe('loopback.token(options)', function() {
       var tokenStub = { id: 'stub id' };
       app.use(function(req, res, next) {
         req.accessToken = tokenStub;
+
         next();
       });
       app.use(loopback.token({ model: Token }));
@@ -223,7 +230,9 @@ describe('loopback.token(options)', function() {
         .expect(200)
         .end(function(err, res) {
           if (err) return done(err);
+
           expect(res.body).to.eql(tokenStub);
+
           done();
         });
     });
@@ -234,6 +243,7 @@ describe('loopback.token(options)', function() {
       var tokenStub = { id: 'stub id' };
       app.use(function(req, res, next) {
         req.accessToken = tokenStub;
+
         next();
       });
       app.use(loopback.token({
@@ -249,7 +259,9 @@ describe('loopback.token(options)', function() {
         .expect(200)
         .end(function(err, res) {
           if (err) return done(err);
+
           expect(res.body).to.eql(tokenStub);
+
           done();
         });
     });
@@ -262,6 +274,7 @@ describe('loopback.token(options)', function() {
 
       app.use(function(req, res, next) {
         req.accessToken = tokenStub;
+
         next();
       });
       app.use(loopback.token({
@@ -278,12 +291,14 @@ describe('loopback.token(options)', function() {
         .expect(200)
         .end(function(err, res) {
           if (err) return done(err);
+
           expect(res.body).to.eql({
             id: token.id,
             ttl: token.ttl,
             userId: token.userId,
             created: token.created.toJSON(),
           });
+
           done();
         });
     });
@@ -306,6 +321,7 @@ describe('AccessToken', function() {
   it('should be validateable', function(done) {
     this.token.validate(function(err, isValid) {
       assert(isValid);
+
       done();
     });
   });
@@ -321,7 +337,9 @@ describe('AccessToken', function() {
 
       Token.findForRequest(req, function(err, token) {
         if (err) return done(err);
+
         expect(token.id).to.eql(expectedTokenId);
+
         done();
       });
     });
@@ -355,9 +373,11 @@ describe('app.enableAuth()', function() {
         if (err) {
           return done(err);
         }
+
         var errorResponse = res.body.error;
         assert(errorResponse);
         assert.equal(errorResponse.code, 'AUTHORIZATION_REQUIRED');
+
         done();
       });
   });
@@ -371,9 +391,11 @@ describe('app.enableAuth()', function() {
         if (err) {
           return done(err);
         }
+
         var errorResponse = res.body.error;
         assert(errorResponse);
         assert.equal(errorResponse.code, 'ACCESS_DENIED');
+
         done();
       });
   });
@@ -387,9 +409,11 @@ describe('app.enableAuth()', function() {
         if (err) {
           return done(err);
         }
+
         var errorResponse = res.body.error;
         assert(errorResponse);
         assert.equal(errorResponse.code, 'MODEL_NOT_FOUND');
+
         done();
       });
   });
@@ -403,9 +427,11 @@ describe('app.enableAuth()', function() {
         if (err) {
           return done(err);
         }
+
         var errorResponse = res.body.error;
         assert(errorResponse);
         assert.equal(errorResponse.code, 'AUTHORIZATION_REQUIRED');
+
         done();
       });
   });
@@ -436,7 +462,9 @@ describe('app.enableAuth()', function() {
       .expect('Content-Type', /json/)
       .end(function(err, res) {
         if (err) return done(err);
+
         expect(res.body.token.id).to.eql(token.id);
+
         done();
       });
   });
@@ -446,7 +474,9 @@ function createTestingToken(done) {
   var test = this;
   Token.create({ userId: '123' }, function(err, token) {
     if (err) return done(err);
+
     test.token = token;
+
     done();
   });
 }

--- a/test/acl.test.js
+++ b/test/acl.test.js
@@ -417,7 +417,9 @@ describe('access check', function() {
     MyTestModel.beforeRemote('find', function(ctx, next) {
       // ensure this is called after checkAccess
       if (!checkAccessCalled) return done(new Error('incorrect order'));
+
       beforeHookCalled = true;
+
       next();
     });
 
@@ -426,6 +428,7 @@ describe('access check', function() {
       .end(function(err, result) {
         assert(beforeHookCalled, 'the before hook should be called');
         assert(checkAccessCalled, 'checkAccess should have been called');
+
         done();
       });
   });

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -36,10 +36,12 @@ describe('app', function() {
 
       executeMiddlewareHandlers(app, function(err) {
         if (err) return done(err);
+
         expect(steps).to.eql([
           'initial', 'session', 'auth', 'parse',
           'main', 'routes', 'files', 'final',
         ]);
+
         done();
       });
     });
@@ -50,7 +52,9 @@ describe('app', function() {
 
       executeMiddlewareHandlers(app, function(err) {
         if (err) return done(err);
+
         expect(steps).to.eql(['first', 'second']);
+
         done();
       });
     });
@@ -62,7 +66,9 @@ describe('app', function() {
 
       executeMiddlewareHandlers(app, function(err) {
         if (err) return done(err);
+
         expect(steps).to.eql(['routes:before', 'main', 'routes:after']);
+
         done();
       });
     });
@@ -82,7 +88,9 @@ describe('app', function() {
       expect(found).have.property('phase', 'routes:before');
       executeMiddlewareHandlers(app, function(err) {
         if (err) return done(err);
+
         expect(steps).to.eql(['my-handler', 'extra-handler']);
+
         done();
       });
     });
@@ -100,7 +108,9 @@ describe('app', function() {
         expect(found).have.property('phase', 'routes:before');
         executeMiddlewareHandlers(app, function(err) {
           if (err) return done(err);
+
           expect(steps).to.eql(['my-handler']);
+
           done();
         });
       });
@@ -118,7 +128,9 @@ describe('app', function() {
         expect(found).have.property('phase', 'routes:before');
         executeMiddlewareHandlers(app, function(err) {
           if (err) return done(err);
+
           expect(steps).to.eql(['my-handler']);
+
           done();
         });
       });
@@ -128,6 +140,7 @@ describe('app', function() {
 
       app.middleware('initial', function(req, res, next) {
         steps.push('initial');
+
         next(expectedError);
       });
 
@@ -135,12 +148,15 @@ describe('app', function() {
       app.use(function errorHandler(err, req, res, next) {
         expect(err).to.equal(expectedError);
         steps.push('error');
+
         next();
       });
 
       executeMiddlewareHandlers(app, function(err) {
         if (err) return done(err);
+
         expect(steps).to.eql(['initial', 'error']);
+
         done();
       });
     });
@@ -154,6 +170,7 @@ describe('app', function() {
 
       executeMiddlewareHandlers(app, function(err) {
         expect(err).to.equal(expectedError);
+
         done();
       });
     });
@@ -172,12 +189,15 @@ describe('app', function() {
 
       app.middleware('initial', function(err, req, res, next) {
         handledError = err;
+
         next();
       });
 
       executeMiddlewareHandlers(app, function(err) {
         if (err) return done(err);
+
         expect(handledError).to.equal(expectedError);
+
         done();
       });
     });
@@ -190,7 +210,9 @@ describe('app', function() {
         function(url, next) { executeMiddlewareHandlers(app, url, next); },
         function(err) {
           if (err) return done(err);
+
           expect(steps).to.eql(['/scope', '/scope/item']);
+
           done();
         });
     });
@@ -203,7 +225,9 @@ describe('app', function() {
         function(url, next) { executeMiddlewareHandlers(app, url, next); },
         function(err) {
           if (err) return done(err);
+
           expect(steps).to.eql(['/a', '/b']);
+
           done();
         });
     });
@@ -216,7 +240,9 @@ describe('app', function() {
         function(url, next) { executeMiddlewareHandlers(app, url, next); },
         function(err) {
           if (err) return done(err);
+
           expect(steps).to.eql(['/a', '/b', '/scope']);
+
           done();
         });
     });
@@ -224,12 +250,15 @@ describe('app', function() {
     it('sets req.url to a sub-path', function(done) {
       app.middleware('initial', ['/scope'], function(req, res, next) {
         steps.push(req.url);
+
         next();
       });
 
       executeMiddlewareHandlers(app, '/scope/id', function(err) {
         if (err) return done(err);
+
         expect(steps).to.eql(['/id']);
+
         done();
       });
     });
@@ -240,11 +269,13 @@ describe('app', function() {
       app.middleware('initial', function(rq, rs, next) {
         req = rq;
         res = rs;
+
         next();
       });
 
       executeMiddlewareHandlers(app, function(err) {
         if (err) return done(err);
+
         expect(getObjectAndPrototypeKeys(req), 'request').to.include.members([
           'accepts',
           'get',
@@ -274,12 +305,15 @@ describe('app', function() {
       var reqProps;
       app.middleware('initial', function(req, res, next) {
         reqProps = { baseUrl: req.baseUrl, originalUrl: req.originalUrl };
+
         next();
       });
 
       executeMiddlewareHandlers(app, '/test/url', function(err) {
         if (err) return done(err);
+
         expect(reqProps).to.eql({ baseUrl: '', originalUrl: '/test/url' });
+
         done();
       });
     });
@@ -291,7 +325,9 @@ describe('app', function() {
 
       executeMiddlewareHandlers(app, '/test', function(err) {
         if (err) return done(err);
+
         expect(steps).to.eql(['route', 'files']);
+
         done();
       });
     });
@@ -311,7 +347,9 @@ describe('app', function() {
 
       executeMiddlewareHandlers(app, function(err) {
         if (err) return done;
+
         expect(steps).to.eql(numbers);
+
         done();
       });
     });
@@ -324,6 +362,7 @@ describe('app', function() {
           mountpath: req.app.mountpath,
           parent: req.app.parent,
         };
+
         next();
       });
       subapp.on('mount', function() { mountWasEmitted = true; });
@@ -332,11 +371,13 @@ describe('app', function() {
 
       executeMiddlewareHandlers(app, '/mountpath/test', function(err) {
         if (err) return done(err);
+
         expect(mountWasEmitted, 'mountWasEmitted').to.be.true;
         expect(data).to.eql({
           mountpath: '/mountpath',
           parent: app,
         });
+
         done();
       });
     });
@@ -349,25 +390,30 @@ describe('app', function() {
       subapp.use(function verifyTestAssumptions(req, res, next) {
         expect(req.__proto__).to.not.equal(expected.req);
         expect(res.__proto__).to.not.equal(expected.res);
+
         next();
       });
 
       app.middleware('initial', function saveOriginalValues(req, res, next) {
         expected.req = req.__proto__;
         expected.res = res.__proto__;
+
         next();
       });
       app.middleware('routes', subapp);
       app.middleware('final', function saveActualValues(req, res, next) {
         actual.req = req.__proto__;
         actual.res = res.__proto__;
+
         next();
       });
 
       executeMiddlewareHandlers(app, function(err) {
         if (err) return done(err);
+
         expect(actual.req, 'req').to.equal(expected.req);
         expect(actual.res, 'res').to.equal(expected.res);
+
         done();
       });
     });
@@ -382,6 +428,7 @@ describe('app', function() {
     function pathSavingHandler() {
       return function(req, res, next) {
         steps.push(req.originalUrl);
+
         next();
       };
     }
@@ -405,6 +452,7 @@ describe('app', function() {
         var args = Array.prototype.slice.apply(arguments);
         return function(req, res, next) {
           steps.push(args);
+
           next();
         };
       };
@@ -455,12 +503,14 @@ describe('app', function() {
 
       executeMiddlewareHandlers(app, function(err) {
         if (err) return done(err);
+
         expect(steps).to.eql([
           ['before'],
           [expectedConfig],
           ['after', 2],
           [{ x: 1 }],
         ]);
+
         done();
       });
     });
@@ -471,6 +521,7 @@ describe('app', function() {
         function factory() {
           return function(req, res, next) {
             steps.push(req.originalUrl);
+
             next();
           };
         },
@@ -484,7 +535,9 @@ describe('app', function() {
         function(url, next) { executeMiddlewareHandlers(app, url, next); },
         function(err) {
           if (err) return done(err);
+
           expect(steps).to.eql(['/a', '/b', '/scope']);
+
           done();
         });
     });
@@ -541,13 +594,16 @@ describe('app', function() {
       names.forEach(function(it) {
         app.middleware(it, function(req, res, next) {
           steps.push(it);
+
           next();
         });
       });
 
       executeMiddlewareHandlers(app, function(err) {
         if (err) return done(err);
+
         expect(steps).to.eql(names);
+
         done();
       });
     }
@@ -777,6 +833,7 @@ describe('app', function() {
 
       app.listen(function() {
         expect(app.get('port'), 'port').to.not.equal(0);
+
         done();
       });
     });
@@ -790,6 +847,7 @@ describe('app', function() {
         var host = process.platform === 'win32' ? 'localhost' : app.get('host');
         var expectedUrl = 'http://' + host + ':' + app.get('port') + '/';
         expect(app.get('url'), 'url').to.equal(expectedUrl);
+
         done();
       });
     });
@@ -800,6 +858,7 @@ describe('app', function() {
       app.listen(0, '127.0.0.1', function() {
         expect(app.get('port'), 'port').to.not.equal(0).and.not.equal(1);
         expect(this.address().address).to.equal('127.0.0.1');
+
         done();
       });
     });
@@ -810,6 +869,7 @@ describe('app', function() {
         app.set('port', 1);
         app.listen(0).on('listening', function() {
           expect(app.get('port'), 'port') .to.not.equal(0).and.not.equal(1);
+
           done();
         });
       }
@@ -824,6 +884,7 @@ describe('app', function() {
       app.listen()
         .on('listening', function() {
           expect(this.address().address).to.equal('127.0.0.1');
+
           done();
         });
     });

--- a/test/change-stream.test.js
+++ b/test/change-stream.test.js
@@ -22,6 +22,7 @@ describe('PersistedModel.createChangeStream()', function() {
         changes.on('data', function(change) {
           expect(change.type).to.equal('create');
           changes.destroy();
+
           done();
         });
 
@@ -36,6 +37,7 @@ describe('PersistedModel.createChangeStream()', function() {
           changes.on('data', function(change) {
             expect(change.type).to.equal('update');
             changes.destroy();
+
             done();
           });
           newScore.updateAttributes({
@@ -52,6 +54,7 @@ describe('PersistedModel.createChangeStream()', function() {
           changes.on('data', function(change) {
             expect(change.type).to.equal('remove');
             changes.destroy();
+
             done();
           });
 

--- a/test/change.test.js
+++ b/test/change.test.js
@@ -32,9 +32,11 @@ describe('Change', function() {
     };
     TestModel.create(test.data, function(err, model) {
       if (err) return done(err);
+
       test.model = model;
       test.modelId = model.id;
       test.revisionForModel = Change.revisionForInst(model);
+
       done();
     });
   });
@@ -65,6 +67,7 @@ describe('Change', function() {
         var test = this;
         Change.rectifyModelChanges(this.modelName, [this.modelId], function(err, trackedChanges) {
           if (err) return done(err);
+
           done();
         });
       });
@@ -73,6 +76,7 @@ describe('Change', function() {
         var test = this;
         Change.find(function(err, trackedChanges) {
           assert.equal(trackedChanges[0].modelId, test.modelId.toString());
+
           done();
         });
       });
@@ -80,6 +84,7 @@ describe('Change', function() {
       it('should only create one change', function(done) {
         Change.count(function(err, count) {
           assert.equal(count, 1);
+
           done();
         });
       });
@@ -102,6 +107,7 @@ describe('Change', function() {
         Change.find()
           .then(function(trackedChanges) {
             assert.equal(trackedChanges[0].modelId, test.modelId.toString());
+
             done();
           })
           .catch(done);
@@ -111,6 +117,7 @@ describe('Change', function() {
         Change.count()
           .then(function(count) {
             assert.equal(count, 1);
+
             done();
           })
           .catch(done);
@@ -124,7 +131,9 @@ describe('Change', function() {
         var test = this;
         Change.findOrCreateChange(this.modelName, this.modelId, function(err, result) {
           if (err) return done(err);
+
           test.result = result;
+
           done();
         });
       });
@@ -133,7 +142,9 @@ describe('Change', function() {
         var test = this;
         Change.findById(this.result.id, function(err, change) {
           if (err) return done(err);
+
           assert.equal(change.id, test.result.id);
+
           done();
         });
       });
@@ -145,6 +156,7 @@ describe('Change', function() {
         Change.findOrCreateChange(this.modelName, this.modelId)
         .then(function(result) {
           test.result = result;
+
           done();
         })
         .catch(done);
@@ -154,7 +166,9 @@ describe('Change', function() {
         var test = this;
         Change.findById(this.result.id, function(err, change) {
           if (err) return done(err);
+
           assert.equal(change.id, test.result.id);
+
           done();
         });
       });
@@ -168,6 +182,7 @@ describe('Change', function() {
           modelId: test.modelId,
         }, function(err, change) {
           test.existingChange = change;
+
           done();
         });
       });
@@ -176,7 +191,9 @@ describe('Change', function() {
         var test = this;
         Change.findOrCreateChange(this.modelName, this.modelId, function(err, result) {
           if (err) return done(err);
+
           test.result = result;
+
           done();
         });
       });
@@ -184,6 +201,7 @@ describe('Change', function() {
       it('should find the entry', function(done) {
         var test = this;
         assert.equal(test.existingChange.id, test.result.id);
+
         done();
       });
     });
@@ -199,6 +217,7 @@ describe('Change', function() {
         },
         function(err, ch) {
           change = ch;
+
           done(err);
         });
     });
@@ -207,6 +226,7 @@ describe('Change', function() {
       var test = this;
       change.rectify(function(err, ch) {
         assert.equal(ch.rev, test.revisionForModel);
+
         done();
       });
     });
@@ -230,6 +250,7 @@ describe('Change', function() {
           expect(change.type(), 'type').to.equal('update');
           expect(change.prev, 'prev').to.equal(originalRev);
           expect(change.rev, 'rev').to.equal(test.revisionForModel);
+
           next();
         },
       ], done);
@@ -241,7 +262,9 @@ describe('Change', function() {
       function checkpoint(next) {
         TestModel.checkpoint(function(err, inst) {
           if (err) return next(err);
+
           cp = inst.seq;
+
           next();
         });
       }
@@ -252,6 +275,7 @@ describe('Change', function() {
         model.name += 'updated';
         model.save(function(err) {
           test.revisionForModel = Change.revisionForInst(model);
+
           next(err);
         });
       }
@@ -267,8 +291,10 @@ describe('Change', function() {
 
         change.rectify(function(err, c) {
           if (err) return done(err);
+
           expect(c.rev, 'rev').to.equal(originalRev); // sanity check
           expect(c.checkpoint, 'checkpoint').to.equal(originalCheckpoint);
+
           done();
         });
       });
@@ -281,6 +307,7 @@ describe('Change', function() {
       Change.findOrCreateChange(this.modelName, this.modelId)
         .then(function(ch) {
           change = ch;
+
           done();
         })
         .catch(done);
@@ -291,6 +318,7 @@ describe('Change', function() {
       change.rectify()
         .then(function(ch) {
           assert.equal(ch.rev, test.revisionForModel);
+
           done();
         })
         .catch(done);
@@ -307,6 +335,7 @@ describe('Change', function() {
 
       change.currentRevision(function(err, rev) {
         assert.equal(rev, test.revisionForModel);
+
         done();
       });
     });
@@ -323,6 +352,7 @@ describe('Change', function() {
       change.currentRevision()
       .then(function(rev) {
         assert.equal(rev, test.revisionForModel);
+
         done();
       })
       .catch(done);
@@ -463,8 +493,10 @@ describe('Change', function() {
 
       Change.diff(this.modelName, 0, remoteChanges, function(err, diff) {
         if (err) return done(err);
+
         assert.equal(diff.deltas.length, 1);
         assert.equal(diff.conflicts.length, 1);
+
         done();
       });
     });
@@ -483,6 +515,7 @@ describe('Change', function() {
         .then(function(diff) {
           assert.equal(diff.deltas.length, 1);
           assert.equal(diff.conflicts.length, 1);
+
           done();
         })
         .catch(done);
@@ -498,6 +531,7 @@ describe('Change', function() {
       };
       Change.diff(this.modelName, 0, [updateRecord], function(err, diff) {
         if (err) return done(err);
+
         expect(diff.conflicts, 'conflicts').to.have.length(0);
         expect(diff.deltas, 'deltas').to.have.length(1);
         var actual = diff.deltas[0].toObject();
@@ -509,6 +543,7 @@ describe('Change', function() {
           prev: 'foo', // this is the current local revision
           rev: 'foo-new',
         });
+
         done();
       });
     });
@@ -525,6 +560,7 @@ describe('Change', function() {
       // with rev=foo CP=1
       Change.diff(this.modelName, 2, [updateRecord], function(err, diff) {
         if (err) return done(err);
+
         expect(diff.conflicts, 'conflicts').to.have.length(0);
         expect(diff.deltas, 'deltas').to.have.length(1);
         var actual = diff.deltas[0].toObject();
@@ -536,6 +572,7 @@ describe('Change', function() {
           prev: 'foo', // this is the current local revision
           rev: 'foo-new',
         });
+
         done();
       });
     });
@@ -551,6 +588,7 @@ describe('Change', function() {
 
       Change.diff(this.modelName, 0, [updateRecord], function(err, diff) {
         if (err) return done(err);
+
         expect(diff.conflicts).to.have.length(0);
         expect(diff.deltas).to.have.length(1);
         var actual = diff.deltas[0].toObject();
@@ -562,6 +600,7 @@ describe('Change', function() {
           prev: null, // this is the current local revision
           rev: 'new-rev',
         });
+
         done();
       });
     });

--- a/test/checkpoint.test.js
+++ b/test/checkpoint.test.js
@@ -25,7 +25,9 @@ describe('Checkpoint', function() {
         function(next) {
           Checkpoint.current(function(err, seq) {
             if (err) next(err);
+
             expect(seq).to.equal(3);
+
             next();
           });
         },
@@ -38,9 +40,12 @@ describe('Checkpoint', function() {
         function(next) { Checkpoint.current(next); },
       ], function(err, list) {
         if (err) return done(err);
+
         Checkpoint.find(function(err, data) {
           if (err) return done(err);
+
           expect(data).to.have.length(1);
+
           done();
         });
       });
@@ -52,6 +57,7 @@ describe('Checkpoint', function() {
         function(next) { Checkpoint.bumpLastSeq(next); },
       ], function(err, list) {
         if (err) return done(err);
+
         Checkpoint.find(function(err, data) {
           if (err) return done(err);
           // The invariant "we have at most 1 checkpoint instance" is preserved
@@ -64,6 +70,7 @@ describe('Checkpoint', function() {
           // should be 2.
           expect(list.map(function(it) { return it.seq; }))
             .to.eql([2, 2]);
+
           done();
         });
       });
@@ -73,6 +80,7 @@ describe('Checkpoint', function() {
     function(done) {
       Checkpoint.current(function(err, seq) {
         expect(seq).to.equal(1);
+
         done(err);
       });
     });
@@ -83,6 +91,7 @@ describe('Checkpoint', function() {
         // `bumpLastSeq` for the first time not only initializes it to one,
         // but also increments the initialized value by one.
         expect(cp.seq).to.equal(2);
+
         done(err);
       });
     });

--- a/test/e2e/remote-connector.e2e.js
+++ b/test/e2e/remote-connector.e2e.js
@@ -24,7 +24,9 @@ describe('RemoteConnector', function() {
       foo: 'bar',
     }, function(err, inst) {
       if (err) return done(err);
+
       assert(inst.id);
+
       done();
     });
   });
@@ -35,7 +37,9 @@ describe('RemoteConnector', function() {
     });
     m.save(function(err, data) {
       if (err) return done(err);
+
       assert(data.foo === 'bar');
+
       done();
     });
   });

--- a/test/e2e/replication.e2e.js
+++ b/test/e2e/replication.e2e.js
@@ -32,8 +32,10 @@ describe('Replication', function() {
     }, function(err, created) {
       LocalTestModel.replicate(0, TestModel, function() {
         if (err) return done(err);
+
         TestModel.findOne({ n: RANDOM }, function(err, found) {
           assert.equal(created.id, found.id);
+
           done();
         });
       });

--- a/test/email.test.js
+++ b/test/email.test.js
@@ -69,6 +69,7 @@ describe('Email and SMTP', function() {
         assert(mail.response);
         assert(mail.envelope);
         assert(mail.messageId);
+
         done(err);
       });
     });
@@ -86,6 +87,7 @@ describe('Email and SMTP', function() {
         assert(mail.response);
         assert(mail.envelope);
         assert(mail.messageId);
+
         done(err);
       });
     });

--- a/test/error-handler.test.js
+++ b/test/error-handler.test.js
@@ -20,6 +20,7 @@ describe('loopback.errorHandler(options)', function() {
       .get('/url-does-not-exist')
       .end(function(err, res) {
         assert.ok(res.error.text.match(/<ul id="stacktrace"><li> &nbsp; &nbsp;at raiseUrlNotFoundError/));
+
         done();
       });
   });
@@ -35,6 +36,7 @@ describe('loopback.errorHandler(options)', function() {
       .get('/url-does-not-exist')
       .end(function(err, res) {
         assert.ok(res.error.text.match(/<ul id="stacktrace"><\/ul>/));
+
         done();
       });
   });
@@ -58,6 +60,7 @@ describe('loopback.errorHandler(options)', function() {
       //assert
       expect(errorLogged)
         .to.have.property('message', 'Cannot GET /url-does-not-exist');
+
       done();
     });
   });

--- a/test/helpers/loopback-testing-helper.js
+++ b/test/helpers/loopback-testing-helper.js
@@ -37,6 +37,7 @@ _beforeEach.withApp = function(app) {
     if (app.booting) {
       return app.once('booted', done);
     }
+
     done();
   });
 };
@@ -78,9 +79,11 @@ _beforeEach.givenModel = function(modelName, attrs, optionalHandler) {
       if (err) {
         console.error(err.message);
         if (err.details) console.error(err.details);
+
         done(err);
       } else {
         test[modelKey] = result;
+
         done();
       }
     });
@@ -107,6 +110,7 @@ _beforeEach.givenLoggedInUser = function(credentials, optionalHandler) {
         done(err);
       } else {
         test.loggedInAccessToken = token;
+
         done();
       }
     });
@@ -116,7 +120,9 @@ _beforeEach.givenLoggedInUser = function(credentials, optionalHandler) {
     var test = this;
     this.loggedInAccessToken.destroy(function(err) {
       if (err) return done(err);
+
       test.loggedInAccessToken = undefined;
+
       done();
     });
   });
@@ -176,6 +182,7 @@ _describe.whenCalledRemotely = function(verb, url, data, cb) {
         test.req = test.http.req;
         test.res = test.http.res;
         delete test.url;
+
         cb();
       });
     });
@@ -187,6 +194,7 @@ _describe.whenCalledRemotely = function(verb, url, data, cb) {
 _describe.whenLoggedInAsUser = function(credentials, cb) {
   describe('when logged in as user', function() {
     _beforeEach.givenLoggedInUser(credentials);
+
     cb();
   });
 };

--- a/test/hidden-properties.test.js
+++ b/test/hidden-properties.test.js
@@ -46,8 +46,10 @@ describe('hidden properties', function() {
        .expect(200)
        .end(function(err, res) {
          if (err) return done(err);
+
          var product = res.body[0];
          assert.equal(product.secret, undefined);
+
          done();
        });
   });
@@ -60,9 +62,11 @@ describe('hidden properties', function() {
       .expect(200)
       .end(function(err, res) {
         if (err) return done(err);
+
         var category = res.body[0];
         var product = category.products[0];
         assert.equal(product.secret, undefined);
+
         done();
       });
   });

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -21,7 +21,9 @@ describe('loopback application', function() {
           'X',
         function(err, res) {
           if (err) return done(err);
+
           expect(res).to.match(/\nX$/);
+
           done();
         });
     });

--- a/test/loopback.test.js
+++ b/test/loopback.test.js
@@ -587,6 +587,7 @@ describe('loopback', function() {
         } else {
           ctxx.result.data = 'context not available';
         }
+
         next();
       });
 
@@ -594,7 +595,9 @@ describe('loopback', function() {
         .get('/TestModels/test')
         .end(function(err, res) {
           if (err) return done(err);
+
           expect(res.body.data).to.equal('a value stored in context');
+
           done();
         });
     });
@@ -608,6 +611,7 @@ describe('loopback', function() {
           var ctx = loopback.getCurrentContext();
           expect(ctx).is.an('object');
           expect(ctx.get('test-key')).to.equal('test-value');
+
           done();
         });
       });

--- a/test/memory.test.js
+++ b/test/memory.test.js
@@ -33,6 +33,7 @@ describe('Memory Connector', function() {
     function count() {
       Product.count(function(err, count) {
         assert.equal(count, 3);
+
         done();
       });
     }

--- a/test/model.application.test.js
+++ b/test/model.application.test.js
@@ -21,6 +21,7 @@ describe('Application', function() {
         assert.equal(app.owner, 'rfeng');
         assert.equal(app.name, 'MyTestApp');
         assert.equal(app.description, 'My test application');
+
         done(err, result);
       });
   });
@@ -33,6 +34,7 @@ describe('Application', function() {
         assert.equal(app.owner, 'rfeng');
         assert.equal(app.name, 'MyTestApp');
         assert.equal(app.description, 'My test application');
+
         done();
       })
       .catch(function(err) {
@@ -56,6 +58,7 @@ describe('Application', function() {
       assert(app.created);
       assert(app.modified);
       assert.equal(typeof app.id, 'string');
+
       done(err, result);
     });
   });
@@ -106,6 +109,7 @@ describe('Application', function() {
             serverApiKey: 'serverKey',
           },
         });
+
         done(err, result);
       });
   });
@@ -125,6 +129,7 @@ describe('Application', function() {
         assert(app.created);
         assert(app.modified);
         registeredApp = app;
+
         done(err, result);
       });
   });
@@ -150,6 +155,7 @@ describe('Application', function() {
       assert(app.created);
       assert(app.modified);
       registeredApp = app;
+
       done(err, result);
     });
   });
@@ -176,6 +182,7 @@ describe('Application', function() {
       assert(app.created);
       assert(app.modified);
       registeredApp = app;
+
       done();
     })
     .catch(function(err) {
@@ -189,6 +196,7 @@ describe('Application', function() {
       assert(app.id);
       assert(app.id === registeredApp.id);
       registeredApp = app;
+
       done(err, result);
     });
   });
@@ -200,6 +208,7 @@ describe('Application', function() {
       assert(app.id);
       assert(app.id === registeredApp.id);
       registeredApp = app;
+
       done();
     })
     .catch(function(err) {
@@ -212,6 +221,7 @@ describe('Application', function() {
       function(err, result) {
         assert.equal(result.application.id, registeredApp.id);
         assert.equal(result.keyType, 'clientKey');
+
         done(err, result);
       });
   });
@@ -222,6 +232,7 @@ describe('Application', function() {
       .then(function(result) {
         assert.equal(result.application.id, registeredApp.id);
         assert.equal(result.keyType, 'clientKey');
+
         done();
       })
       .catch(function(err) {
@@ -234,6 +245,7 @@ describe('Application', function() {
       function(err, result) {
         assert.equal(result.application.id, registeredApp.id);
         assert.equal(result.keyType, 'javaScriptKey');
+
         done(err, result);
       });
   });
@@ -243,6 +255,7 @@ describe('Application', function() {
       function(err, result) {
         assert.equal(result.application.id, registeredApp.id);
         assert.equal(result.keyType, 'restApiKey');
+
         done(err, result);
       });
   });
@@ -252,6 +265,7 @@ describe('Application', function() {
       function(err, result) {
         assert.equal(result.application.id, registeredApp.id);
         assert.equal(result.keyType, 'masterKey');
+
         done(err, result);
       });
   });
@@ -261,6 +275,7 @@ describe('Application', function() {
       function(err, result) {
         assert.equal(result.application.id, registeredApp.id);
         assert.equal(result.keyType, 'windowsKey');
+
         done(err, result);
       });
   });
@@ -269,6 +284,7 @@ describe('Application', function() {
     Application.authenticate(registeredApp.id, 'invalid-key',
       function(err, result) {
         assert(!result);
+
         done(err, result);
       });
   });
@@ -277,6 +293,7 @@ describe('Application', function() {
     Application.authenticate(registeredApp.id, 'invalid-key')
     .then(function(result) {
       assert(!result);
+
       done();
     })
     .catch(function(err) {
@@ -313,6 +330,7 @@ describe('Application subclass', function() {
             Application.findById(app.id, function(err, myApp) {
               assert(!err);
               assert(myApp === null);
+
               done(err, myApp);
             });
           });

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -142,6 +142,7 @@ describe.onServer('Remote Methods', function() {
             User.destroyAll(function() {
               User.count(function(err, count) {
                 assert.equal(count, 0);
+
                 done();
               });
             });
@@ -158,7 +159,9 @@ describe.onServer('Remote Methods', function() {
         .expect(200)
         .end(function(err, res) {
           if (err) return done(err);
+
           assert.equal(res.body, 123);
+
           done();
         });
     });
@@ -168,12 +171,12 @@ describe.onServer('Remote Methods', function() {
         .get('/users/not-found')
         .expect(404)
         .end(function(err, res) {
-          if (err) {
-            return done(err);
-          }
+          if (err) return done(err);
+
           var errorResponse = res.body.error;
           assert(errorResponse);
           assert.equal(errorResponse.code, 'MODEL_NOT_FOUND');
+
           done();
         });
     });
@@ -186,6 +189,7 @@ describe.onServer('Remote Methods', function() {
         .expect(200)
         .end(function(err, res) {
           if (err) return done(err);
+
           var userId = res.body.id;
           assert(userId);
           request(app)
@@ -194,8 +198,10 @@ describe.onServer('Remote Methods', function() {
             .expect(200)
             .end(function(err, res) {
               if (err) return done(err);
+
               assert.equal(res.body.first, 'x', 'first should be x');
               assert(res.body.last === undefined, 'last should not be present');
+
               done();
             });
         });
@@ -209,6 +215,7 @@ describe.onServer('Remote Methods', function() {
         .expect(200)
         .end(function(err, res) {
           if (err) return done(err);
+
           var userId = res.body.id;
           assert(userId);
           request(app)
@@ -218,6 +225,7 @@ describe.onServer('Remote Methods', function() {
             .expect(200)
             .end(function(err, res) {
               if (err) return done(err);
+
               var post = res.body;
               request(app)
                 .get('/users/' + userId + '?filter[include]=posts')
@@ -225,9 +233,11 @@ describe.onServer('Remote Methods', function() {
                 .expect(200)
                 .end(function(err, res) {
                   if (err) return done(err);
+
                   assert.equal(res.body.first, 'x', 'first should be x');
                   assert.equal(res.body.last, 'y', 'last should be y');
                   assert.deepEqual(post, res.body.posts[0]);
+
                   done();
                 });
             });
@@ -241,6 +251,7 @@ describe.onServer('Remote Methods', function() {
 
       User.beforeRemote('create', function(ctx, user, next) {
         hookCalled = true;
+
         next();
       });
 
@@ -252,7 +263,9 @@ describe.onServer('Remote Methods', function() {
         .expect(200)
         .end(function(err, res) {
           if (err) return done(err);
+
           assert(hookCalled, 'hook wasnt called');
+
           done();
         });
     });
@@ -266,11 +279,13 @@ describe.onServer('Remote Methods', function() {
       User.beforeRemote('create', function(ctx, user, next) {
         assert(!afterCalled);
         beforeCalled = true;
+
         next();
       });
       User.afterRemote('create', function(ctx, user, next) {
         assert(beforeCalled);
         afterCalled = true;
+
         next();
       });
 
@@ -282,8 +297,10 @@ describe.onServer('Remote Methods', function() {
         .expect(200)
         .end(function(err, res) {
           if (err) return done(err);
+
           assert(beforeCalled, 'before hook was not called');
           assert(afterCalled, 'after hook was not called');
+
           done();
         });
     });
@@ -294,14 +311,17 @@ describe.onServer('Remote Methods', function() {
       var actualError = 'hook not called';
       User.afterRemoteError('login', function(ctx, next) {
         actualError = ctx.error;
+
         next();
       });
 
       request(app).get('/users/sign-in?username=bob&password=123')
         .end(function(err, res) {
           if (err) return done(err);
+
           expect(actualError)
             .to.have.property('message', 'bad username and password!');
+
           done();
         });
     });
@@ -320,6 +340,7 @@ describe.onServer('Remote Methods', function() {
           assert(ctx.res);
           assert(ctx.res.write);
           assert(ctx.res.end);
+
           next();
         });
 
@@ -331,7 +352,9 @@ describe.onServer('Remote Methods', function() {
           .expect(200)
           .end(function(err, res) {
             if (err) return done(err);
+
             assert(hookCalled);
+
             done();
           });
       });
@@ -349,6 +372,7 @@ describe.onServer('Remote Methods', function() {
           assert(ctx.res);
           assert(ctx.res.write);
           assert(ctx.res.end);
+
           next();
         });
 
@@ -360,7 +384,9 @@ describe.onServer('Remote Methods', function() {
           .expect(200)
           .end(function(err, res) {
             if (err) return done(err);
+
             assert(hookCalled);
+
             done();
           });
       });
@@ -385,6 +411,7 @@ describe.onServer('Remote Methods', function() {
               book.chapters({ where: { title: 'Chapter 1' }}, function(err, chapters) {
                 assert.equal(chapters.length, 1);
                 assert.equal(chapters[0].title, 'Chapter 1');
+
                 done();
               });
             });
@@ -529,6 +556,7 @@ describe.onServer('Remote Methods', function() {
     it('Get the Source Id', function(done) {
       User.getSourceId(function(err, id) {
         assert.equal('memory-user', id);
+
         done();
       });
     });
@@ -547,6 +575,7 @@ describe.onServer('Remote Methods', function() {
         if (err) return done(err);
 
         assert.equal(result, current + 1);
+
         done();
       });
 
@@ -646,7 +675,9 @@ describe.onServer('Remote Methods', function() {
       app.model(TestModel, { dataSource: 'db' });
       TestModel.getApp(function(err, a) {
         if (err) return done(err);
+
         expect(a).to.equal(app);
+
         done();
       });
       // fails on time-out when not implemented correctly
@@ -655,7 +686,9 @@ describe.onServer('Remote Methods', function() {
     it('calls the callback after attached', function(done) {
       TestModel.getApp(function(err, a) {
         if (err) return done(err);
+
         expect(a).to.equal(app);
+
         done();
       });
       app.model(TestModel, { dataSource: 'db' });

--- a/test/registries.test.js
+++ b/test/registries.test.js
@@ -43,6 +43,7 @@ describe('Registry', function() {
               expect(bars.map(function(f) {
                 return f.parent;
               })).to.eql(['bar']);
+
               done();
             });
           });

--- a/test/relations.integration.js
+++ b/test/relations.integration.js
@@ -69,10 +69,12 @@ describe('relations - integration', function() {
       app.models.Team.create({ name: 'Team 1' },
         function(err, team) {
           if (err) return done(err);
+
           test.team = team;
           app.models.Reader.create({ name: 'Reader 1' },
           function(err, reader) {
             if (err) return done(err);
+
             test.reader = reader;
             reader.pictures.create({ name: 'Picture 1' });
             reader.pictures.create({ name: 'Picture 2' });
@@ -93,12 +95,13 @@ describe('relations - integration', function() {
         .query({ 'filter': { 'include': 'pictures' }})
         .expect(200, function(err, res) {
           if (err) return done(err);
-          // console.log(res.body);
+
           expect(res.body.name).to.be.equal('Reader 1');
           expect(res.body.pictures).to.be.eql([
             { name: 'Picture 1', id: 1, imageableId: 1, imageableType: 'Reader' },
             { name: 'Picture 2', id: 2, imageableId: 1, imageableType: 'Reader' },
           ]);
+
           done();
         });
     });
@@ -109,10 +112,11 @@ describe('relations - integration', function() {
         .query({ 'filter': { 'include': 'imageable' }})
         .expect(200, function(err, res) {
           if (err) return done(err);
-          // console.log(res.body);
+
           expect(res.body[0].name).to.be.equal('Picture 1');
           expect(res.body[1].name).to.be.equal('Picture 2');
           expect(res.body[0].imageable).to.be.eql({ name: 'Reader 1', id: 1, teamId: 1 });
+
           done();
         });
     });
@@ -126,10 +130,12 @@ describe('relations - integration', function() {
         }}})
         .expect(200, function(err, res) {
           if (err) return done(err);
+
           expect(res.body[0].name).to.be.equal('Picture 1');
           expect(res.body[1].name).to.be.equal('Picture 2');
           expect(res.body[0].imageable.name).to.be.eql('Reader 1');
           expect(res.body[0].imageable.team).to.be.eql({ name: 'Team 1', id: 1 });
+
           done();
         });
     });
@@ -140,7 +146,9 @@ describe('relations - integration', function() {
       this.get('/api/stores/superStores')
         .expect(200, function(err, res) {
           if (err) return done(err);
+
           expect(res.body).to.be.array;
+
           done();
         });
     });
@@ -190,8 +198,10 @@ describe('relations - integration', function() {
         this.http.send(this.newWidget);
         this.http.end(function(err) {
           if (err) return done(err);
+
           this.req = this.http.req;
           this.res = this.http.res;
+
           done();
         }.bind(this));
       });
@@ -217,7 +227,9 @@ describe('relations - integration', function() {
           storeId: this.store.id,
         }, function(err, count) {
           if (err) return done(err);
+
           assert.equal(count, 2);
+
           done();
         });
       });
@@ -232,6 +244,7 @@ describe('relations - integration', function() {
       }, function(err, widget) {
         self.widget = widget;
         self.url = '/api/stores/' + self.store.id + '/widgets/' + widget.id;
+
         done();
       });
     });
@@ -305,6 +318,7 @@ describe('relations - integration', function() {
       }, function(err, widget) {
         self.widget = widget;
         self.url = '/api/widgets/' + self.widget.id + '/store';
+
         done();
       });
     });
@@ -338,6 +352,7 @@ describe('relations - integration', function() {
             name: 'ph1',
           }, function(err, physician) {
             root.physician = physician;
+
             done();
           });
         },
@@ -350,6 +365,7 @@ describe('relations - integration', function() {
             root.patient = patient;
             root.relUrl = '/api/physicians/' + root.physician.id +
               '/patients/rel/' + root.patient.id;
+
             done();
           });
         } : function(done) {
@@ -359,6 +375,7 @@ describe('relations - integration', function() {
             root.patient = patient;
             root.relUrl = '/api/physicians/' + root.physician.id +
               '/patients/rel/' + root.patient.id;
+
             done();
           });
         }], function(err, done) {
@@ -373,6 +390,7 @@ describe('relations - integration', function() {
           self.url = root.relUrl;
           self.patient = root.patient;
           self.physician = root.physician;
+
           done(err);
         });
       });
@@ -389,6 +407,7 @@ describe('relations - integration', function() {
           app.models.appointment.find(function(err, apps) {
             assert.equal(apps.length, 1);
             assert.equal(apps[0].patientId, self.patient.id);
+
             done();
           });
         });
@@ -398,6 +417,7 @@ describe('relations - integration', function() {
           self.physician.patients(function(err, patients) {
             assert.equal(patients.length, 1);
             assert.equal(patients[0].id, self.patient.id);
+
             done();
           });
         });
@@ -411,6 +431,7 @@ describe('relations - integration', function() {
           self.url = root.relUrl;
           self.patient = root.patient;
           self.physician = root.physician;
+
           done(err);
         });
       });
@@ -433,6 +454,7 @@ describe('relations - integration', function() {
             assert.equal(apps[0].patientId, self.patient.id);
             assert.equal(apps[0].physicianId, self.physician.id);
             assert.equal(apps[0].date.getTime(), NOW);
+
             done();
           });
         });
@@ -442,6 +464,7 @@ describe('relations - integration', function() {
           self.physician.patients(function(err, patients) {
             assert.equal(patients.length, 1);
             assert.equal(patients[0].id, self.patient.id);
+
             done();
           });
         });
@@ -455,6 +478,7 @@ describe('relations - integration', function() {
           self.url = root.relUrl;
           self.patient = root.patient;
           self.physician = root.physician;
+
           done(err);
         });
       });
@@ -474,6 +498,7 @@ describe('relations - integration', function() {
             '/patients/rel/' + '999';
           self.patient = root.patient;
           self.physician = root.physician;
+
           done(err);
         });
       });
@@ -492,6 +517,7 @@ describe('relations - integration', function() {
           self.url = root.relUrl;
           self.patient = root.patient;
           self.physician = root.physician;
+
           done(err);
         });
       });
@@ -501,6 +527,7 @@ describe('relations - integration', function() {
         app.models.appointment.find(function(err, apps) {
           assert.equal(apps.length, 1);
           assert.equal(apps[0].patientId, self.patient.id);
+
           done();
         });
       });
@@ -510,6 +537,7 @@ describe('relations - integration', function() {
         self.physician.patients(function(err, patients) {
           assert.equal(patients.length, 1);
           assert.equal(patients[0].id, self.patient.id);
+
           done();
         });
       });
@@ -523,6 +551,7 @@ describe('relations - integration', function() {
           var self = this;
           app.models.appointment.find(function(err, apps) {
             assert.equal(apps.length, 0);
+
             done();
           });
         });
@@ -532,6 +561,7 @@ describe('relations - integration', function() {
           // Need to refresh the cache
           self.physician.patients(true, function(err, patients) {
             assert.equal(patients.length, 0);
+
             done();
           });
         });
@@ -546,6 +576,7 @@ describe('relations - integration', function() {
             '/patients/' + root.patient.id;
           self.patient = root.patient;
           self.physician = root.physician;
+
           done(err);
         });
       });
@@ -566,6 +597,7 @@ describe('relations - integration', function() {
             '/patients/' + root.patient.id;
           self.patient = root.patient;
           self.physician = root.physician;
+
           done(err);
         });
       });
@@ -579,6 +611,7 @@ describe('relations - integration', function() {
           var self = this;
           app.models.appointment.find(function(err, apps) {
             assert.equal(apps.length, 0);
+
             done();
           });
         });
@@ -588,6 +621,7 @@ describe('relations - integration', function() {
           // Need to refresh the cache
           self.physician.patients(true, function(err, patients) {
             assert.equal(patients.length, 0);
+
             done();
           });
         });
@@ -596,6 +630,7 @@ describe('relations - integration', function() {
           var self = this;
           app.models.patient.find(function(err, patients) {
             assert.equal(patients.length, 0);
+
             done();
           });
         });
@@ -626,7 +661,9 @@ describe('relations - integration', function() {
         name: 'a-product',
       }, function(err, product) {
         if (err) return done(err);
+
         test.product = product;
+
         done();
       });
     });
@@ -635,6 +672,7 @@ describe('relations - integration', function() {
       app.models.category.create({ name: 'another-category' },
         function(err, cat) {
           if (err) return done(err);
+
           cat.products.create({ name: 'another-product' }, done);
         });
     });
@@ -649,12 +687,14 @@ describe('relations - integration', function() {
       this.get('/api/products?filter[where][categoryId]=' + this.category.id)
         .expect(200, function(err, res) {
           if (err) return done(err);
+
           expect(res.body).to.eql([
             {
               id: expectedProduct.id,
               name: expectedProduct.name,
             },
           ]);
+
           done();
         });
     });
@@ -664,12 +704,14 @@ describe('relations - integration', function() {
       this.get('/api/categories/' + this.category.id + '/products')
         .expect(200, function(err, res) {
           if (err) return done(err);
+
           expect(res.body).to.eql([
             {
               id: expectedProduct.id,
               name: expectedProduct.name,
             },
           ]);
+
           done();
         });
     });
@@ -682,6 +724,7 @@ describe('relations - integration', function() {
       this.get(url)
         .expect(200, function(err, res) {
           if (err) return done(err);
+
           expect(res.body).to.have.property('products');
           expect(res.body.products).to.eql([
             {
@@ -689,6 +732,7 @@ describe('relations - integration', function() {
               name: expectedProduct.name,
             },
           ]);
+
           done();
         });
     });
@@ -702,6 +746,7 @@ describe('relations - integration', function() {
       this.get(url)
         .expect(200, function(err, res) {
           if (err) return done(err);
+
           expect(res.body).to.have.property('products');
           expect(res.body.products).to.eql([
             {
@@ -709,6 +754,7 @@ describe('relations - integration', function() {
               name: expectedProduct.name,
             },
           ]);
+
           done();
         });
     });
@@ -735,7 +781,9 @@ describe('relations - integration', function() {
       app.models.group.create({ name: 'Group 1' },
         function(err, group) {
           if (err) return done(err);
+
           test.group = group;
+
           done();
         });
     });
@@ -753,6 +801,7 @@ describe('relations - integration', function() {
           expect(res.body).to.be.eql(
             { url: 'http://image.url' }
           );
+
           done();
         });
     });
@@ -763,10 +812,12 @@ describe('relations - integration', function() {
       this.get(url)
         .expect(200, function(err, res) {
           if (err) return done(err);
+
           expect(res.body.name).to.be.equal('Group 1');
           expect(res.body.poster).to.be.eql(
             { url: 'http://image.url' }
           );
+
           done();
         });
     });
@@ -777,9 +828,11 @@ describe('relations - integration', function() {
       this.get(url)
         .expect(200, function(err, res) {
           if (err) return done(err);
+
           expect(res.body).to.be.eql(
             { url: 'http://image.url' }
           );
+
           done();
         });
     });
@@ -791,6 +844,7 @@ describe('relations - integration', function() {
         .send({ url: 'http://changed.url' })
         .expect(200, function(err, res) {
           expect(res.body.url).to.be.equal('http://changed.url');
+
           done();
         });
     });
@@ -801,9 +855,11 @@ describe('relations - integration', function() {
       this.get(url)
         .expect(200, function(err, res) {
           if (err) return done(err);
+
           expect(res.body).to.be.eql(
             { url: 'http://changed.url' }
           );
+
           done();
         });
     });
@@ -840,6 +896,7 @@ describe('relations - integration', function() {
       app.models.todoList.create({ name: 'List A' },
         function(err, list) {
           if (err) return done(err);
+
           test.todoList = list;
           list.items.build({ content: 'Todo 1' });
           list.items.build({ content: 'Todo 2' });
@@ -857,11 +914,13 @@ describe('relations - integration', function() {
       this.get(url)
         .expect(200, function(err, res) {
           if (err) return done(err);
+
           expect(res.body.name).to.be.equal('List A');
           expect(res.body.todoItems).to.be.eql([
             { content: 'Todo 1', id: 1 },
             { content: 'Todo 2', id: 2 },
           ]);
+
           done();
         });
     });
@@ -872,10 +931,12 @@ describe('relations - integration', function() {
       this.get(url)
         .expect(200, function(err, res) {
           if (err) return done(err);
+
           expect(res.body).to.be.eql([
             { content: 'Todo 1', id: 1 },
             { content: 'Todo 2', id: 2 },
           ]);
+
           done();
         });
     });
@@ -887,9 +948,11 @@ describe('relations - integration', function() {
       this.get(url)
         .expect(200, function(err, res) {
           if (err) return done(err);
+
           expect(res.body).to.be.eql([
             { content: 'Todo 2', id: 2 },
           ]);
+
           done();
         });
     });
@@ -903,6 +966,7 @@ describe('relations - integration', function() {
         .send({ content: 'Todo 3' })
         .expect(200, function(err, res) {
           expect(res.body).to.be.eql(expected);
+
           done();
         });
     });
@@ -913,11 +977,13 @@ describe('relations - integration', function() {
       this.get(url)
         .expect(200, function(err, res) {
           if (err) return done(err);
+
           expect(res.body).to.be.eql([
             { content: 'Todo 1', id: 1 },
             { content: 'Todo 2', id: 2 },
             { content: 'Todo 3', id: 3 },
           ]);
+
           done();
         });
     });
@@ -928,9 +994,11 @@ describe('relations - integration', function() {
       this.get(url)
         .expect(200, function(err, res) {
           if (err) return done(err);
+
           expect(res.body).to.be.eql(
             { content: 'Todo 3', id: 3 }
           );
+
           done();
         });
     });
@@ -951,10 +1019,12 @@ describe('relations - integration', function() {
       this.get(url)
         .expect(200, function(err, res) {
           if (err) return done(err);
+
           expect(res.body).to.be.eql([
             { content: 'Todo 1', id: 1 },
             { content: 'Todo 3', id: 3 },
           ]);
+
           done();
         });
     });
@@ -963,9 +1033,11 @@ describe('relations - integration', function() {
       var url = '/api/todo-lists/' + this.todoList.id + '/items/2';
       this.get(url).expect(404, function(err, res) {
         if (err) return done(err);
+
         expect(res.body.error.status).to.be.equal(404);
         expect(res.body.error.message).to.be.equal('Unknown "todoItem" id "2".');
         expect(res.body.error.code).to.be.equal('MODEL_NOT_FOUND');
+
         done();
       });
     });
@@ -1015,6 +1087,7 @@ describe('relations - integration', function() {
       app.models.recipe.create({ name: 'Recipe' },
         function(err, recipe) {
           if (err) return done(err);
+
           test.recipe = recipe;
           recipe.ingredients.create({
             name: 'Chocolate' },
@@ -1029,6 +1102,7 @@ describe('relations - integration', function() {
       var test = this;
       app.models.ingredient.create({ name: 'Sugar' }, function(err, ing) {
         test.ingredient2 = ing.id;
+
         done();
       });
     });
@@ -1049,8 +1123,10 @@ describe('relations - integration', function() {
       this.get(url)
         .expect(200, function(err, res) {
           if (err) return done(err);
+
           expect(res.body.ingredientIds).to.eql([test.ingredient1]);
           expect(res.body).to.not.have.property('ingredients');
+
           done();
         });
     });
@@ -1064,6 +1140,7 @@ describe('relations - integration', function() {
         .expect(200, function(err, res) {
           expect(res.body.name).to.be.eql('Butter');
           test.ingredient3 = res.body.id;
+
           done();
         });
     });
@@ -1075,11 +1152,13 @@ describe('relations - integration', function() {
       this.get(url)
         .expect(200, function(err, res) {
           if (err) return done(err);
+
           expect(res.body).to.be.eql([
             { name: 'Chocolate', id: test.ingredient1 },
             { name: 'Sugar', id: test.ingredient2 },
             { name: 'Butter', id: test.ingredient3 },
           ]);
+
           done();
         });
     });
@@ -1091,10 +1170,12 @@ describe('relations - integration', function() {
       this.get(url)
         .expect(200, function(err, res) {
           if (err) return done(err);
+
           expect(res.body).to.be.eql([
             { name: 'Chocolate', id: test.ingredient1 },
             { name: 'Butter', id: test.ingredient3 },
           ]);
+
           done();
         });
     });
@@ -1107,9 +1188,11 @@ describe('relations - integration', function() {
       this.get(url)
         .expect(200, function(err, res) {
           if (err) return done(err);
+
           expect(res.body).to.be.eql([
             { name: 'Butter', id: test.ingredient3 },
           ]);
+
           done();
         });
     });
@@ -1122,6 +1205,7 @@ describe('relations - integration', function() {
       this.get(url)
         .expect(200, function(err, res) {
           if (err) return done(err);
+
           expect(res.body.ingredientIds).to.eql([
             test.ingredient1, test.ingredient3,
           ]);
@@ -1129,6 +1213,7 @@ describe('relations - integration', function() {
             { name: 'Chocolate', id: test.ingredient1 },
             { name: 'Butter', id: test.ingredient3 },
           ]);
+
           done();
         });
     });
@@ -1141,9 +1226,11 @@ describe('relations - integration', function() {
       this.get(url)
         .expect(200, function(err, res) {
           if (err) return done(err);
+
           expect(res.body).to.be.eql(
             { name: 'Butter', id: test.ingredient3 }
           );
+
           done();
         });
     });
@@ -1157,8 +1244,10 @@ describe('relations - integration', function() {
       this.get(url)
         .expect(200, function(err, res) {
           if (err) return done(err);
+
           expect(res.body.ingredientIds).to.eql(expected);
           expect(res.body).to.not.have.property('ingredients');
+
           done();
         });
     });
@@ -1181,10 +1270,12 @@ describe('relations - integration', function() {
       this.get(url)
         .expect(200, function(err, res) {
           if (err) return done(err);
+
           expect(res.body).to.be.eql([
             { name: 'Chocolate', id: test.ingredient1 },
             { name: 'Sugar', id: test.ingredient2 },
           ]);
+
           done();
         });
     });
@@ -1196,9 +1287,11 @@ describe('relations - integration', function() {
       this.get(url)
         .expect(200, function(err, res) {
           if (err) return done(err);
+
           expect(res.body).to.be.eql([
             { name: 'Chocolate', id: test.ingredient1 },
           ]);
+
           done();
         });
     });
@@ -1213,6 +1306,7 @@ describe('relations - integration', function() {
           expect(res.body).to.be.eql(
             { name: 'Sugar', id: test.ingredient2 }
           );
+
           done();
         });
     });
@@ -1224,10 +1318,12 @@ describe('relations - integration', function() {
       this.get(url)
         .expect(200, function(err, res) {
           if (err) return done(err);
+
           expect(res.body).to.be.eql([
             { name: 'Chocolate', id: test.ingredient1 },
             { name: 'Sugar', id: test.ingredient2 },
           ]);
+
           done();
         });
     });
@@ -1250,9 +1346,11 @@ describe('relations - integration', function() {
       this.get(url)
         .expect(200, function(err, res) {
           if (err) return done(err);
+
           expect(res.body).to.be.eql([
             { name: 'Sugar', id: test.ingredient2 },
           ]);
+
           done();
         });
     });
@@ -1264,10 +1362,12 @@ describe('relations - integration', function() {
       this.get(url)
         .expect(200, function(err, res) {
           if (err) return done(err);
+
           expect(res.body).to.be.eql([
             { name: 'Chocolate', id: test.ingredient1 },
             { name: 'Sugar', id: test.ingredient2 },
           ]);
+
           done();
         });
     });
@@ -1278,8 +1378,10 @@ describe('relations - integration', function() {
       this.get(url)
         .expect(200, function(err, res) {
           if (err) return done(err);
+
           expect(err).to.not.exist;
           expect(res.body.name).to.equal('Photo 1');
+
           done();
         });
     });
@@ -1354,11 +1456,13 @@ describe('relations - integration', function() {
 
       Page.beforeRemote('prototype.__findById__notes', function(ctx, result, next) {
         ctx.res.set('x-before', 'before');
+
         next();
       });
 
       Page.afterRemote('prototype.__findById__notes', function(ctx, result, next) {
         ctx.res.set('x-after', 'after');
+
         next();
       });
     });
@@ -1368,14 +1472,17 @@ describe('relations - integration', function() {
       app.models.Book.create({ name: 'Book 1' },
         function(err, book) {
           if (err) return done(err);
+
           test.book = book;
           book.pages.create({ name: 'Page 1' },
           function(err, page) {
             if (err) return done(err);
+
             test.page = page;
             page.notes.create({ text: 'Page Note 1' },
             function(err, note) {
               test.note = note;
+
               done();
             });
           });
@@ -1387,9 +1494,11 @@ describe('relations - integration', function() {
       test.book.chapters.create({ name: 'Chapter 1' },
         function(err, chapter) {
           if (err) return done(err);
+
           test.chapter = chapter;
           chapter.notes.create({ text: 'Chapter Note 1' }, function(err, note) {
             test.cnote = note;
+
             done();
           });
         });
@@ -1400,7 +1509,9 @@ describe('relations - integration', function() {
       app.models.Image.create({ name: 'Cover 1', book: test.book },
         function(err, image) {
           if (err) return done(err);
+
           test.image = image;
+
           done();
         });
     });
@@ -1410,9 +1521,11 @@ describe('relations - integration', function() {
       this.get('/api/books/' + test.book.id + '/pages')
         .expect(200, function(err, res) {
           if (err) return done(err);
+
           expect(res.body).to.be.an.array;
           expect(res.body).to.have.length(1);
           expect(res.body[0].name).to.equal('Page 1');
+
           done();
         });
     });
@@ -1422,10 +1535,12 @@ describe('relations - integration', function() {
       this.get('/api/pages/' + test.page.id + '/notes/' + test.note.id)
         .expect(200, function(err, res) {
           if (err) return done(err);
+
           expect(res.headers['x-before']).to.equal('before');
           expect(res.headers['x-after']).to.equal('after');
           expect(res.body).to.be.an.object;
           expect(res.body.text).to.equal('Page Note 1');
+
           done();
         });
     });
@@ -1435,10 +1550,12 @@ describe('relations - integration', function() {
       this.get('/api/books/unknown/pages/' + test.page.id + '/notes')
         .expect(404, function(err, res) {
           if (err) return done(err);
+
           expect(res.body.error).to.be.an.object;
           var expected = 'could not find a model with id unknown';
           expect(res.body.error.message).to.equal(expected);
           expect(res.body.error.code).to.be.equal('MODEL_NOT_FOUND');
+
           done();
         });
     });
@@ -1448,9 +1565,11 @@ describe('relations - integration', function() {
       this.get('/api/images/' + test.image.id + '/book/pages')
         .end(function(err, res) {
           if (err) return done(err);
+
           expect(res.body).to.be.an.array;
           expect(res.body).to.have.length(1);
           expect(res.body[0].name).to.equal('Page 1');
+
           done();
         });
     });
@@ -1460,8 +1579,10 @@ describe('relations - integration', function() {
       this.get('/api/images/' + test.image.id + '/book/pages/' + test.page.id)
         .end(function(err, res) {
           if (err) return done(err);
+
           expect(res.body).to.be.an.object;
           expect(res.body.name).to.equal('Page 1');
+
           done();
         });
     });
@@ -1471,9 +1592,11 @@ describe('relations - integration', function() {
       this.get('/api/books/' + test.book.id + '/pages/' + test.page.id + '/notes')
         .expect(200, function(err, res) {
           if (err) return done(err);
+
           expect(res.body).to.be.an.array;
           expect(res.body).to.have.length(1);
           expect(res.body[0].text).to.equal('Page Note 1');
+
           done();
         });
     });
@@ -1483,10 +1606,12 @@ describe('relations - integration', function() {
       this.get('/api/books/' + test.book.id + '/pages/' + test.page.id + '/notes/' + test.note.id)
         .expect(200, function(err, res) {
           if (err) return done(err);
+
           expect(res.headers['x-before']).to.equal('before');
           expect(res.headers['x-after']).to.equal('after');
           expect(res.body).to.be.an.object;
           expect(res.body.text).to.equal('Page Note 1');
+
           done();
         });
     });
@@ -1496,8 +1621,10 @@ describe('relations - integration', function() {
       this.get('/api/books/' + test.book.id + '/chapters/' + test.chapter.id + '/notes/' + test.cnote.id)
         .expect(200, function(err, res) {
           if (err) return done(err);
+
           expect(res.headers['x-before']).to.empty;
           expect(res.headers['x-after']).to.empty;
+
           done();
         });
     });
@@ -1509,6 +1636,7 @@ describe('relations - integration', function() {
           http.forEach(function(opt) {
             // destroyAll has been shared but missing http property
             if (opt.path === undefined) return;
+
             expect(opt.path, method.stringName).to.match(/^\/.*/);
           });
         });
@@ -1520,11 +1648,13 @@ describe('relations - integration', function() {
       this.get('/api/books/' + test.book.id + '/pages/' + this.page.id + '/throws')
         .end(function(err, res) {
           if (err) return done(err);
+
           expect(res.body).to.be.an('object');
           expect(res.body.error).to.be.an('object');
           expect(res.body.error.name).to.equal('Error');
           expect(res.body.error.status).to.equal(500);
           expect(res.body.error.message).to.equal('This should not crash the app');
+
           done();
         });
     });
@@ -1536,10 +1666,10 @@ describe('relations - integration', function() {
     before(function createCustomer(done) {
       var test = this;
       app.models.customer.create({ name: 'John' }, function(err, c) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
+
         cust = c;
+
         done();
       });
     });
@@ -1547,9 +1677,8 @@ describe('relations - integration', function() {
     after(function(done) {
       var self = this;
       this.app.models.customer.destroyAll(function(err) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
+
         self.app.models.profile.destroyAll(done);
       });
     });
@@ -1560,11 +1689,11 @@ describe('relations - integration', function() {
       this.post(url)
         .send({ points: 10 })
         .expect(200, function(err, res) {
-          if (err) {
-            return done(err);
-          }
+          if (err) return done(err);
+
           expect(res.body.points).to.be.eql(10);
           expect(res.body.customerId).to.be.eql(cust.id);
+
           done();
         });
     });
@@ -1573,11 +1702,11 @@ describe('relations - integration', function() {
       var url = '/api/customers/' + cust.id + '/profile';
       this.get(url)
         .expect(200, function(err, res) {
-          if (err) {
-            return done(err);
-          }
+          if (err) return done(err);
+
           expect(res.body.points).to.be.eql(10);
           expect(res.body.customerId).to.be.eql(cust.id);
+
           done();
         });
     });
@@ -1596,11 +1725,11 @@ describe('relations - integration', function() {
       this.put(url)
         .send({ points: 100 })
         .expect(200, function(err, res) {
-          if (err) {
-            return done(err);
-          }
+          if (err) return done(err);
+
           expect(res.body.points).to.be.eql(100);
           expect(res.body.customerId).to.be.eql(cust.id);
+
           done();
         });
     });

--- a/test/remote-connector.test.js
+++ b/test/remote-connector.test.js
@@ -20,6 +20,7 @@ describe('RemoteConnector', function() {
           port: remoteApp.get('port'),
           connector: loopback.Remote,
         });
+
         done();
       });
     },
@@ -47,6 +48,7 @@ describe('RemoteConnector', function() {
         port: remoteApp.get('port'),
         connector: loopback.Remote,
       });
+
       done();
     });
   });
@@ -69,8 +71,10 @@ describe('RemoteConnector', function() {
     var m = new RemoteModel({ foo: 'bar' });
     m.save(function(err, inst) {
       if (err) return done(err);
+
       assert(inst instanceof RemoteModel);
       assert(calledServerCreate);
+
       done();
     });
   });

--- a/test/remoting-coercion.test.js
+++ b/test/remoting-coercion.test.js
@@ -32,7 +32,9 @@ describe('remoting coercion', function() {
       })
       .end(function(err) {
         if (err) return done(err);
+
         assert(called);
+
         done();
       });
   });

--- a/test/remoting.integration.js
+++ b/test/remoting.integration.js
@@ -45,6 +45,7 @@ describe('remoting - integration', function() {
         this.req = this.http.req;
         this.res = this.http.res;
         assert.equal(this.res.statusCode, 200);
+
         done();
       }.bind(this));
     });
@@ -65,6 +66,7 @@ describe('remoting - integration', function() {
         this.res = this.http.res;
         // Request is rejected with 413
         assert.equal(this.res.statusCode, 413);
+
         done();
       }.bind(this));
     });

--- a/test/replication.rest.test.js
+++ b/test/replication.rest.test.js
@@ -116,11 +116,14 @@ describe('Replication over REST', function() {
       it('allows pull from server', function(done) {
         RemoteCar.replicate(LocalCar, function(err, conflicts, cps) {
           if (err) return done(err);
+
           if (conflicts.length) return done(conflictError(conflicts));
 
           LocalCar.find(function(err, list) {
             if (err) return done(err);
+
             expect(list.map(carToString)).to.include.members(serverCars);
+
             done();
           });
         });
@@ -139,11 +142,14 @@ describe('Replication over REST', function() {
       it('allows pull from server', function(done) {
         RemoteCar.replicate(LocalCar, function(err, conflicts, cps) {
           if (err) return done(err);
+
           if (conflicts.length) return done(conflictError(conflicts));
 
           LocalCar.find(function(err, list) {
             if (err) return done(err);
+
             expect(list.map(carToString)).to.include.members(serverCars);
+
             done();
           });
         });
@@ -152,11 +158,14 @@ describe('Replication over REST', function() {
       it('allows push to the server', function(done) {
         LocalCar.replicate(RemoteCar, function(err, conflicts, cps) {
           if (err) return done(err);
+
           if (conflicts.length) return done(conflictError(conflicts));
 
           ServerCar.find(function(err, list) {
             if (err) return done(err);
+
             expect(list.map(carToString)).to.include.members(clientCars);
+
             done();
           });
         });
@@ -226,6 +235,7 @@ describe('Replication over REST', function() {
       it('allows reverse resolve() on the client', function(done) {
         RemoteCar.replicate(LocalCar, function(err, conflicts) {
           if (err) return done(err);
+
           expect(conflicts, 'conflicts').to.have.length(1);
 
           // By default, conflicts are always resolved by modifying
@@ -240,7 +250,9 @@ describe('Replication over REST', function() {
 
             RemoteCar.replicate(LocalCar, function(err, conflicts) {
               if (err) return done(err);
+
               if (conflicts.length) return done(conflictError(conflicts));
+
               done();
             });
           });
@@ -250,6 +262,7 @@ describe('Replication over REST', function() {
       it('rejects resolve() on the server', function(done) {
         RemoteCar.replicate(LocalCar, function(err, conflicts) {
           if (err) return done(err);
+
           expect(conflicts, 'conflicts').to.have.length(1);
           conflicts[0].resolveUsingSource(expectHttpError(401, done));
         });
@@ -264,13 +277,17 @@ describe('Replication over REST', function() {
       it('allows resolve() on the client', function(done) {
         LocalCar.replicate(RemoteCar, function(err, conflicts) {
           if (err) return done(err);
+
           expect(conflicts).to.have.length(1);
 
           conflicts[0].resolveUsingSource(function(err) {
             if (err) return done(err);
+
             LocalCar.replicate(RemoteCar, function(err, conflicts) {
               if (err) return done(err);
+
               if (conflicts.length) return done(conflictError(conflicts));
+
               done();
             });
           });
@@ -280,13 +297,17 @@ describe('Replication over REST', function() {
       it('allows resolve() on the server', function(done) {
         RemoteCar.replicate(LocalCar, function(err, conflicts) {
           if (err) return done(err);
+
           expect(conflicts).to.have.length(1);
 
           conflicts[0].resolveUsingSource(function(err) {
             if (err) return done(err);
+
             RemoteCar.replicate(LocalCar, function(err, conflicts) {
               if (err) return done(err);
+
               if (conflicts.length) return done(conflictError(conflicts));
+
               done();
             });
           });
@@ -300,10 +321,13 @@ describe('Replication over REST', function() {
       setAccessToken(aliceToken);
       RemoteUser.replicate(LocalUser, function(err, conflicts, cps) {
         if (err) return done(err);
+
         if (conflicts.length) return done(conflictError(conflicts));
+
         LocalUser.find(function(err, users) {
           var userNames = users.map(function(u) { return u.username; });
           expect(userNames).to.eql([ALICE.username]);
+
           done();
         });
       });
@@ -317,7 +341,9 @@ describe('Replication over REST', function() {
           setAccessToken(aliceToken);
           LocalUser.replicate(RemoteUser, function(err, conflicts) {
             if (err) return next(err);
+
             if (conflicts.length) return next(conflictError(conflicts));
+
             next();
           });
         },
@@ -325,8 +351,10 @@ describe('Replication over REST', function() {
         function verify(next) {
           RemoteUser.findById(aliceId, function(err, found) {
             if (err) return next(err);
+
             expect(found.toObject())
               .to.have.property('fullname', 'Alice Smith');
+
             next();
           });
         },
@@ -342,7 +370,9 @@ describe('Replication over REST', function() {
           LocalUser.replicate(RemoteUser, function(err, conflicts) {
             if (!err)
               return next(new Error('Replicate should have failed.'));
+
             expect(err).to.have.property('statusCode', 401); // or 403?
+
             next();
           });
         },
@@ -350,8 +380,10 @@ describe('Replication over REST', function() {
         function verify(next) {
           ServerUser.findById(aliceId, function(err, found) {
             if (err) return next(err);
+
             expect(found.toObject())
               .to.not.have.property('fullname');
+
             next();
           });
         },
@@ -463,6 +495,7 @@ describe('Replication over REST', function() {
 
     serverApp.use(function(req, res, next) {
       debug(req.method + ' ' + req.path);
+
       next();
     });
     serverApp.use(loopback.token({ model: ServerToken }));
@@ -474,6 +507,7 @@ describe('Replication over REST', function() {
     serverApp.listen(function() {
       serverUrl = serverApp.get('url').replace(/\/+$/, '');
       request = supertest(serverUrl);
+
       done();
     });
   }
@@ -529,18 +563,22 @@ describe('Replication over REST', function() {
       function(next) {
         ServerUser.create([ALICE, PETER, EMERY], function(err, created) {
           if (err) return next(err);
+
           aliceId = created[0].id;
           peterId = created[1].id;
+
           next();
         });
       },
       function(next) {
         ServerUser.login(ALICE, function(err, token) {
           if (err) return next(err);
+
           aliceToken = token.id;
 
           ServerUser.login(PETER, function(err, token) {
             if (err) return next(err);
+
             peterToken = token.id;
 
             ServerUser.login(EMERY, function(err, token) {
@@ -559,7 +597,9 @@ describe('Replication over REST', function() {
           ],
           function(err, cars) {
             if (err) return next(err);
+
             serverCars = cars.map(carToString);
+
             next();
           });
       },
@@ -576,7 +616,9 @@ describe('Replication over REST', function() {
           [{ maker: 'Local', model: 'Custom' }],
           function(err, cars) {
             if (err) return next(err);
+
             clientCars = cars.map(carToString);
+
             next();
           });
       },
@@ -586,9 +628,12 @@ describe('Replication over REST', function() {
   function seedConflict(done) {
     LocalCar.replicate(ServerCar, function(err, conflicts) {
       if (err) return done(err);
+
       if (conflicts.length) return done(conflictError(conflicts));
+
       ServerCar.replicate(LocalCar, function(err, conflicts) {
         if (err) return done(err);
+
         if (conflicts.length) return done(conflictError(conflicts));
 
         // Hard-coded, see the seed data above
@@ -597,6 +642,7 @@ describe('Replication over REST', function() {
         new LocalCar({ id: conflictedCarId })
           .updateAttributes({ model: 'Client' }, function(err, c) {
             if (err) return done(err);
+
             new ServerCar({ id: conflictedCarId })
               .updateAttributes({ model: 'Server' }, done);
           });
@@ -614,7 +660,9 @@ describe('Replication over REST', function() {
   function expectHttpError(code, done) {
     return function(err) {
       if (!err) return done(new Error('The method should have failed.'));
+
       expect(err).to.have.property('statusCode', code);
+
       done();
     };
   }
@@ -622,7 +670,9 @@ describe('Replication over REST', function() {
   function replicateServerToLocal(next) {
     ServerUser.replicate(LocalUser, function(err, conflicts) {
       if (err) return next(err);
+
       if (conflicts.length) return next(conflictError(conflicts));
+
       next();
     });
   }

--- a/test/replication.test.js
+++ b/test/replication.test.js
@@ -50,6 +50,7 @@ describe('Replication / Change APIs', function() {
     this.createInitalData = function(cb) {
       SourceModel.create({ name: 'foo' }, function(err, inst) {
         if (err) return cb(err);
+
         test.model = inst;
         SourceModel.replicate(TargetModel, cb);
       });
@@ -74,7 +75,9 @@ describe('Replication / Change APIs', function() {
       var calls = mockSourceModelRectify();
       SourceModel.destroyAll({ name: 'John' }, function(err, data) {
         if (err) return done(err);
+
         expect(calls).to.eql(['rectifyAllChanges']);
+
         done();
       });
     });
@@ -84,7 +87,9 @@ describe('Replication / Change APIs', function() {
       var newData = { 'name': 'Janie' };
       SourceModel.update({ name: 'Jane' }, newData, function(err, data) {
         if (err) return done(err);
+
         expect(calls).to.eql(['rectifyAllChanges']);
+
         done();
       });
     });
@@ -102,7 +107,9 @@ describe('Replication / Change APIs', function() {
         },
       ], function(err, results) {
         if (err) return done(err);
+
         expect(calls).to.eql(['rectifyChange']);
+
         done();
       });
     });
@@ -121,7 +128,9 @@ describe('Replication / Change APIs', function() {
         },
       ], function(err, result) {
         if (err) return done(err);
+
         expect(calls).to.eql(['rectifyChange']);
+
         done();
       });
     });
@@ -140,7 +149,9 @@ describe('Replication / Change APIs', function() {
         },
       ], function(err, result) {
         if (err) return done(err);
+
         expect(calls).to.eql(['rectifyChange']);
+
         done();
       });
     });
@@ -183,9 +194,11 @@ describe('Replication / Change APIs', function() {
       var test = this;
       this.SourceModel.create({ name: 'foo' }, function(err) {
         if (err) return done(err);
+
         setTimeout(function() {
           test.SourceModel.changes(test.startingCheckpoint, {}, function(err, changes) {
             assert.equal(changes.length, 1);
+
             done();
           });
         }, 1);
@@ -199,7 +212,9 @@ describe('Replication / Change APIs', function() {
         if (err) return done(err);
         SourceModel.changes(FUTURE_CHECKPOINT, {}, function(err, changes) {
           if (err) return done(err);
+
           expect(changes).to.be.empty;
+
           done();
         });
       });
@@ -216,6 +231,7 @@ describe('Replication / Change APIs', function() {
         function(cb) {
           sourceModel.find(function(err, result) {
             if (err) return cb(err);
+
             sourceData = result;
             cb();
           });
@@ -223,6 +239,7 @@ describe('Replication / Change APIs', function() {
         function(cb) {
           targetModel.find(function(err, result) {
             if (err) return cb(err);
+
             targetData = result;
             cb();
           });
@@ -231,6 +248,7 @@ describe('Replication / Change APIs', function() {
         if (err) return done(err);
 
         assert.deepEqual(sourceData, targetData);
+
         done();
       });
     }
@@ -241,6 +259,7 @@ describe('Replication / Change APIs', function() {
 
       this.SourceModel.create({ name: 'foo' }, function(err) {
         if (err) return done(err);
+
         test.SourceModel.replicate(test.startingCheckpoint, test.TargetModel,
         options, function(err, conflicts) {
           if (err) return done(err);
@@ -257,6 +276,7 @@ describe('Replication / Change APIs', function() {
 
       this.SourceModel.create({ name: 'foo' }, function(err) {
         if (err) return done(err);
+
         test.SourceModel.replicate(test.startingCheckpoint, test.TargetModel,
         options)
           .then(function(conflicts) {
@@ -291,6 +311,7 @@ describe('Replication / Change APIs', function() {
             if (err) return done(err);
             // '1' should be skipped by replication
             expect(getIds(list)).to.eql(['2']);
+
             next();
           });
         },
@@ -323,6 +344,7 @@ describe('Replication / Change APIs', function() {
             if (err) return done(err);
             // '1' should be skipped by replication
             expect(getIds(list)).to.eql(['2']);
+
             next();
           });
         },
@@ -338,7 +360,9 @@ describe('Replication / Change APIs', function() {
 
       SourceModel.replicate(10, TargetModel, function(err) {
         if (err) return done(err);
+
         expect(diffSince).to.eql([10]);
+
         done();
       });
     });
@@ -353,6 +377,7 @@ describe('Replication / Change APIs', function() {
       SourceModel.replicate(10, TargetModel, {})
         .then(function() {
           expect(diffSince).to.eql([10]);
+
           done();
         })
         .catch(function(err) {
@@ -370,8 +395,10 @@ describe('Replication / Change APIs', function() {
       var since = { source: 1, target: 2 };
       SourceModel.replicate(since, TargetModel, function(err) {
         if (err) return done(err);
+
         expect(sourceSince).to.eql([1]);
         expect(targetSince).to.eql([2]);
+
         done();
       });
     });
@@ -388,6 +415,7 @@ describe('Replication / Change APIs', function() {
         .then(function() {
           expect(sourceSince).to.eql([1]);
           expect(targetSince).to.eql([2]);
+
           done();
         })
         .catch(function(err) {
@@ -410,7 +438,9 @@ describe('Replication / Change APIs', function() {
         function getLastCp(next) {
           SourceModel.currentCheckpoint(function(err, cp) {
             if (err) return done(err);
+
             lastCp = cp;
+
             next();
           });
         },
@@ -425,6 +455,7 @@ describe('Replication / Change APIs', function() {
             TargetModel.find(function(err, list) {
               expect(getIds(list), 'target ids after first sync')
                 .to.include.members(['init']);
+
               next();
             });
           });
@@ -435,6 +466,7 @@ describe('Replication / Change APIs', function() {
         function verify(next) {
           TargetModel.find(function(err, list) {
             expect(getIds(list), 'target ids').to.eql(['init', 'racer']);
+
             next();
           });
         },
@@ -454,11 +486,13 @@ describe('Replication / Change APIs', function() {
             TargetModel,
             function(err, conflicts, newCheckpoints) {
               if (err) return cb(err);
+
               expect(conflicts, 'conflicts').to.eql([]);
               expect(newCheckpoints, 'currentCheckpoints').to.eql({
                 source: sourceCp + 1,
                 target: targetCp + 1,
               });
+
               cb();
             });
         },
@@ -467,7 +501,9 @@ describe('Replication / Change APIs', function() {
       function bumpSourceCheckpoint(cb) {
         SourceModel.checkpoint(function(err, inst) {
           if (err) return cb(err);
+
           sourceCp = inst.seq;
+
           cb();
         });
       }
@@ -475,7 +511,9 @@ describe('Replication / Change APIs', function() {
       function bumpTargetCheckpoint(cb) {
         TargetModel.checkpoint(function(err, inst) {
           if (err) return cb(err);
+
           targetCp = inst.seq;
+
           cb();
         });
       }
@@ -490,11 +528,14 @@ describe('Replication / Change APIs', function() {
         function verify(next) {
           TargetModel.currentCheckpoint(function(err, cp) {
             if (err) return next(err);
+
             TargetModel.getChangeModel().find(
               { where: { checkpoint: { gte: cp }}},
               function(err, changes) {
                 if (err) return done(err);
+
                 expect(changes).to.have.length(0);
+
                 done();
               });
           });
@@ -658,6 +699,7 @@ describe('Replication / Change APIs', function() {
                   cb);
               }
             });
+
             next();
           },
           replicateExpectingSuccess(),
@@ -693,10 +735,13 @@ describe('Replication / Change APIs', function() {
           },
         ], function(err) {
           if (err) return done(err);
+
           SourceModel.replicate(TargetModel, function(err, conflicts) {
             if (err) return done(err);
+
             test.conflicts = conflicts;
             test.conflict = conflicts[0];
+
             done();
           });
         });
@@ -709,6 +754,7 @@ describe('Replication / Change APIs', function() {
     it('type should be UPDATE', function(done) {
       this.conflict.type(function(err, type) {
         assert.equal(type, Change.UPDATE);
+
         done();
       });
     });
@@ -720,6 +766,7 @@ describe('Replication / Change APIs', function() {
         assert.equal(test.model.getId(), sourceChange.getModelId());
         assert.equal(sourceChange.type(), Change.UPDATE);
         assert.equal(targetChange.type(), Change.UPDATE);
+
         done();
       });
     });
@@ -734,6 +781,7 @@ describe('Replication / Change APIs', function() {
           id: test.model.id,
           name: 'target update',
         });
+
         done();
       });
     });
@@ -752,6 +800,7 @@ describe('Replication / Change APIs', function() {
           function(cb) {
             SourceModel.findOne(function(err, inst) {
               if (err) return cb(err);
+
               test.model = inst;
               inst.remove(cb);
             });
@@ -759,16 +808,20 @@ describe('Replication / Change APIs', function() {
           function(cb) {
             TargetModel.findOne(function(err, inst) {
               if (err) return cb(err);
+
               inst.name = 'target update';
               inst.save(cb);
             });
           },
         ], function(err) {
           if (err) return done(err);
+
           SourceModel.replicate(TargetModel, function(err, conflicts) {
             if (err) return done(err);
+
             test.conflicts = conflicts;
             test.conflict = conflicts[0];
+
             done();
           });
         });
@@ -781,6 +834,7 @@ describe('Replication / Change APIs', function() {
     it('type should be DELETE', function(done) {
       this.conflict.type(function(err, type) {
         assert.equal(type, Change.DELETE);
+
         done();
       });
     });
@@ -792,6 +846,7 @@ describe('Replication / Change APIs', function() {
         assert.equal(test.model.getId(), sourceChange.getModelId());
         assert.equal(sourceChange.type(), Change.DELETE);
         assert.equal(targetChange.type(), Change.UPDATE);
+
         done();
       });
     });
@@ -803,6 +858,7 @@ describe('Replication / Change APIs', function() {
           id: test.model.id,
           name: 'target update',
         });
+
         done();
       });
     });
@@ -829,15 +885,19 @@ describe('Replication / Change APIs', function() {
           function(cb) {
             TargetModel.findOne(function(err, inst) {
               if (err) return cb(err);
+
               inst.remove(cb);
             });
           },
         ], function(err) {
           if (err) return done(err);
+
           SourceModel.replicate(TargetModel, function(err, conflicts) {
             if (err) return done(err);
+
             test.conflicts = conflicts;
             test.conflict = conflicts[0];
+
             done();
           });
         });
@@ -850,6 +910,7 @@ describe('Replication / Change APIs', function() {
     it('type should be DELETE', function(done) {
       this.conflict.type(function(err, type) {
         assert.equal(type, Change.DELETE);
+
         done();
       });
     });
@@ -861,6 +922,7 @@ describe('Replication / Change APIs', function() {
         assert.equal(test.model.getId(), sourceChange.getModelId());
         assert.equal(sourceChange.type(), Change.UPDATE);
         assert.equal(targetChange.type(), Change.DELETE);
+
         done();
       });
     });
@@ -872,6 +934,7 @@ describe('Replication / Change APIs', function() {
           id: test.model.id,
           name: 'source update',
         });
+
         done();
       });
     });
@@ -890,6 +953,7 @@ describe('Replication / Change APIs', function() {
           function(cb) {
             SourceModel.findOne(function(err, inst) {
               if (err) return cb(err);
+
               test.model = inst;
               inst.remove(cb);
             });
@@ -897,15 +961,19 @@ describe('Replication / Change APIs', function() {
           function(cb) {
             TargetModel.findOne(function(err, inst) {
               if (err) return cb(err);
+
               inst.remove(cb);
             });
           },
         ], function(err) {
           if (err) return done(err);
+
           SourceModel.replicate(TargetModel, function(err, conflicts) {
             if (err) return done(err);
+
             test.conflicts = conflicts;
             test.conflict = conflicts[0];
+
             done();
           });
         });
@@ -921,6 +989,7 @@ describe('Replication / Change APIs', function() {
     it('detects "create"', function(done) {
       SourceModel.create({}, function(err, inst) {
         if (err) return done(err);
+
         assertChangeRecordedForId(inst.id, done);
       });
     });
@@ -928,10 +997,12 @@ describe('Replication / Change APIs', function() {
     it('detects "updateOrCreate"', function(done) {
       givenReplicatedInstance(function(err, created) {
         if (err) return done(err);
+
         var data = created.toObject();
         created.name = 'updated';
         SourceModel.updateOrCreate(created, function(err, inst) {
           if (err) return done(err);
+
           assertChangeRecordedForId(inst.id, done);
         });
       });
@@ -945,6 +1016,7 @@ describe('Replication / Change APIs', function() {
             this.all(model, query, function(err, list) {
               if (err || (list && list[0]))
                 return callback(err, list && list[0], false);
+
               this.create(model, data, function(err) {
                 callback(err, data, true);
               });
@@ -954,6 +1026,7 @@ describe('Replication / Change APIs', function() {
             this.all(model, query, {}, function(err, list) {
               if (err || (list && list[0]))
                 return callback(err, list && list[0], false);
+
               this.create(model, data, {}, function(err) {
                 callback(err, data, true);
               });
@@ -966,6 +1039,7 @@ describe('Replication / Change APIs', function() {
         { name: 'created' },
         function(err, inst) {
           if (err) return done(err);
+
           assertChangeRecordedForId(inst.id, done);
         });
     });
@@ -973,6 +1047,7 @@ describe('Replication / Change APIs', function() {
     it('detects "deleteById"', function(done) {
       givenReplicatedInstance(function(err, inst) {
         if (err) return done(err);
+
         SourceModel.deleteById(inst.id, function(err) {
           assertChangeRecordedForId(inst.id, done);
         });
@@ -982,8 +1057,10 @@ describe('Replication / Change APIs', function() {
     it('detects "deleteAll"', function(done) {
       givenReplicatedInstance(function(err, inst) {
         if (err) return done(err);
+
         SourceModel.deleteAll({ name: inst.name }, function(err) {
           if (err) return done(err);
+
           assertChangeRecordedForId(inst.id, done);
         });
       });
@@ -992,11 +1069,13 @@ describe('Replication / Change APIs', function() {
     it('detects "updateAll"', function(done) {
       givenReplicatedInstance(function(err, inst) {
         if (err) return done(err);
+
         SourceModel.updateAll(
           { name: inst.name },
           { name: 'updated' },
           function(err) {
             if (err) return done(err);
+
             assertChangeRecordedForId(inst.id, done);
           });
       });
@@ -1005,9 +1084,11 @@ describe('Replication / Change APIs', function() {
     it('detects "prototype.save"', function(done) {
       givenReplicatedInstance(function(err, inst) {
         if (err) return done(err);
+
         inst.name = 'updated';
         inst.save(function(err) {
           if (err) return done(err);
+
           assertChangeRecordedForId(inst.id, done);
         });
       });
@@ -1016,8 +1097,10 @@ describe('Replication / Change APIs', function() {
     it('detects "prototype.updateAttributes"', function(done) {
       givenReplicatedInstance(function(err, inst) {
         if (err) return done(err);
+
         inst.updateAttributes({ name: 'updated' }, function(err) {
           if (err) return done(err);
+
           assertChangeRecordedForId(inst.id, done);
         });
       });
@@ -1026,6 +1109,7 @@ describe('Replication / Change APIs', function() {
     it('detects "prototype.delete"', function(done) {
       givenReplicatedInstance(function(err, inst) {
         if (err) return done(err);
+
         inst.delete(function(err) {
           assertChangeRecordedForId(inst.id, done);
         });
@@ -1035,8 +1119,10 @@ describe('Replication / Change APIs', function() {
     function givenReplicatedInstance(cb) {
       SourceModel.create({ name: 'a-name' }, function(err, inst) {
         if (err) return cb(err);
+
         SourceModel.checkpoint(function(err) {
           if (err) return cb(err);
+
           cb(null, inst);
         });
       });
@@ -1046,8 +1132,10 @@ describe('Replication / Change APIs', function() {
       SourceModel.getChangeModel().getCheckpointModel()
         .current(function(err, cp) {
           if (err) return cb(err);
+
           SourceModel.changes(cp - 1, {}, function(err, pendingChanges) {
             if (err) return cb(err);
+
             expect(pendingChanges, 'list of changes').to.have.length(1);
             var change = pendingChanges[0].toObject();
             expect(change).to.have.property('checkpoint', cp); // sanity check
@@ -1055,6 +1143,7 @@ describe('Replication / Change APIs', function() {
             // NOTE(bajtos) Change.modelId is always String
             // regardless of the type of the changed model's id property
             expect(change).to.have.property('modelId', '' + id);
+
             cb();
           });
         });
@@ -1070,6 +1159,7 @@ describe('Replication / Change APIs', function() {
           SourceModel.create({ id: 'test-instance' }, function(err, result) {
             sourceInstance = result;
             sourceInstanceId = result.id;
+
             next(err);
           });
         },
@@ -1108,7 +1198,9 @@ describe('Replication / Change APIs', function() {
         function verifyTargetModelWasDeleted(next) {
           TargetModel.find(function(err, list) {
             if (err) return next(err);
+
             expect(getIds(list)).to.not.contain(sourceInstance.id);
+
             next();
           });
         },
@@ -1374,6 +1466,7 @@ describe('Replication / Change APIs', function() {
         return function updateInstanceB(next) {
           ClientB.findById(sourceInstanceId, function(err, instance) {
             if (err) return next(err);
+
             instance.name = name;
             instance.save(next);
           });
@@ -1405,6 +1498,7 @@ describe('Replication / Change APIs', function() {
         debug('delete source instance', value);
         sourceInstance.remove(function(err) {
           sourceInstance = null;
+
           next(err);
         });
       };
@@ -1412,11 +1506,14 @@ describe('Replication / Change APIs', function() {
 
     function verifySourceWasReplicated(target) {
       if (!target) target = TargetModel;
+
       return function verify(next) {
         target.findById(sourceInstanceId, function(err, targetInstance) {
           if (err) return next(err);
+
           expect(targetInstance && targetInstance.toObject())
             .to.eql(sourceInstance && sourceInstance.toObject());
+
           next();
         });
       };
@@ -1442,9 +1539,11 @@ describe('Replication / Change APIs', function() {
 
     source.replicate(since, target, function(err, conflicts, cps) {
       if (err) return next(err);
+
       if (conflicts.length === 0) {
         _since[sinceIx] = cps;
       }
+
       next(err, conflicts, cps);
     });
   }
@@ -1462,10 +1561,12 @@ describe('Replication / Change APIs', function() {
     return function doReplicate(next) {
       replicate(source, target, since, function(err, conflicts, cps) {
         if (err) return next(err);
+
         if (conflicts.length) {
           return next(new Error('Unexpected conflicts\n' +
             conflicts.map(JSON.stringify).join('\n')));
         }
+
         next();
       });
     };
@@ -1479,6 +1580,7 @@ describe('Replication / Change APIs', function() {
       var self = this;
       fn(function(err) {
         if (err) return cb(err);
+
         bulkUpdate.call(self, data, cb);
       });
 
@@ -1491,11 +1593,14 @@ describe('Replication / Change APIs', function() {
     return function verify(next) {
       source.findById(id, function(err, expected) {
         if (err) return next(err);
+
         target.findById(id, function(err, actual) {
           if (err) return next(err);
+
           expect(actual && actual.toObject())
             .to.eql(expected && expected.toObject());
           debug('replicated instance: %j', actual);
+
           next();
         });
       });

--- a/test/rest.middleware.test.js
+++ b/test/rest.middleware.test.js
@@ -34,6 +34,7 @@ describe('loopback.rest', function() {
         .del('/mymodels/' + inst.id)
         .expect(200, function(err, res) {
           expect(res.body.count).to.equal(1);
+
           done();
         });
     });
@@ -45,12 +46,12 @@ describe('loopback.rest', function() {
     request(app).get('/mymodels/1')
       .expect(404)
       .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
+
         var errorResponse = res.body.error;
         assert(errorResponse);
         assert.equal(errorResponse.code, 'MODEL_NOT_FOUND');
+
         done();
       });
   });
@@ -70,7 +71,9 @@ describe('loopback.rest', function() {
       .expect(200)
       .end(function(err, res) {
         if (err) return done(err);
+
         expect(res.body).to.eql({ exists: false });
+
         done();
       });
   });
@@ -103,7 +106,9 @@ describe('loopback.rest', function() {
         .expect(200)
         .end(function(err, res) {
           if (err) return done(err);
+
           expect(res.body).to.eql({ exists: true });
+
           done();
         });
     });
@@ -177,12 +182,15 @@ describe('loopback.rest', function() {
     app.use(loopback.rest());
     givenLoggedInUser(function(err, token) {
       if (err) return done(err);
+
       request(app).get('/users/getToken')
         .set('Authorization', token.id)
         .expect(200)
         .end(function(err, res) {
           if (err) return done(err);
+
           expect(res.body.id).to.equal(null);
+
           done();
         });
     }, done);
@@ -194,7 +202,9 @@ describe('loopback.rest', function() {
       .expect(200)
       .end(function(err, res) {
         if (err) return done(err);
+
         expect(res.body).to.eql([]);
+
         done();
       });
   });
@@ -205,7 +215,9 @@ describe('loopback.rest', function() {
       .expect(200)
       .end(function(err, res) {
         if (err) return done(err);
+
         expect(res.body).to.eql({});
+
         done();
       });
   });
@@ -262,12 +274,15 @@ describe('loopback.rest', function() {
     function invokeGetToken(done) {
       givenLoggedInUser(function(err, token) {
         if (err) return done(err);
+
         request(app).get('/users/getToken')
           .set('Authorization', token.id)
           .expect(200)
           .end(function(err, res) {
             if (err) return done(err);
+
             expect(res.body.id).to.equal(token.id);
+
             done();
           });
       });
@@ -296,6 +311,7 @@ describe('loopback.rest', function() {
         { model: app.registry.getModelByType('AccessToken') }));
       app.use(function(req, res, next) {
         loopback.getCurrentContext().set('accessToken', req.accessToken);
+
         next();
       });
       app.use(loopback.rest());
@@ -351,6 +367,7 @@ describe('loopback.rest', function() {
     User.create(credentials,
       function(err, user) {
         if (err) return done(err);
+
         User.login(credentials, cb);
       });
   }
@@ -399,7 +416,9 @@ describe('loopback.rest', function() {
             .expect(200)
             .end(function(err, res) {
               if (err) return done(err);
+
               expect(res.body.count).to.equal(3);
+
               done();
             });
         });
@@ -445,7 +464,9 @@ describe('loopback.rest', function() {
             .expect(200)
             .end(function(err, res) {
               if (err) return done(err);
+
               expect(res.body.count).to.equal(3);
+
               done();
             });
         });

--- a/test/role.test.js
+++ b/test/role.test.js
@@ -260,6 +260,7 @@ describe('role model', function() {
         password: 'jpass',
       }, function(err, u) {
         if (err) return done(err);
+
         user = u;
         User.create({
           username: 'mary',
@@ -267,15 +268,18 @@ describe('role model', function() {
           password: 'mpass',
         }, function(err, u) {
           if (err) return done(err);
+
           Application.create({
             name: 'demo',
           }, function(err, a) {
             if (err) return done(err);
+
             app = a;
             Role.create({
               name: 'admin',
             }, function(err, r) {
               if (err) return done(err);
+
               role = r;
               var principals = [
                 {
@@ -299,7 +303,9 @@ describe('role model', function() {
     it('should resolve user by id', function(done) {
       ACL.resolvePrincipal(ACL.USER, user.id, function(err, u) {
         if (err) return done(err);
+
         expect(u.id).to.eql(user.id);
+
         done();
       });
     });
@@ -307,7 +313,9 @@ describe('role model', function() {
     it('should resolve user by username', function(done) {
       ACL.resolvePrincipal(ACL.USER, user.username, function(err, u) {
         if (err) return done(err);
+
         expect(u.username).to.eql(user.username);
+
         done();
       });
     });
@@ -315,7 +323,9 @@ describe('role model', function() {
     it('should resolve user by email', function(done) {
       ACL.resolvePrincipal(ACL.USER, user.email, function(err, u) {
         if (err) return done(err);
+
         expect(u.email).to.eql(user.email);
+
         done();
       });
     });
@@ -323,7 +333,9 @@ describe('role model', function() {
     it('should resolve app by id', function(done) {
       ACL.resolvePrincipal(ACL.APP, app.id, function(err, a) {
         if (err) return done(err);
+
         expect(a.id).to.eql(app.id);
+
         done();
       });
     });
@@ -331,7 +343,9 @@ describe('role model', function() {
     it('should resolve app by name', function(done) {
       ACL.resolvePrincipal(ACL.APP, app.name, function(err, a) {
         if (err) return done(err);
+
         expect(a.name).to.eql(app.name);
+
         done();
       });
     });
@@ -339,7 +353,9 @@ describe('role model', function() {
     it('should report isMappedToRole by user.username', function(done) {
       ACL.isMappedToRole(ACL.USER, user.username, 'admin', function(err, flag) {
         if (err) return done(err);
+
         expect(flag).to.eql(true);
+
         done();
       });
     });
@@ -347,7 +363,9 @@ describe('role model', function() {
     it('should report isMappedToRole by user.email', function(done) {
       ACL.isMappedToRole(ACL.USER, user.email, 'admin', function(err, flag) {
         if (err) return done(err);
+
         expect(flag).to.eql(true);
+
         done();
       });
     });
@@ -356,7 +374,9 @@ describe('role model', function() {
       function(done) {
         ACL.isMappedToRole(ACL.USER, 'mary', 'admin', function(err, flag) {
           if (err) return done(err);
+
           expect(flag).to.eql(false);
+
           done();
         });
       });
@@ -364,7 +384,9 @@ describe('role model', function() {
     it('should report isMappedToRole by app.name', function(done) {
       ACL.isMappedToRole(ACL.APP, app.name, 'admin', function(err, flag) {
         if (err) return done(err);
+
         expect(flag).to.eql(true);
+
         done();
       });
     });
@@ -372,7 +394,9 @@ describe('role model', function() {
     it('should report isMappedToRole by app.name', function(done) {
       ACL.isMappedToRole(ACL.APP, app.name, 'admin', function(err, flag) {
         if (err) return done(err);
+
         expect(flag).to.eql(true);
+
         done();
       });
     });
@@ -432,6 +456,7 @@ describe('role model', function() {
               assert.equal(users.length, 1);
               assert.equal(users[0].id, user.id);
               assert(User.find.calledWith(query));
+
               done();
             });
           });
@@ -457,7 +482,9 @@ describe('role model', function() {
 
         Role.isOwner(User, user.id, user.id, function(err, result) {
           if (err) return done(err);
+
           expect(result, 'isOwner result').to.equal(true);
+
           done();
         });
       });

--- a/test/user.integration.js
+++ b/test/user.integration.js
@@ -22,10 +22,13 @@ describe('users - integration', function() {
     app.models.AccessToken.belongsTo(app.models.User);
     app.models.User.destroyAll(function(err) {
       if (err) return done(err);
+
       app.models.post.destroyAll(function(err) {
         if (err) return done(err);
+
         app.models.blog.destroyAll(function(err) {
           if (err) return done(err);
+
           done();
         });
       });
@@ -40,8 +43,10 @@ describe('users - integration', function() {
         .send({ username: 'x', email: 'x@y.com', password: 'x' })
         .expect(200, function(err, res) {
           if (err) return done(err);
+
           expect(res.body.id).to.exist;
           userId = res.body.id;
+
           done();
         });
     });
@@ -52,11 +57,11 @@ describe('users - integration', function() {
       this.post(url)
         .send({ username: 'x', email: 'x@y.com', password: 'x' })
         .expect(200, function(err, res) {
-          if (err) {
-            return done(err);
-          }
+          if (err) return done(err);
+
           expect(res.body.id).to.exist;
           accessToken = res.body.id;
+
           done();
         });
     });
@@ -66,12 +71,12 @@ describe('users - integration', function() {
       this.post(url)
         .send({ title: 'T1', content: 'C1' })
         .expect(200, function(err, res) {
-          if (err) {
-            return done(err);
-          }
+          if (err) return done(err);
+
           expect(res.body.title).to.be.eql('T1');
           expect(res.body.content).to.be.eql('C1');
           expect(res.body.userId).to.be.eql(userId);
+
           done();
         });
     });
@@ -82,13 +87,13 @@ describe('users - integration', function() {
       var url = '/api/posts?filter={"include":{"user":"accessTokens"}}';
       this.get(url)
         .expect(200, function(err, res) {
-          if (err) {
-            return done(err);
-          }
+          if (err) return done(err);
+
           expect(res.body).to.have.property('length', 1);
           var post = res.body[0];
           expect(post.user).to.have.property('username', 'x');
           expect(post.user).to.not.have.property('accessTokens');
+
           done();
         });
     });
@@ -103,11 +108,11 @@ describe('users - integration', function() {
       this.post(url)
         .send({ username: 'x', email: 'x@y.com', password: 'x' })
         .expect(200, function(err, res) {
-          if (err) {
-            return done(err);
-          }
+          if (err) return done(err);
+
           expect(res.body.id).to.exist;
           userId = res.body.id;
+
           done();
         });
     });
@@ -118,11 +123,11 @@ describe('users - integration', function() {
       this.post(url)
         .send({ username: 'x', email: 'x@y.com', password: 'x' })
         .expect(200, function(err, res) {
-          if (err) {
-            return done(err);
-          }
+          if (err) return done(err);
+
           expect(res.body.id).to.exist;
           accessToken = res.body.id;
+
           done();
         });
     });
@@ -136,9 +141,11 @@ describe('users - integration', function() {
             console.error(err);
             return done(err);
           }
+
           expect(res.body.title).to.be.eql('T1');
           expect(res.body.content).to.be.eql('C1');
           expect(res.body.userId).to.be.eql(userId);
+
           done();
         });
     });
@@ -147,13 +154,13 @@ describe('users - integration', function() {
       var url = '/api/blogs?filter={"include":{"user":"accessTokens"}}';
       this.get(url)
         .expect(200, function(err, res) {
-          if (err) {
-            return done(err);
-          }
+          if (err) return done(err);
+
           expect(res.body).to.have.property('length', 1);
           var blog = res.body[0];
           expect(blog.user).to.have.property('username', 'x');
           expect(blog.user).to.not.have.property('accessTokens');
+
           done();
         });
     });

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -70,6 +70,7 @@ describe('User', function() {
 
     User.create(validCredentials, function(err, user) {
       if (err) return done(err);
+
       User.create(validCredentialsEmailVerified, done);
     });
   });
@@ -80,6 +81,7 @@ describe('User', function() {
         assert(!err);
         assert(user.id);
         assert(user.email);
+
         done();
       });
     });
@@ -88,8 +90,10 @@ describe('User', function() {
       User.settings.caseSensitiveEmail = false;
       User.create({ email: 'F@b.com', password: 'bar' }, function(err, user) {
         if (err) return done(err);
+
         assert(user.id);
         assert.equal(user.email, user.email.toLowerCase());
+
         done();
       });
     });
@@ -97,9 +101,11 @@ describe('User', function() {
     it('Create a new user (email case-sensitive)', function(done) {
       User.create({ email: 'F@b.com', password: 'bar' }, function(err, user) {
         if (err) return done(err);
+
         assert(user.id);
         assert(user.email);
         assert.notEqual(user.email, user.email.toLowerCase());
+
         done();
       });
     });
@@ -115,6 +121,7 @@ describe('User', function() {
           assert(user.email);
           assert.deepEqual(user.credentials, { cert: 'xxxxx', key: '111' });
           assert.deepEqual(user.challenges, { x: 'X', a: 1 });
+
           done();
         });
       });
@@ -141,6 +148,7 @@ describe('User', function() {
 
       User.create({ email: 'c@d.com' }, function(err) {
         assert(err);
+
         done();
       });
     });
@@ -148,6 +156,7 @@ describe('User', function() {
     it('Requires a valid email', function(done) {
       User.create({ email: 'foo@', password: '123' }, function(err) {
         assert(err);
+
         done();
       });
     });
@@ -156,6 +165,7 @@ describe('User', function() {
       User.create({ email: 'a@b.com', password: 'foobar' }, function() {
         User.create({ email: 'a@b.com', password: 'batbaz' }, function(err) {
           assert(err, 'should error because the email is not unique!');
+
           done();
         });
       });
@@ -165,8 +175,10 @@ describe('User', function() {
       User.settings.caseSensitiveEmail = false;
       User.create({ email: 'A@b.com', password: 'foobar' }, function(err) {
         if (err) return done(err);
+
         User.create({ email: 'a@b.com', password: 'batbaz' }, function(err) {
           assert(err, 'should error because the email is not unique!');
+
           done();
         });
       });
@@ -176,7 +188,9 @@ describe('User', function() {
       User.create({ email: 'A@b.com', password: 'foobar' }, function(err, user1) {
         User.create({ email: 'a@b.com', password: 'batbaz' }, function(err, user2) {
           if (err) return done(err);
+
           assert.notEqual(user1.email, user2.email);
+
           done();
         });
       });
@@ -186,6 +200,7 @@ describe('User', function() {
       User.create({ email: 'a@b.com', username: 'abc', password: 'foobar' }, function() {
         User.create({ email: 'b@b.com', username: 'abc',  password: 'batbaz' }, function(err) {
           assert(err, 'should error because the username is not unique!');
+
           done();
         });
       });
@@ -197,6 +212,7 @@ describe('User', function() {
           assert(!accessToken, 'should not create a accessToken without a valid password');
           assert(err, 'should not login without a password');
           assert.equal(err.code, 'LOGIN_FAILED');
+
           done();
         });
       });
@@ -260,10 +276,10 @@ describe('User', function() {
         .expect(200)
         .send(validCredentialsEmailVerifiedOverREST)
         .end(function(err, res) {
-          if (err) {
-            return done(err);
-          }
+          if (err) return done(err);
+
           assert(!res.body.emailVerified);
+
           done();
         });
     });
@@ -273,6 +289,7 @@ describe('User', function() {
     it('Should not throw an error if the query does not contain {where: }', function(done) {
       User.find({}, function(err) {
         if (err) done(err);
+
         done();
       });
     });
@@ -281,8 +298,10 @@ describe('User', function() {
       User.settings.caseSensitiveEmail = false;
       User.find({ where: { email: validMixedCaseEmailCredentials.email }}, function(err, result) {
         if (err) done(err);
+
         assert(result[0], 'The query did not find the user');
         assert.equal(result[0].email, validCredentialsEmail);
+
         done();
       });
     });
@@ -305,6 +324,7 @@ describe('User', function() {
         assert(accessToken.userId);
         assert(accessToken.id);
         assert.equal(accessToken.id.length, 64);
+
         done();
       });
     });
@@ -312,6 +332,7 @@ describe('User', function() {
     it('Try to login with invalid email case', function(done) {
       User.login(validMixedCaseEmailCredentials, function(err, accessToken) {
         assert(err);
+
         done();
       });
     });
@@ -338,6 +359,7 @@ describe('User', function() {
             assert(accessToken.id);
             assert.equal(accessToken.ttl, 120);
             assert.equal(accessToken.id.length, 64);
+
             done();
           });
         });
@@ -356,6 +378,7 @@ describe('User', function() {
               assert(accessToken.id);
               assert.equal(accessToken.ttl, 120);
               assert.equal(accessToken.id.length, 64);
+
               done();
             })
             .catch(function(err) {
@@ -386,6 +409,7 @@ describe('User', function() {
             assert.equal(accessToken.id.length, 64);
             // Restore create access token
             User.prototype.createAccessToken = createToken;
+
             done();
           });
         });
@@ -416,6 +440,7 @@ describe('User', function() {
               assert.equal(accessToken.scopes, 'default');
               // Restore create access token
               User.prototype.createAccessToken = createToken;
+
               done();
             });
           });
@@ -427,6 +452,7 @@ describe('User', function() {
         assert(err);
         assert.equal(err.code, 'LOGIN_FAILED');
         assert(!accessToken);
+
         done();
       });
     });
@@ -435,11 +461,13 @@ describe('User', function() {
       User.login(invalidCredentials)
         .then(function(accessToken) {
           assert(!accessToken);
+
           done();
         })
         .catch(function(err) {
           assert(err);
           assert.equal(err.code, 'LOGIN_FAILED');
+
           done();
         });
     });
@@ -448,6 +476,7 @@ describe('User', function() {
       User.login(incompleteCredentials, function(err, accessToken) {
         assert(err);
         assert.equal(err.code, 'USERNAME_EMAIL_REQUIRED');
+
         done();
       });
     });
@@ -456,11 +485,13 @@ describe('User', function() {
       User.login(incompleteCredentials)
         .then(function(accessToken) {
           assert(!accessToken);
+
           done();
         })
         .catch(function(err) {
           assert(err);
           assert.equal(err.code, 'USERNAME_EMAIL_REQUIRED');
+
           done();
         });
     });
@@ -472,9 +503,8 @@ describe('User', function() {
         .expect(200)
         .send(validCredentials)
         .end(function(err, res) {
-          if (err) {
-            return done(err);
-          }
+          if (err) return done(err);
+
           var accessToken = res.body;
 
           assert(accessToken.userId);
@@ -493,11 +523,11 @@ describe('User', function() {
         .expect(401)
         .send(invalidCredentials)
         .end(function(err, res) {
-          if (err) {
-            return done(err);
-          }
+          if (err) return done(err);
+
           var errorResponse = res.body.error;
           assert.equal(errorResponse.code, 'LOGIN_FAILED');
+
           done();
         });
     });
@@ -509,11 +539,11 @@ describe('User', function() {
         .expect(400)
         .send(incompleteCredentials)
         .end(function(err, res) {
-          if (err) {
-            return done(err);
-          }
+          if (err) return done(err);
+
           var errorResponse = res.body.error;
           assert.equal(errorResponse.code, 'USERNAME_EMAIL_REQUIRED');
+
           done();
         });
     });
@@ -526,11 +556,11 @@ describe('User', function() {
         .expect(400)
         .send(JSON.stringify(validCredentials))
         .end(function(err, res) {
-          if (err) {
-            return done(err);
-          }
+          if (err) return done(err);
+
           var errorResponse = res.body.error;
           assert.equal(errorResponse.code, 'USERNAME_EMAIL_REQUIRED');
+
           done();
         });
     });
@@ -542,13 +572,13 @@ describe('User', function() {
         .expect(200)
         .expect('Content-Type', /json/)
         .end(function(err, res) {
-          if (err) {
-            return done(err);
-          }
+          if (err) return done(err);
+
           var token = res.body;
           expect(token.user, 'body.user').to.not.equal(undefined);
           expect(token.user, 'body.user')
             .to.have.property('email', validCredentials.email);
+
           done();
         });
     });
@@ -560,13 +590,13 @@ describe('User', function() {
         .expect(200)
         .expect('Content-Type', /json/)
         .end(function(err, res) {
-          if (err) {
-            return done(err);
-          }
+          if (err) return done(err);
+
           var token = res.body;
           expect(token.user, 'body.user').to.not.equal(undefined);
           expect(token.user, 'body.user')
             .to.have.property('email', validCredentials.email);
+
           done();
         });
     });
@@ -595,6 +625,7 @@ describe('User', function() {
         assert(err && !/verified/.test(err.message),
           'expecting "login failed" error message, received: "' + err.message + '"');
         assert.equal(err.code, 'LOGIN_FAILED');
+
         done();
       });
     });
@@ -611,6 +642,7 @@ describe('User', function() {
         assert(err && !/verified/.test(err.message),
           'expecting "login failed" error message, received: "' + err.message + '"');
         assert.equal(err.code, 'LOGIN_FAILED');
+
         done();
       });
     });
@@ -619,6 +651,7 @@ describe('User', function() {
       User.login(validCredentials, function(err, accessToken) {
         assert(err);
         assert.equal(err.code, 'LOGIN_FAILED_EMAIL_NOT_VERIFIED');
+
         done();
       });
     });
@@ -631,6 +664,7 @@ describe('User', function() {
         .catch(function(err) {
           assert(err);
           assert.equal(err.code, 'LOGIN_FAILED_EMAIL_NOT_VERIFIED');
+
           done();
         });
     });
@@ -638,6 +672,7 @@ describe('User', function() {
     it('Login a user by with email verification', function(done) {
       User.login(validCredentialsEmailVerified, function(err, accessToken) {
         assertGoodToken(accessToken);
+
         done();
       });
     });
@@ -646,6 +681,7 @@ describe('User', function() {
       User.login(validCredentialsEmailVerified)
         .then(function(accessToken) {
           assertGoodToken(accessToken);
+
           done();
         })
         .catch(function(err) {
@@ -660,9 +696,8 @@ describe('User', function() {
         .expect(200)
         .send(validCredentialsEmailVerified)
         .end(function(err, res) {
-          if (err) {
-            return done(err);
-          }
+          if (err) return done(err);
+
           var accessToken = res.body;
 
           assertGoodToken(accessToken);
@@ -681,9 +716,8 @@ describe('User', function() {
         .expect(401)
         .send({ email: validCredentialsEmail })
         .end(function(err, res) {
-          if (err) {
-            return done(err);
-          }
+          if (err) return done(err);
+
           // strongloop/loopback#931
           // error message should be "login failed"
           // and not "login failed as the email has not been verified"
@@ -691,6 +725,7 @@ describe('User', function() {
           assert(errorResponse && !/verified/.test(errorResponse.message),
             'expecting "login failed" error message, received: "' + errorResponse.message + '"');
           assert.equal(errorResponse.code, 'LOGIN_FAILED');
+
           done();
         });
     });
@@ -702,11 +737,11 @@ describe('User', function() {
         .expect(401)
         .send(validCredentials)
         .end(function(err, res) {
-          if (err) {
-            return done(err);
-          }
+          if (err) return done(err);
+
           var errorResponse = res.body.error;
           assert.equal(errorResponse.code, 'LOGIN_FAILED_EMAIL_NOT_VERIFIED');
+
           done();
         });
     });
@@ -790,9 +825,8 @@ describe('User', function() {
     var user1 = null;
     beforeEach(function(done) {
       User.create(realm1User, function(err, u) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
+
         user1 = u;
         User.create(realm2User, done);
       });
@@ -802,6 +836,7 @@ describe('User', function() {
       User.login(credentialWithoutRealm, function(err, accessToken) {
         assert(err);
         assert.equal(err.code, 'REALM_REQUIRED');
+
         done();
       });
     });
@@ -810,6 +845,7 @@ describe('User', function() {
       User.login(credentialWithBadRealm, function(err, accessToken) {
         assert(err);
         assert.equal(err.code, 'LOGIN_FAILED');
+
         done();
       });
     });
@@ -818,6 +854,7 @@ describe('User', function() {
       User.login(credentialWithBadPass, function(err, accessToken) {
         assert(err);
         assert.equal(err.code, 'LOGIN_FAILED');
+
         done();
       });
     });
@@ -826,6 +863,7 @@ describe('User', function() {
       User.login(credentialWithRealm, function(err, accessToken) {
         assertGoodToken(accessToken);
         assert.equal(accessToken.userId, user1.id);
+
         done();
       });
     });
@@ -834,6 +872,7 @@ describe('User', function() {
       User.login(credentialRealmInUsername, function(err, accessToken) {
         assertGoodToken(accessToken);
         assert.equal(accessToken.userId, user1.id);
+
         done();
       });
     });
@@ -842,6 +881,7 @@ describe('User', function() {
       User.login(credentialRealmInEmail, function(err, accessToken) {
         assertGoodToken(accessToken);
         assert.equal(accessToken.userId, user1.id);
+
         done();
       });
     });
@@ -859,6 +899,7 @@ describe('User', function() {
         User.login(credentialWithRealm, function(err, accessToken) {
           assertGoodToken(accessToken);
           assert.equal(accessToken.userId, user1.id);
+
           done();
         });
       });
@@ -868,6 +909,7 @@ describe('User', function() {
           User.login(credentialRealmInEmail, function(err, accessToken) {
             assert(err);
             assert.equal(err.code, 'REALM_REQUIRED');
+
             done();
           });
         });
@@ -913,9 +955,8 @@ describe('User', function() {
           .expect(200)
           .send({ email: 'foo@bar.com', password: 'bar' })
           .end(function(err, res) {
-            if (err) {
-              return done(err);
-            }
+            if (err) return done(err);
+
             var accessToken = res.body;
 
             assert(accessToken.userId);
@@ -938,12 +979,11 @@ describe('User', function() {
       assert(token);
 
       return function(err) {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         AccessToken.findById(token, function(err, accessToken) {
           assert(!accessToken, 'accessToken should not exist after logging out');
+
           done(err);
         });
       };
@@ -955,6 +995,7 @@ describe('User', function() {
       var u = new User({ username: 'foo', password: 'bar' });
       u.hasPassword('bar', function(err, isMatch) {
         assert(isMatch, 'password doesnt match');
+
         done();
       });
     });
@@ -964,6 +1005,7 @@ describe('User', function() {
       u.hasPassword('bar')
         .then(function(isMatch) {
           assert(isMatch, 'password doesnt match');
+
           done();
         })
         .catch(function(err) {
@@ -978,6 +1020,7 @@ describe('User', function() {
         User.findById(user.id, function(err, uu) {
           uu.hasPassword('b', function(err, isMatch) {
             assert(isMatch);
+
             done();
           });
         });
@@ -997,6 +1040,7 @@ describe('User', function() {
                 User.findById(user.id, function(err, uu) {
                   uu.hasPassword('baz2', function(err, isMatch) {
                     assert(isMatch);
+
                     done();
                   });
                 });
@@ -1030,6 +1074,7 @@ describe('User', function() {
             var msg = result.email.response.toString('utf-8');
             assert(~msg.indexOf('/api/test-users/confirm'));
             assert(~msg.indexOf('To: bar@bat.com'));
+
             done();
           });
         });
@@ -1040,9 +1085,7 @@ describe('User', function() {
           .expect(200)
           .send({ email: 'bar@bat.com', password: 'bar' })
           .end(function(err, res) {
-            if (err) {
-              return done(err);
-            }
+            if (err) return done(err);
           });
       });
 
@@ -1067,6 +1110,7 @@ describe('User', function() {
               var msg = result.email.response.toString('utf-8');
               assert(~msg.indexOf('/api/test-users/confirm'));
               assert(~msg.indexOf('To: bar@bat.com'));
+
               done();
             })
             .catch(function(err) {
@@ -1080,9 +1124,7 @@ describe('User', function() {
           .expect('Content-Type', /json/)
           .expect(200)
           .end(function(err, res) {
-            if (err) {
-              return done(err);
-            }
+            if (err) return done(err);
           });
       });
 
@@ -1103,6 +1145,7 @@ describe('User', function() {
           user.verify(options, function(err, result) {
             assert(result.email);
             assert.equal(result.email.messageId, 'custom-header-value');
+
             done();
           });
         });
@@ -1113,9 +1156,7 @@ describe('User', function() {
           .expect(200)
           .send({ email: 'bar@bat.com', password: 'bar' })
           .end(function(err, res) {
-            if (err) {
-              return done(err);
-            }
+            if (err) return done(err);
           });
       });
 
@@ -1149,6 +1190,7 @@ describe('User', function() {
             assert.equal(result.token, 'token-123456');
             var msg = result.email.response.toString('utf-8');
             assert(~msg.indexOf('token-123456'));
+
             done();
           });
         });
@@ -1159,9 +1201,7 @@ describe('User', function() {
           .expect(200)
           .send({ email: 'bar@bat.com', password: 'bar' })
           .end(function(err, res) {
-            if (err) {
-              return done(err);
-            }
+            if (err) return done(err);
           });
       });
 
@@ -1188,6 +1228,7 @@ describe('User', function() {
             assert(err);
             assert.equal(err.message, 'Fake error');
             assert.equal(result, undefined);
+
             done();
           });
         });
@@ -1198,9 +1239,7 @@ describe('User', function() {
           .expect(200)
           .send({ email: 'bar@bat.com', password: 'bar' })
           .end(function(err, res) {
-            if (err) {
-              return done(err);
-            }
+            if (err) return done(err);
           });
       });
 
@@ -1222,6 +1261,7 @@ describe('User', function() {
             user.verify(options, function(err, result) {
               var msg = result.email.response.toString('utf-8');
               assert(~msg.indexOf('http://myapp.org:3000/'));
+
               done();
             });
           });
@@ -1232,9 +1272,7 @@ describe('User', function() {
             .expect(200)
             .send({ email: 'bar@bat.com', password: 'bar' })
             .end(function(err, res) {
-              if (err) {
-                return done(err);
-              }
+              if (err) return done(err);
             });
         });
 
@@ -1255,6 +1293,7 @@ describe('User', function() {
             user.verify(options, function(err, result) {
               var msg = result.email.response.toString('utf-8');
               assert(~msg.indexOf('http://myapp.org/'));
+
               done();
             });
           });
@@ -1265,9 +1304,7 @@ describe('User', function() {
             .expect(200)
             .send({ email: 'bar@bat.com', password: 'bar' })
             .end(function(err, res) {
-              if (err) {
-                return done(err);
-              }
+              if (err) return done(err);
             });
         });
 
@@ -1288,6 +1325,7 @@ describe('User', function() {
             user.verify(options, function(err, result) {
               var msg = result.email.response.toString('utf-8');
               assert(~msg.indexOf('https://myapp.org:3000/'));
+
               done();
             });
           });
@@ -1298,9 +1336,7 @@ describe('User', function() {
             .expect(200)
             .send({ email: 'bar@bat.com', password: 'bar' })
             .end(function(err, res) {
-              if (err) {
-                return done(err);
-              }
+              if (err) return done(err);
             });
         });
 
@@ -1321,6 +1357,7 @@ describe('User', function() {
             user.verify(options, function(err, result) {
               var msg = result.email.response.toString('utf-8');
               assert(~msg.indexOf('https://myapp.org/'));
+
               done();
             });
           });
@@ -1331,9 +1368,7 @@ describe('User', function() {
             .expect(200)
             .send({ email: 'bar@bat.com', password: 'bar' })
             .end(function(err, res) {
-              if (err) {
-                return done(err);
-              }
+              if (err) return done(err);
             });
         });
       });
@@ -1346,6 +1381,7 @@ describe('User', function() {
         });
         var data = user.toJSON();
         assert(!('verificationToken' in data));
+
         done();
       });
     });
@@ -1367,9 +1403,8 @@ describe('User', function() {
           };
 
           user.verify(options, function(err, result) {
-            if (err) {
-              return done(err);
-            }
+            if (err) return done(err);
+
             testFunc(result, done);
           });
         });
@@ -1380,9 +1415,7 @@ describe('User', function() {
           .expect(302)
           .send({ email: 'bar@bat.com', password: 'bar' })
           .end(function(err, res) {
-            if (err) {
-              return done(err);
-            }
+            if (err) return done(err);
           });
       }
 
@@ -1394,9 +1427,8 @@ describe('User', function() {
               '&redirect=' + encodeURIComponent(options.redirect))
             .expect(302)
             .end(function(err, res) {
-              if (err) {
-                return done(err);
-              }
+              if (err) return done(err);
+
               done();
             });
         }, done);
@@ -1432,12 +1464,12 @@ describe('User', function() {
                '&redirect=' + encodeURIComponent(options.redirect))
             .expect(404)
             .end(function(err, res) {
-              if (err) {
-                return done(err);
-              }
+              if (err) return done(err);
+
               var errorResponse = res.body.error;
               assert(errorResponse);
               assert.equal(errorResponse.code, 'USER_NOT_FOUND');
+
               done();
             });
         }, done);
@@ -1451,12 +1483,12 @@ describe('User', function() {
               '&redirect=' + encodeURIComponent(options.redirect))
             .expect(400)
             .end(function(err, res) {
-              if (err) {
-                return done(err);
-              }
+              if (err) return done(err);
+
               var errorResponse = res.body.error;
               assert(errorResponse);
               assert.equal(errorResponse.code, 'INVALID_TOKEN');
+
               done();
             });
         }, done);
@@ -1472,6 +1504,7 @@ describe('User', function() {
         User.resetPassword({ }, function(err) {
           assert(err);
           assert.equal(err.code, 'EMAIL_REQUIRED');
+
           done();
         });
       });
@@ -1484,6 +1517,7 @@ describe('User', function() {
           .catch(function(err) {
             assert(err);
             assert.equal(err.code, 'EMAIL_REQUIRED');
+
             done();
           });
       });
@@ -1493,6 +1527,7 @@ describe('User', function() {
           assert(err);
           assert.equal(err.code, 'EMAIL_NOT_FOUND');
           assert.equal(err.statusCode, 404);
+
           done();
         });
       });
@@ -1514,7 +1549,9 @@ describe('User', function() {
           assert(calledBack);
           info.accessToken.user(function(err, user) {
             if (err) return done(err);
+
             assert.equal(user.email, email);
+
             done();
           });
         });
@@ -1527,12 +1564,12 @@ describe('User', function() {
           .expect(400)
           .send({ })
           .end(function(err, res) {
-            if (err) {
-              return done(err);
-            }
+            if (err) return done(err);
+
             var errorResponse = res.body.error;
             assert(errorResponse);
             assert.equal(errorResponse.code, 'EMAIL_REQUIRED');
+
             done();
           });
       });
@@ -1544,10 +1581,10 @@ describe('User', function() {
           .expect(204)
           .send({ email: email })
           .end(function(err, res) {
-            if (err) {
-              return done(err);
-            }
+            if (err) return done(err);
+
             assert.deepEqual(res.body, { });
+
             done();
           });
       });

--- a/test/util/model-tests.js
+++ b/test/util/model-tests.js
@@ -127,6 +127,7 @@ module.exports = function defineModelTestsWithDataSource(options) {
         user.isValid(function(valid) {
           assert(valid === false);
           assert(user.errors.age, 'model should have age error');
+
           done();
         });
       });
@@ -137,6 +138,7 @@ module.exports = function defineModelTestsWithDataSource(options) {
       function(done) {
         User.create({ first: 'Joe', last: 'Bob' }, function(err, user) {
           assert(user instanceof User);
+
           done();
         });
       });
@@ -149,6 +151,7 @@ module.exports = function defineModelTestsWithDataSource(options) {
           assert(user.id);
           assert(!err);
           assert(!user.errors);
+
           done();
         });
       });
@@ -168,6 +171,7 @@ module.exports = function defineModelTestsWithDataSource(options) {
             assert.equal(updatedUser.first, 'updatedFirst');
             assert.equal(updatedUser.last, 'updatedLast');
             assert.equal(updatedUser.age, 100);
+
             done();
           });
         });
@@ -183,6 +187,7 @@ module.exports = function defineModelTestsWithDataSource(options) {
           User.upsert({ first: 'bob', id: 7 }, function(err, updatedUser) {
             assert(!err);
             assert.equal(updatedUser.first, 'bob');
+
             done();
           });
         });
@@ -194,12 +199,16 @@ module.exports = function defineModelTestsWithDataSource(options) {
         User.create({ first: 'joe', last: 'bob' }, function(err, user) {
           User.findById(user.id, function(err, foundUser) {
             if (err) return done(err);
+
             assert.equal(user.id, foundUser.id);
             User.deleteById(foundUser.id, function(err) {
               if (err) return done(err);
+
               User.find({ where: { id: user.id }}, function(err, found) {
                 if (err) return done(err);
+
                 assert.equal(found.length, 0);
+
                 done();
               });
             });
@@ -214,6 +223,7 @@ module.exports = function defineModelTestsWithDataSource(options) {
           User.deleteById(user.id, function(err) {
             User.findById(user.id, function(err, notFound) {
               assert.equal(notFound, null);
+
               done();
             });
           });
@@ -228,6 +238,7 @@ module.exports = function defineModelTestsWithDataSource(options) {
             assert.equal(user.id, 23);
             assert.equal(user.first, 'michael');
             assert.equal(user.last, 'jordan');
+
             done();
           });
         });
@@ -245,6 +256,7 @@ module.exports = function defineModelTestsWithDataSource(options) {
           .on('done', function() {
             User.count({ age: { gt: 99 }}, function(err, count) {
               assert.equal(count, 2);
+
               done();
             });
           });


### PR DESCRIPTION
Based on @superkhau's suggestion that we should add blank lines to separate error-checking logic, done logic from other logic. I found most test files still don't follow this convention. So, I've refactored them.

I also changed a few error checking conditions to be one-liner;
From
```
if (err) {
  return done(err);
}
````
to
`
if (err) return done(err);
`