### PR TITLE
Encode/decode redirect in verifyHref

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -426,7 +426,6 @@ module.exports = function(User) {
 
     // TODO - support more verification types
     function sendEmail(user) {
-      //add redirect here to allow hashed paths
       options.verifyHref += '&token=' + user.verificationToken +
        '&redirect=' + options.redirect;
 

--- a/common/models/user.js
+++ b/common/models/user.js
@@ -403,7 +403,8 @@ module.exports = function(User) {
       userModel.http.path +
       userModel.sharedClass.findMethodByName('confirm').http.path +
       '?uid=' +
-      options.user.id;
+      options.user.id +
+      '&redirect=' + encodeURIComponent(options.redirect);
 
     // Email model
     var Email = options.mailer || this.constructor.email || registry.getModelByType(loopback.Email);
@@ -426,8 +427,8 @@ module.exports = function(User) {
 
     // TODO - support more verification types
     function sendEmail(user) {
-      options.verifyHref += '&token=' + user.verificationToken +
-       '&redirect=' + options.redirect;
+      options.verifyHref += '&token=' + user.verificationToken;
+
 
       options.text = options.text || 'Please verify your email by opening ' +
         'this link in a web browser:\n\t{href}';
@@ -705,7 +706,7 @@ module.exports = function(User) {
         if (!ctx.res) {
           return next(new Error('The transport does not support HTTP redirects.'));
         }
-        ctx.res.location(ctx.args.redirect);
+        ctx.res.location(decodeURIComponent(ctx.args.redirect));
         ctx.res.status(302);
       }
       next();

--- a/common/models/user.js
+++ b/common/models/user.js
@@ -403,9 +403,7 @@ module.exports = function(User) {
       userModel.http.path +
       userModel.sharedClass.findMethodByName('confirm').http.path +
       '?uid=' +
-      options.user.id +
-      '&redirect=' +
-      options.redirect;
+      options.user.id;
 
     // Email model
     var Email = options.mailer || this.constructor.email || registry.getModelByType(loopback.Email);
@@ -428,7 +426,8 @@ module.exports = function(User) {
 
     // TODO - support more verification types
     function sendEmail(user) {
-      options.verifyHref += '&token=' + user.verificationToken;
+      options.verifyHref += '&token=' + user.verificationToken +
+       '&redirect=' + options.redirect;
 
       options.text = options.text || 'Please verify your email by opening ' +
         'this link in a web browser:\n\t{href}';

--- a/common/models/user.js
+++ b/common/models/user.js
@@ -426,6 +426,7 @@ module.exports = function(User) {
 
     // TODO - support more verification types
     function sendEmail(user) {
+      //add redirect here to allow hashed paths
       options.verifyHref += '&token=' + user.verificationToken +
        '&redirect=' + options.redirect;
 


### PR DESCRIPTION
The encoding of options.redirect and decoding it after verification is done allows the hash paths without breaking href in email.