### PR TITLE
Allow passwords to be all numbers

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -604,8 +604,8 @@ module.exports = function(User) {
     };
 
     UserModel.setter.password = function(plain) {
-      if (typeof plain !== 'string') {
-        return;
+      if (typeof plain === 'number') {
+        plain = plain.toString();
       }
       if (plain.indexOf('$2a$') === 0 && plain.length === 60) {
         // The password is already hashed. It can be the case


### PR DESCRIPTION
Allow number passwords by converting number to string before hashing.

connect to #2324 