### PR TITLE
[SEMVER-MAJOR] Fix remoting strong-error-handler

### DIFF
--- a/test/access-token.test.js
+++ b/test/access-token.test.js
@@ -503,6 +503,7 @@ function createTestApp(testToken, settings, done) {
 
   app.use(cookieParser('secret'));
   app.use(loopback.token(tokenSettings));
+  app.set('remoting', { errorHandler: { debug: true, log: false }});
   app.get('/token', function(req, res) {
     res.cookie('authorization', testToken.id, { signed: true });
     res.cookie('access_token', testToken.id, { signed: true });

--- a/test/acl.test.js
+++ b/test/acl.test.js
@@ -396,6 +396,7 @@ describe('access check', function() {
   var app;
   before(function() {
     app = loopback();
+    app.set('remoting', { errorHandler: { debug: true, log: false }});
     app.use(loopback.rest());
     app.enableAuth();
     app.dataSource('test', { connector: 'memory' });

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -613,6 +613,7 @@ describe('app', function() {
     var app, db;
     beforeEach(function() {
       app = loopback();
+      app.set('remoting', { errorHandler: { debug: true, log: false }});
       db = loopback.createDataSource({ connector: loopback.Memory });
     });
 

--- a/test/fixtures/access-control/server/config.json
+++ b/test/fixtures/access-control/server/config.json
@@ -1,5 +1,11 @@
 {
   "port": 3000,
   "host": "0.0.0.0",
-  "legacyExplorer": false
+  "legacyExplorer": false,
+  "remoting": {
+    "errorHandler": {
+      "debug": true,
+      "log": false
+    }
+  }
 }

--- a/test/fixtures/shared-methods/both-configs-set/server/config.json
+++ b/test/fixtures/shared-methods/both-configs-set/server/config.json
@@ -20,7 +20,8 @@
     },
     "cors": false,
     "errorHandler": {
-      "disableStackTrace": false
+      "debug": true,
+      "log": false
     },
     "sharedMethods": {
       "*": false,

--- a/test/fixtures/shared-methods/config-default-false/server/config.json
+++ b/test/fixtures/shared-methods/config-default-false/server/config.json
@@ -20,7 +20,8 @@
     },
     "cors": false,
     "errorHandler": {
-      "disableStackTrace": false
+      "debug": true,
+      "log": false
     },
     "sharedMethods": {
       "*": false

--- a/test/fixtures/shared-methods/config-default-true/server/config.json
+++ b/test/fixtures/shared-methods/config-default-true/server/config.json
@@ -20,7 +20,8 @@
     },
     "cors": false,
     "errorHandler": {
-      "disableStackTrace": false
+      "debug": true,
+      "log": false
     },
     "sharedMethods": {
       "*": true

--- a/test/fixtures/shared-methods/config-defined-false/server/config.json
+++ b/test/fixtures/shared-methods/config-defined-false/server/config.json
@@ -20,7 +20,8 @@
     },
     "cors": false,
     "errorHandler": {
-      "disableStackTrace": false
+      "debug": true,
+      "log": false
     },
     "sharedMethods": {
       "find": false

--- a/test/fixtures/shared-methods/config-defined-true/server/config.json
+++ b/test/fixtures/shared-methods/config-defined-true/server/config.json
@@ -20,7 +20,8 @@
     },
     "cors": false,
     "errorHandler": {
-      "disableStackTrace": false
+      "debug": true,
+      "log": false
     },
     "sharedMethods": {
       "find": true

--- a/test/fixtures/shared-methods/model-config-default-false/server/config.json
+++ b/test/fixtures/shared-methods/model-config-default-false/server/config.json
@@ -20,7 +20,8 @@
     },
     "cors": false,
     "errorHandler": {
-      "disableStackTrace": false
+      "debug": true,
+      "log": false
     }
   },
   "legacyExplorer": false

--- a/test/fixtures/shared-methods/model-config-default-true/server/config.json
+++ b/test/fixtures/shared-methods/model-config-default-true/server/config.json
@@ -20,7 +20,8 @@
     },
     "cors": false,
     "errorHandler": {
-      "disableStackTrace": false
+      "debug": true,
+      "log": false
     }
   },
   "legacyExplorer": false

--- a/test/fixtures/shared-methods/model-config-defined-false/server/config.json
+++ b/test/fixtures/shared-methods/model-config-defined-false/server/config.json
@@ -20,7 +20,8 @@
     },
     "cors": false,
     "errorHandler": {
-      "disableStackTrace": false
+      "debug": true,
+      "log": false
     }
   },
   "legacyExplorer": false

--- a/test/fixtures/shared-methods/model-config-defined-true/server/config.json
+++ b/test/fixtures/shared-methods/model-config-defined-true/server/config.json
@@ -20,7 +20,8 @@
     },
     "cors": false,
     "errorHandler": {
-      "disableStackTrace": false
+      "debug": true,
+      "log": false
     }
   },
   "legacyExplorer": false

--- a/test/fixtures/simple-app/server/config.json
+++ b/test/fixtures/simple-app/server/config.json
@@ -1,5 +1,11 @@
 {
   "port": 3000,
   "host": "127.0.0.1",
-  "legacyExplorer": false
+  "legacyExplorer": false,
+  "remoting": {
+    "errorHandler": {
+      "debug": true,
+      "log": false
+    }
+  }
 }

--- a/test/fixtures/simple-integration-app/server/config.json
+++ b/test/fixtures/simple-integration-app/server/config.json
@@ -9,6 +9,10 @@
     },
     "urlencoded": {
       "limit": "8kb"
+    },
+    "errorHandler": {
+      "debug": true,
+      "log": false
     }
   },
   "legacyExplorer": false

