### PR TITLE
Make the doc clear for `findORCreate` cb

### DIFF
--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -143,7 +143,7 @@ module.exports = function(registry) {
    * @callback {Function} callback Callback function called with `cb(err, instance, created)` arguments.  Required.
    * @param {Error} err Error object; see [Error object](http://docs.strongloop.com/display/LB/Error+object).
    * @param {Object} instance Model instance matching the `where` filter, if found.
-   * @param {Boolean} created True if the instance matching the `where` filter was created.
+   * @param {Boolean} created True if the instance does not exist and gets created.
    */
 
   PersistedModel.findOrCreate = function findOrCreate(query, data, callback) {


### PR DESCRIPTION
Make the `created` from callback JSdoc clearer.

Connect to https://github.com/strongloop/loopback-datasource-juggler/issues/932

@crandmck PTAL.