### PR TITLE
Docuemtation for `replace*` methods

### DIFF
--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -116,6 +116,22 @@ module.exports = function(registry) {
   };
 
   /**
+   * Replace or insert a model instance; replace existing record if one is found,
+   * such that parameter `data.id` matches `id` of model instance; otherwise,
+   * insert a new record.
+   * @param {Object} data The model instance data.
+   * @options {Object} [options] Options for replaceOrCreate
+   * @property {Boolean} validate Perform validation before saving.  Default is true.
+   * @callback {Function} callback Callback function called with `cb(err, obj)` signature.
+   * @param {Error} err Error object; see [Error object](http://docs.strongloop.com/display/LB/Error+object).
+   * @param {Object} model Replaced model instance.
+   */
+
+  PersistedModel.replaceOrCreate = function replaceOrCreate(data, callback) {
+    throwNotAttached(this.modelName, 'replaceOrCreate');
+  };
+
+  /**
    * Finds one record matching the optional filter object. If not found, creates
    * the object using the data provided as second argument. In this sense it is
    * the same as `find`, but limited to one object. Returns an object, not
@@ -480,6 +496,40 @@ module.exports = function(registry) {
 
   PersistedModel.prototype.updateAttributes = function updateAttributes(data, cb) {
     throwNotAttached(this.modelName, 'updateAttributes');
+  };
+
+  /**
+   * Replace attributes for a model instance and persist it into the datasource.
+   * Performs validation before replacing.
+   *
+   * @param {Object} data Data to replace.
+   * @options {Object} [options] Options for replace
+   * @property {Boolean} validate Perform validation before saving.  Default is true.
+   * @callback {Function} callback Callback function called with `(err, instance)` arguments.
+   * @param {Error} err Error object; see [Error object](http://docs.strongloop.com/display/LB/Error+object).
+   * @param {Object} instance Replaced instance.
+   */
+
+  PersistedModel.prototype.replaceAttributes = function replaceAttributes(data, cb) {
+    throwNotAttached(this.modelName, 'replaceAttributes');
+  };
+
+  /**
+   * Replace attributes for a model instance whose id is the first input
+   * argument and persist it into the datasource.
+   * Performs validation before replacing.
+   *
+   * @param {*} id The ID value of model instance to replace.
+   * @param {Object} data Data to replace.
+   * @options {Object} [options] Options for replace
+   * @property {Boolean} validate Perform validation before saving.  Default is true.
+   * @callback {Function} callback Callback function called with `(err, instance)` arguments.
+   * @param {Error} err Error object; see [Error object](http://docs.strongloop.com/display/LB/Error+object).
+   * @param {Object} instance Replaced instance.
+   */
+
+  PersistedModel.replaceById = function replaceById(id, data, cb) {
+    throwNotAttached(this.modelName, 'replaceById');
   };
 
   /**


### PR DESCRIPTION
This PR adds JS doc in `lib/persisted-model.js` for `replace*` methods.

@crandmck Please review!