### PR TITLE
Composite Key validation for Realm enabled users

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -789,8 +789,18 @@ module.exports = function(User) {
       message: g.f('Must provide a valid email'),
     });
 
-    // FIXME: We need to add support for uniqueness of composite keys in juggler
-    if (!(UserModel.settings.realmRequired || UserModel.settings.realmDelimiter)) {
+    // Realm users validation
+    if (UserModel.settings.realmRequired && UserModel.settings.realmDelimiter) {
+      UserModel.validatesUniquenessOf('email', {
+        message: 'Email already exists',
+        scopedTo: ['realm'],
+      });
+      UserModel.validatesUniquenessOf('username', {
+        message: 'User already exists',
+        scopedTo: ['realm'],
+      });
+    } else {
+      // Regular(Non-realm) users validation
       UserModel.validatesUniquenessOf('email', { message: 'Email already exists' });
       UserModel.validatesUniquenessOf('username', { message: 'User already exists' });
     }

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -998,6 +998,15 @@ describe('User', function() {
       });
     });
 
+    it('honors unique email for realm', function(done) {
+      User.create(realm1User, function(err, u) {
+        assert(err);
+        assert(err.message.match(/User already exists/) &&
+          err.message.match(/Email already exists/));
+        done();
+      });
+    });
+
     it('rejects a user by without realm', function(done) {
       User.login(credentialWithoutRealm, function(err, accessToken) {
         assert(err);


### PR DESCRIPTION
connect to https://github.com/strongloop/loopback/issues/2322

addresses this https://github.com/strongloop/loopback/blob/cc95860c68d5b7726c0dd762687af4940e8a82c9/common/models/user.js#L759
currently realm doesnt enforce user-uniqueness at all.

@raymondfeng @gunjpan PTAL
