### PR TITLE
Allow hash path (/#/path ) for redirect Url

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -426,8 +426,8 @@ module.exports = function(User) {
 
     // TODO - support more verification types
     function sendEmail(user) {
-      options.verifyHref += '&token=' + user.verificationToken+ 
-      '&redirect=' + options.redirect;
+      options.verifyHref += '&token=' + user.verificationToken +
+        '&redirect=' + options.redirect;
 
       options.text = options.text || 'Please verify your email by opening ' +
         'this link in a web browser:\n\t{href}';

--- a/common/models/user.js
+++ b/common/models/user.js
@@ -403,9 +403,7 @@ module.exports = function(User) {
       userModel.http.path +
       userModel.sharedClass.findMethodByName('confirm').http.path +
       '?uid=' +
-      options.user.id +
-      '&redirect=' +
-      options.redirect;
+      options.user.id;
 
     // Email model
     var Email = options.mailer || this.constructor.email || registry.getModelByType(loopback.Email);
@@ -428,7 +426,8 @@ module.exports = function(User) {
 
     // TODO - support more verification types
     function sendEmail(user) {
-      options.verifyHref += '&token=' + user.verificationToken;
+      options.verifyHref += '&token=' + user.verificationToken+ 
+      '&redirect=' + options.redirect;
 
       options.text = options.text || 'Please verify your email by opening ' +
         'this link in a web browser:\n\t{href}';


### PR DESCRIPTION
Changed adding `'&redirect=' +options.redirect` to verifyHref, from inside `.verfiy()` method to insde of `sendEmail()` method, to allow hash paths for redirect url. From issue at https://github.com/strongloop/loopback/issues/2307

connect to #2307 
