### PR TITLE
Fix JSCS unsupported rule error

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -15,9 +15,7 @@
      "allowComments": true,
      "allowRegex": true
   },
-  "validateJSDoc": {
-    "checkParamNames": false,
-    "checkRedundantParams": false,
+  "jsDoc": {
     "requireParamTypes": true
   }
 }


### PR DESCRIPTION
This suppresses a JSCS `Unsupported rule: validateJSDoc` error by replacing the `validateJSDoc` rule with `jsDoc`. The offending rule was deprecated in JSCS [v1.7.0](https://github.com/jscs-dev/node-jscs/releases/tag/v1.7.0).

In related news, JSCS was [recently deprecated](https://medium.com/@markelog/jscs-end-of-the-line-bc9bf0b3fdb2#.5jko28oyg) in favor of ESLint.