### PR TITLE
[SEMVER-MINOR] Deprecate getters for express 3.x middleware

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -14,8 +14,5 @@
      "value": 150,
      "allowComments": true,
      "allowRegex": true
-  },
-  "jsDoc": {
-    "requireParamTypes": true
   }
 }

--- a/lib/express-middleware.js
+++ b/lib/express-middleware.js
@@ -4,6 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 var path = require('path');
+var deprecated = require('depd')('loopback');
 
 var middlewares = exports;
 
@@ -29,12 +30,10 @@ var middlewareModules = {
   'cookieParser': 'cookie-parser',
   'cookieSession': 'cookie-session',
   'csrf': 'csurf',
-  'errorHandler': 'errorhandler',
   'session': 'express-session',
   'methodOverride': 'method-override',
   'logger': 'morgan',
   'responseTime': 'response-time',
-  'favicon': 'serve-favicon',
   'directory': 'serve-index',
   // 'static': 'serve-static',
   'vhost': 'vhost'
@@ -44,14 +43,20 @@ middlewares.bodyParser = safeRequire('body-parser');
 middlewares.json = middlewares.bodyParser && middlewares.bodyParser.json;
 middlewares.urlencoded = middlewares.bodyParser && middlewares.bodyParser.urlencoded;
 
+['bodyParser', 'json', 'urlencoded'].forEach(function(name) {
+  if (!middlewares[name]) return;
+  middlewares[name] = deprecated.function(
+    middlewares[name],
+    deprecationMessage(name, 'body-parser'));
+});
+
 for (var m in middlewareModules) {
   var moduleName = middlewareModules[m];
   middlewares[m] = safeRequire(moduleName) || createMiddlewareNotInstalled(m, moduleName);
+  deprecated.property(middlewares, m, deprecationMessage(m, moduleName));
 }
 
-// serve-favicon requires a path
-var favicon = middlewares.favicon;
-middlewares.favicon = function(icon, options) {
-  icon = icon || path.join(__dirname, '../favicon.ico');
-  return favicon(icon, options);
-};
+function deprecationMessage(accessor, moduleName) {
+  return 'loopback.' + accessor + ' is deprecated. ' +
+    'Use `require(\'' + moduleName + '\');` instead.';
+}

--- a/server/middleware/favicon.js
+++ b/server/middleware/favicon.js
@@ -3,8 +3,14 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+var favicon = require('serve-favicon');
+var path = require('path');
+
 /**
  * Serve the LoopBack favicon.
  * @header loopback.favicon()
  */
-module.exports = require('../../lib/express-middleware').favicon;
+module.exports = function(icon, options) {
+  icon = icon || path.join(__dirname, '../../favicon.ico');
+  return favicon(icon, options);
+};

--- a/test/access-token.test.js
+++ b/test/access-token.test.js
@@ -3,6 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+var cookieParser = require('cookie-parser');
 var loopback = require('../');
 var extend = require('util')._extend;
 var Token = loopback.AccessToken.extend('MyToken');
@@ -500,7 +501,7 @@ function createTestApp(testToken, settings, done) {
 
   var app = loopback();
 
-  app.use(loopback.cookieParser('secret'));
+  app.use(cookieParser('secret'));
   app.use(loopback.token(tokenSettings));
   app.get('/token', function(req, res) {
     res.cookie('authorization', testToken.id, {signed: true});

--- a/test/rest.middleware.test.js
+++ b/test/rest.middleware.test.js
@@ -17,6 +17,9 @@ describe('loopback.rest', function() {
     MyModel.attachTo(db);
   });
 
+  if (process.env.CI)
+    this.timeout(3000);
+
   it('works out-of-the-box', function(done) {
     app.model(MyModel);
     app.use(loopback.rest());


### PR DESCRIPTION
We are removing these getter in LoopBack 3.0, see #2394 for more details.

@raymondfeng please review