--- a/test/fixtures/user-integration-app/server/config.json
+++ b/test/fixtures/user-integration-app/server/config.json
@@ -9,6 +9,10 @@
     },
     "urlencoded": {
       "limit": "8kb"
+    },
+    "errorHandler": {
+      "debug": true,
+      "log": false
     }
   },
   "legacyExplorer": false

--- a/test/helpers/loopback-testing-helper.js
+++ b/test/helpers/loopback-testing-helper.js
@@ -67,6 +67,8 @@ _beforeEach.givenModel = function(modelName, attrs, optionalHandler) {
     var test = this;
     var app = this.app;
     var model = app.models[modelName];
+
+    app.set('remoting', { errorHandler: { debug: true, log: false }});
     assert(model, 'cannot get model of name ' + modelName + ' from app.models');
     assert(model.dataSource, 'cannot test model ' + modelName +
         ' without attached dataSource');

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -125,6 +125,7 @@ describe.onServer('Remote Methods', function() {
     );
 
     app = loopback();
+    app.set('remoting', { errorHandler: { debug: true, log: false }});
     app.use(loopback.rest());
     app.model(User);
   });

--- a/test/relations.integration.js
+++ b/test/relations.integration.js
@@ -263,7 +263,7 @@ describe('relations - integration', function() {
     lt.describe.whenCalledRemotely('GET', '/stores/:id/widgets/:fk', function() {
       it('should fail with statusCode 404', function() {
         assert.equal(this.res.statusCode, 404);
-        assert.equal(this.res.body.error.status, 404);
+        assert.equal(this.res.body.error.statusCode, 404);
       });
     });
   });
@@ -1652,7 +1652,7 @@ describe('relations - integration', function() {
           expect(res.body).to.be.an('object');
           expect(res.body.error).to.be.an('object');
           expect(res.body.error.name).to.equal('Error');
-          expect(res.body.error.status).to.equal(500);
+          expect(res.body.error.statusCode).to.equal(500);
           expect(res.body.error.message).to.equal('This should not crash the app');
 
           done();

--- a/test/remote-connector.test.js
+++ b/test/remote-connector.test.js
@@ -13,6 +13,7 @@ describe('RemoteConnector', function() {
     beforeEach: function(done) {
       var test = this;
       remoteApp = loopback();
+      remoteApp.set('remoting', { errorHandler: { debug: true, log: false }});
       remoteApp.use(loopback.rest());
       remoteApp.listen(0, function() {
         test.dataSource = loopback.createDataSource({

--- a/test/remoting.integration.js
+++ b/test/remoting.integration.js
@@ -22,7 +22,8 @@ describe('remoting - integration', function() {
     it('should load remoting options', function() {
       var remotes = app.remotes();
       assert.deepEqual(remotes.options, { 'json': { 'limit': '1kb', 'strict': false },
-        'urlencoded': { 'limit': '8kb', 'extended': true }});
+        'urlencoded': { 'limit': '8kb', 'extended': true },
+        'errorHandler': { 'debug': true, log: false }});
     });
 
     it('rest handler', function() {

--- a/test/replication.rest.test.js
+++ b/test/replication.rest.test.js
@@ -462,6 +462,7 @@ describe('Replication over REST', function() {
 
   function setupServer(done) {
     serverApp = loopback();
+    serverApp.set('remoting', { errorHandler: { debug: true, log: false }});
     serverApp.enableAuth();
 
     serverApp.dataSource('db', { connector: 'memory' });

--- a/test/rest.middleware.test.js
+++ b/test/rest.middleware.test.js
@@ -12,6 +12,7 @@ describe('loopback.rest', function() {
     // override the global app object provided by test/support.js
     // and create a local one that does not share state with other tests
     app = loopback({ localRegistry: true, loadBuiltinModels: true });
+    app.set('remoting', { errorHandler: { debug: true, log: false }});
     var db = app.dataSource('db', { connector: 'memory' });
     MyModel = app.registry.createModel('MyModel');
     MyModel.attachTo(db);

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -30,6 +30,7 @@ describe('User', function() {
     // override the global app object provided by test/support.js
     // and create a local one that does not share state with other tests
     app = loopback({ localRegistry: true, loadBuiltinModels: true });
+    app.set('remoting', { errorHandler: { debug: true, log: false }});
     app.dataSource('db', { connector: 'memory' });
 
     // setup Email model, it's needed by User tests


### PR DESCRIPTION
connect to https://github.com/strongloop-internal/scrum-loopback/issues/852

addresses test cases failing and stacktrace showing up on `npm test` 

should land with https://github.com/strongloop/strong-remoting/pull/302
