### PR TITLE
[SEMVER-MAJOR] Remove legacyExplorer

### DIFF
--- a/server/middleware/rest.js
+++ b/server/middleware/rest.js
@@ -35,19 +35,6 @@ function rest() {
     var app = req.app;
     var registry = app.registry;
 
-    // added for https://github.com/strongloop/loopback/issues/1134
-    if (app.get('legacyExplorer') !== false) {
-      deprecate(
-        'Routes "/methods" and "/models" are considered dangerous and should not be used.\n' +
-        'Disable them by setting "legacyExplorer=false" in "server/config.json" or via "app.set()".'
-      );
-      if (req.url === '/routes') {
-        return res.send(app.handler('rest').adapter.allRoutes());
-      } else if (req.url === '/models') {
-        return res.send(app.remotes().toJSON());
-      }
-    }
-
     if (!handlers) {
       handlers = [];
       var remotingOptions = app.get('remoting') || {};

--- a/test/fixtures/access-control/server/config.json
+++ b/test/fixtures/access-control/server/config.json
@@ -1,7 +1,6 @@
 {
   "port": 3000,
   "host": "0.0.0.0",
-  "legacyExplorer": false,
   "remoting": {
     "errorHandler": {
       "debug": true,

--- a/test/fixtures/shared-methods/both-configs-set/server/config.json
+++ b/test/fixtures/shared-methods/both-configs-set/server/config.json
@@ -27,7 +27,5 @@
       "*": false,
       "destroyAll": true
     }
-  },
-  "legacyExplorer": false
+  }
 }
-

--- a/test/fixtures/shared-methods/config-default-false/server/config.json
+++ b/test/fixtures/shared-methods/config-default-false/server/config.json
@@ -26,7 +26,5 @@
     "sharedMethods": {
       "*": false
     }
-  },
-  "legacyExplorer": false
+  }
 }
-

--- a/test/fixtures/shared-methods/config-default-true/server/config.json
+++ b/test/fixtures/shared-methods/config-default-true/server/config.json
@@ -26,7 +26,5 @@
     "sharedMethods": {
       "*": true
     }
-  },
-  "legacyExplorer": false
+  }
 }
-

--- a/test/fixtures/shared-methods/config-defined-false/server/config.json
+++ b/test/fixtures/shared-methods/config-defined-false/server/config.json
@@ -26,7 +26,5 @@
     "sharedMethods": {
       "find": false
     }
-  },
-  "legacyExplorer": false
+  }
 }
-

--- a/test/fixtures/shared-methods/config-defined-true/server/config.json
+++ b/test/fixtures/shared-methods/config-defined-true/server/config.json
@@ -26,7 +26,5 @@
     "sharedMethods": {
       "find": true
     }
-  },
-  "legacyExplorer": false
+  }
 }
-

--- a/test/fixtures/shared-methods/model-config-default-false/server/config.json
+++ b/test/fixtures/shared-methods/model-config-default-false/server/config.json
@@ -23,7 +23,5 @@
       "debug": true,
       "log": false
     }
-  },
-  "legacyExplorer": false
+  }
 }
-

--- a/test/fixtures/shared-methods/model-config-default-true/server/config.json
+++ b/test/fixtures/shared-methods/model-config-default-true/server/config.json
@@ -23,7 +23,5 @@
       "debug": true,
       "log": false
     }
-  },
-  "legacyExplorer": false
+  }
 }
-

--- a/test/fixtures/shared-methods/model-config-defined-false/server/config.json
+++ b/test/fixtures/shared-methods/model-config-defined-false/server/config.json
@@ -23,7 +23,5 @@
       "debug": true,
       "log": false
     }
-  },
-  "legacyExplorer": false
+  }
 }
-

--- a/test/fixtures/shared-methods/model-config-defined-true/server/config.json
+++ b/test/fixtures/shared-methods/model-config-defined-true/server/config.json
@@ -23,7 +23,5 @@
       "debug": true,
       "log": false
     }
-  },
-  "legacyExplorer": false
+  }
 }
-

--- a/test/fixtures/simple-app/server/config.json
+++ b/test/fixtures/simple-app/server/config.json
@@ -1,7 +1,6 @@
 {
   "port": 3000,
   "host": "127.0.0.1",
-  "legacyExplorer": false,
   "remoting": {
     "errorHandler": {
       "debug": true,

--- a/test/fixtures/simple-integration-app/server/config.json
+++ b/test/fixtures/simple-integration-app/server/config.json
@@ -14,6 +14,5 @@
       "debug": true,
       "log": false
     }
-  },
-  "legacyExplorer": false
+  }
 }

--- a/test/fixtures/user-integration-app/server/config.json
+++ b/test/fixtures/user-integration-app/server/config.json
@@ -14,6 +14,5 @@
       "debug": true,
       "log": false
     }
-  },
-  "legacyExplorer": false
+  }
 }

--- a/test/replication.rest.test.js
+++ b/test/replication.rest.test.js
@@ -502,7 +502,6 @@ describe('Replication over REST', function() {
     serverApp.use(loopback.token({ model: ServerToken }));
     serverApp.use(loopback.rest());
 
-    serverApp.set('legacyExplorer', false);
     serverApp.set('port', 0);
     serverApp.set('host', '127.0.0.1');
     serverApp.listen(function() {

--- a/test/rest.middleware.test.js
+++ b/test/rest.middleware.test.js
@@ -27,7 +27,6 @@ describe('loopback.rest', function() {
   });
 
   it('should report 200 for DELETE /:id found', function(done) {
-    app.set('legacyExplorer', false);
     app.model(MyModel);
     app.use(loopback.rest());
     MyModel.create({ name: 'm1' }, function(err, inst) {
@@ -195,48 +194,6 @@ describe('loopback.rest', function() {
           done();
         });
     }, done);
-  });
-
-  it('should report 200 for legacy explorer route /routes', function(done) {
-    app.use(loopback.rest());
-    request(app).get('/routes')
-      .expect(200)
-      .end(function(err, res) {
-        if (err) return done(err);
-
-        expect(res.body).to.eql([]);
-
-        done();
-      });
-  });
-
-  it('should report 200 for legacy explorer route /models', function(done) {
-    app.use(loopback.rest());
-    request(app).get('/models')
-      .expect(200)
-      .end(function(err, res) {
-        if (err) return done(err);
-
-        expect(res.body).to.eql({});
-
-        done();
-      });
-  });
-
-  it('should report 404 for disabled legacy explorer route /routes', function(done) {
-    app.set('legacyExplorer', false);
-    app.use(loopback.rest());
-    request(app).get('/routes')
-      .expect(404)
-      .end(done);
-  });
-
-  it('should report 404 for disabled legacy explorer route /models', function(done) {
-    app.set('legacyExplorer', false);
-    app.use(loopback.rest());
-    request(app).get('/models')
-      .expect(404)
-      .end(done);
   });
 
   describe('context propagation', function() {


### PR DESCRIPTION
- Removes backward compatibility
for legacy end points `/models` & `/routes`
- Removes `legacyExplorer` flag which
enabled these routes
- Update related tests & tests using the
legacyExplorer flag

Connect to https://github.com/strongloop/loopback/issues/2037