### PR TITLE
Remove unused condition for checking non-existent model

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -109,11 +109,10 @@ Registry.prototype.createModel = function(name, properties, options) {
 
   if (typeof BaseModel === 'string') {
     var baseName = BaseModel;
-    BaseModel = this.getModel(BaseModel);
-
-    if (BaseModel === undefined) {
-      console.warn('Model `%s` is extending an unknown model `%s`. ' +
-        'Using `PersistedModel` as the base.', name, baseName);
+    BaseModel = this.findModel(BaseModel);
+    if (!BaseModel) {
+      throw new Error('Model not found: model `' + name + '` is extending an unknown model `' +
+        baseName + '`.');
     }
   }
 

--- a/test/registries.test.js
+++ b/test/registries.test.js
@@ -4,6 +4,16 @@
 // License text available at https://opensource.org/licenses/MIT
 
 describe('Registry', function() {
+  describe('createModel', function() {
+    it('should throw error upon extending non-exist base model', function() {
+      var app = loopback();
+      var props = {};
+      var opts = { base: 'nonexistent' };
+      expect(function() { app.registry.createModel('aModel', props, opts); })
+        .to.throw(/model\s`aModel`(.*)unknown\smodel\s`nonexistent`/);
+    });
+  });
+
   describe('one per app', function() {
     it('should allow two apps to reuse the same model name', function(done) {
       var appFoo = loopback();


### PR DESCRIPTION
connect to https://github.com/strongloop-internal/scrum-loopback/issues/770

This behavior is actually handled by [registry.getModel()](https://github.com/strongloop/loopback/blob/1559db2ca3f5cf75606a09a806428140e9c967d6/lib/registry.js#L305)

added a test case to make sure it throws the error. 
This actually is no longer a breaking change because it already threw error