### PR TITLE
Explicitly specified indexes on the User and ACL models

### DIFF
--- a/common/models/acl.json
+++ b/common/models/acl.json
@@ -3,13 +3,18 @@
   "properties": {
     "model": {
       "type": "string",
+      "index": true,
       "description": "The name of the model"
     },
     "property": {
       "type": "string",
+      "index": true,
       "description": "The name of the property, method, scope, or relation"
     },
-    "accessType": "string",
+    "accessType": {
+      "type": "string",
+      "index": true
+    },
     "permission": "string",
     "principalType": "string",
     "principalId": "string"

--- a/common/models/user.json
+++ b/common/models/user.json
@@ -5,7 +5,8 @@
       "type": "string"
     },
     "username": {
-      "type": "string"
+      "type": "string",
+      "index": true
     },
     "password": {
       "type": "string",
@@ -13,7 +14,8 @@
     },
     "email": {
       "type": "string",
-      "required": true
+      "required": true,
+      "index": true
     },
     "emailVerified": "boolean",
     "verificationToken": "string"


### PR DESCRIPTION
This change allows the default common models to work out of the box with the Redis loopback connector.  Without it, this error is shown:

```
Error: User: no indexes found for username impossible to sort and filter using redis connector
```

After this, normal operations can work properly.  I took this to mean that other connectors implicitly determine the indexes while the Redis connector cannot.

I understand that this may be a problem with the Redis connector not implicitly determining the correct indexes, but it is honestly a lot easier and a lot simpler to make the change here.
