### PR TITLE
Change set verificationToken on User.confirm

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -485,7 +485,7 @@ module.exports = function(User) {
         fn(err);
       } else {
         if (user && user.verificationToken === token) {
-          user.verificationToken = undefined;
+          user.verificationToken = null;
           user.emailVerified = true;
           user.save(function(err) {
             if (err) {


### PR DESCRIPTION
This addresses issue #2424

Simple change to setting the verificationToken to null, instead of undefined. undefined causes the field to not be updated via the Postgres adapter.

Note: the tests have a single failure for me at the moment, but they're also failing on master branch.