### PR TITLE
Expose `Replace*` methods for 2.x

### DIFF
--- a/common/models/user.json
+++ b/common/models/user.json
@@ -77,6 +77,12 @@
     },
     {
       "principalType": "ROLE",
+      "principalId": "$owner",
+      "permission": "ALLOW",
+      "property": "replaceById"
+    },  
+    {
+      "principalType": "ROLE",
       "principalId": "$everyone",
       "permission": "ALLOW",
       "property": "confirm"

--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -125,8 +125,25 @@ module.exports = function(registry) {
    * @param {Object} model Updated model instance.
    */
 
-  PersistedModel.upsert = PersistedModel.updateOrCreate = function upsert(data, callback) {
+  PersistedModel.upsert = PersistedModel.updateOrCreate = PersistedModel.patchOrCreate =
+  function upsert(data, callback) {
     throwNotAttached(this.modelName, 'upsert');
+  };
+
+  /**
+   * Replace or insert a model instance; replace existing record if one is found,
+   * such that parameter `data.id` matches `id` of model instance; otherwise,
+   * insert a new record.
+   * @param {Object} data The model instance data.
+   * @options {Object} [options] Options for replaceOrCreate
+   * @property {Boolean} validate Perform validation before saving.  Default is true.
+   * @callback {Function} callback Callback function called with `cb(err, obj)` signature.
+   * @param {Error} err Error object; see [Error object](http://docs.strongloop.com/display/LB/Error+object).
+   * @param {Object} model Replaced model instance.
+   */
+
+  PersistedModel.replaceOrCreate = function replaceOrCreate(data, callback) {
+    throwNotAttached(this.modelName, 'replaceOrCreate');
   };
 
   /**
@@ -492,8 +509,43 @@ module.exports = function(registry) {
    * @param {Object} instance Updated instance.
    */
 
-  PersistedModel.prototype.updateAttributes = function updateAttributes(data, cb) {
+  PersistedModel.prototype.updateAttributes = PersistedModel.prototype.patchAttributes =
+  function updateAttributes(data, cb) {
     throwNotAttached(this.modelName, 'updateAttributes');
+  };
+
+  /**
+   * Replace attributes for a model instance and persist it into the datasource.
+   * Performs validation before replacing.
+   *
+   * @param {Object} data Data to replace.
+   * @options {Object} [options] Options for replace
+   * @property {Boolean} validate Perform validation before saving.  Default is true.
+   * @callback {Function} callback Callback function called with `(err, instance)` arguments.
+   * @param {Error} err Error object; see [Error object](http://docs.strongloop.com/display/LB/Error+object).
+   * @param {Object} instance Replaced instance.
+   */
+
+  PersistedModel.prototype.replaceAttributes = function replaceAttributes(data, cb) {
+    throwNotAttached(this.modelName, 'replaceAttributes');
+  };
+
+  /**
+   * Replace attributes for a model instance whose id is the first input
+   * argument and persist it into the datasource.
+   * Performs validation before replacing.
+   *
+   * @param {*} id The ID value of model instance to replace.
+   * @param {Object} data Data to replace.
+   * @options {Object} [options] Options for replace
+   * @property {Boolean} validate Perform validation before saving.  Default is true.
+   * @callback {Function} callback Callback function called with `(err, instance)` arguments.
+   * @param {Error} err Error object; see [Error object](http://docs.strongloop.com/display/LB/Error+object).
+   * @param {Object} instance Replaced instance.
+   */
+
+  PersistedModel.replaceById = function replaceById(id, data, cb) {
+    throwNotAttached(this.modelName, 'replaceById');
   };
 
   /**
@@ -564,6 +616,9 @@ module.exports = function(registry) {
     var typeName = PersistedModel.modelName;
     var options = PersistedModel.settings;
 
+    // This is just for LB 2.x
+    options.replaceOnPUT = options.replaceOnPUT === true;
+
     function setRemoting(scope, name, options) {
       var fn = scope[name];
       fn._delegate = true;
@@ -579,15 +634,35 @@ module.exports = function(registry) {
       http: {verb: 'post', path: '/'}
     });
 
-    setRemoting(PersistedModel, 'upsert', {
-      aliases: ['updateOrCreate'],
-      description: g.s('Update an existing model instance or insert a new one ' +
-        'into the data source.'),
+    var upsertOptions = {
+      aliases: ['patchOrCreate', 'updateOrCreate'],
+      description: g.s('Patch an existing model instance or insert a new one into the data source.'),
       accessType: 'WRITE',
-      accepts: {arg: 'data', type: 'object', description: 'Model instance data', http: {source: 'body'}},
-      returns: {arg: 'data', type: typeName, root: true},
-      http: {verb: 'put', path: '/'}
-    });
+      accepts: { arg: 'data', type: 'object', http: { source: 'body' }, description:
+        'Model instance data' },
+      returns: { arg: 'data', type: typeName, root: true },
+      http: [{ verb: 'patch', path: '/' }],
+    };
+
+    if (!options.replaceOnPUT) {
+      upsertOptions.http.push({ verb: 'put', path: '/' });
+    }
+    setRemoting(PersistedModel, 'upsert', upsertOptions);
+
+    var replaceOrCreateOptions = {
+      description: 'Replace an existing model instance or insert a new one into the data source.',
+      accessType: 'WRITE',
+      accepts: { arg: 'data', type: 'object', http: { source: 'body' }, description:
+        'Model instance data' },
+      returns: { arg: 'data', type: typeName, root: true },
+      http: [{ verb: 'post', path: '/replaceOrCreate' }],
+    };
+
+    if (options.replaceOnPUT) {
+      replaceOrCreateOptions.http.push({ verb: 'put', path: '/' });
+    }
+
+    setRemoting(PersistedModel, 'replaceOrCreate', replaceOrCreateOptions);
 
     setRemoting(PersistedModel, 'exists', {
       description: g.s('Check whether a model instance exists in the data source.'),
@@ -633,6 +708,25 @@ module.exports = function(registry) {
       http: {verb: 'get', path: '/:id'},
       rest: {after: convertNullToNotFoundError}
     });
+
+    var replaceByIdOptions = {
+      description: 'Replace attributes for a model instance and persist it into the data source.',
+      accessType: 'WRITE',
+      accepts: [
+        { arg: 'id', type: 'any', description: 'Model id', required: true,
+          http: { source: 'path' }},
+          { arg: 'data', type: 'object', http: { source: 'body' }, description:
+        'Model instance data' },
+      ],
+      returns: { arg: 'data', type: typeName, root: true },
+      http: [{ verb: 'post', path: '/:id/replace' }],
+    };
+
+    if (options.replaceOnPUT) {
+      replaceByIdOptions.http.push({ verb: 'put', path: '/:id' });
+    }
+
+    setRemoting(PersistedModel, 'replaceById', replaceByIdOptions);
 
     setRemoting(PersistedModel, 'find', {
       description: g.s('Find all instances of the model matched by filter from the data source.'),
@@ -702,14 +796,21 @@ module.exports = function(registry) {
       http: {verb: 'get', path: '/count'}
     });
 
-    setRemoting(PersistedModel.prototype, 'updateAttributes', {
-      description: g.s('Update attributes for a model instance and persist it into ' +
-        'the data source.'),
+    var updateAttributesOptions = {
+      aliases: ['patchAttributes'],
+      description: g.s('Patch attributes for a model instance and persist it into the data source.'),
       accessType: 'WRITE',
-      accepts: {arg: 'data', type: 'object', http: {source: 'body'}, description: 'An object of model property name/value pairs'},
-      returns: {arg: 'data', type: typeName, root: true},
-      http: {verb: 'put', path: '/'}
-    });
+
+      accepts: { arg: 'data', type: 'object', http: { source: 'body' }, description: 'An object of model property name/value pairs' },
+      returns: { arg: 'data', type: typeName, root: true },
+      http: [{ verb: 'patch', path: '/' }],
+    };
+
+    setRemoting(PersistedModel.prototype, 'updateAttributes', updateAttributesOptions);
+
+    if (!options.replaceOnPUT) {
+      updateAttributesOptions.http.push({ verb: 'put', path: '/' });
+    }
 
     if (options.trackChanges || options.enableRemoteReplication) {
       setRemoting(PersistedModel, 'diff', {

--- a/test/fixtures/access-control/common/models/accountWithReplaceOnPUTfalse.json
+++ b/test/fixtures/access-control/common/models/accountWithReplaceOnPUTfalse.json
@@ -1,6 +1,6 @@
 {
-  "name": "accountWithReplaceOnPUTtrue",
-  "plural": "accounts-replacing",
+  "name": "accountWithReplaceOnPUTfalse",
+  "plural": "accounts-updating",
   "relations": {
     "transactions": {
       "model": "transaction",
@@ -40,5 +40,5 @@
     }
   ],
   "properties": {},
-  "replaceOnPUT": true
+  "replaceOnPUT": false
 }

--- a/test/fixtures/access-control/common/models/user.json
+++ b/test/fixtures/access-control/common/models/user.json
@@ -19,5 +19,6 @@
       "principalType": "ROLE",
       "principalId": "$everyone"
     }
-  ]
+  ],
+  "replaceOnPUT": false  
 }

--- a/test/fixtures/access-control/server/model-config.json
+++ b/test/fixtures/access-control/server/model-config.json
@@ -34,7 +34,11 @@
     "public": true,
     "dataSource": "db"
   },
-  "account": {
+  "accountWithReplaceOnPUTtrue": {
+    "public": true,
+    "dataSource": "db"
+  },
+  "accountWithReplaceOnPUTfalse": {
     "public": true,
     "dataSource": "db"
   },

--- a/test/fixtures/simple-integration-app/common/models/store-replacing.json
+++ b/test/fixtures/simple-integration-app/common/models/store-replacing.json
@@ -1,0 +1,19 @@
+{
+  "name": "storeWithReplaceOnPUTtrue",
+  "plural": "stores-replacing",
+  "properties": {},
+  "scopes": {
+    "superStores": {
+      "where": {
+        "size": "super"
+      }
+    }
+  },
+  "relations": {
+    "widgets": {
+      "model": "widget",
+      "type": "hasMany"
+    }
+  },
+  "replaceOnPUT": true
+}

--- a/test/fixtures/simple-integration-app/common/models/store-updating.json
+++ b/test/fixtures/simple-integration-app/common/models/store-updating.json
@@ -1,0 +1,19 @@
+{
+  "name": "storeWithReplaceOnPUTfalse",
+  "plural": "stores-updating",
+  "properties": {},
+  "scopes": {
+    "superStores": {
+      "where": {
+        "size": "super"
+      }
+    }
+  },
+  "relations": {
+    "widgets": {
+      "model": "widget",
+      "type": "hasMany"
+    }
+  },
+  "replaceOnPUT": false
+}

--- a/test/fixtures/simple-integration-app/server/model-config.json
+++ b/test/fixtures/simple-integration-app/server/model-config.json
@@ -38,6 +38,14 @@
     "public": true,
     "dataSource": "db"
   },
+  "storeWithReplaceOnPUTfalse": {
+    "public": true,
+    "dataSource": "db"
+  },
+  "storeWithReplaceOnPUTtrue": {
+    "public": true,
+    "dataSource": "db"
+  },
   "physician": {
     "dataSource": "db",
     "public": true

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -627,9 +627,14 @@ describe.onServer('Remote Methods', function() {
       var methodNames = [];
       metadata.methods.forEach(function(method) {
         methodNames.push(method.name);
-        methodNames = methodNames.concat(method.sharedMethod.aliases || []);
+        var aliases = method.sharedMethod.aliases;
+        if (method.name.indexOf('prototype.') === 0) {
+          aliases = aliases.map(function(alias) {
+            return 'prototype.' + alias;
+          });
+        }
+        methodNames = methodNames.concat(aliases || []);
       });
-
       expect(methodNames).to.have.members([
         // NOTE(bajtos) These three methods are disabled by default
         // Because all tests share the same global registry model
@@ -637,9 +642,11 @@ describe.onServer('Remote Methods', function() {
         // this test was seeing this method (with all aliases) as public
         // 'destroyAll', 'deleteAll', 'remove',
         'create',
-        'upsert', 'updateOrCreate',
+        'upsert', 'updateOrCreate', 'patchOrCreate',
         'exists',
         'findById',
+        'replaceById',
+        'replaceOrCreate',
         'find',
         'findOne',
         'updateAll', 'update',
@@ -647,8 +654,8 @@ describe.onServer('Remote Methods', function() {
         'destroyById',
         'removeById',
         'count',
-        'prototype.updateAttributes',
-        'createChangeStream'
+        'prototype.patchAttributes', 'prototype.updateAttributes',
+        'createChangeStream',
       ]);
     });
 


### PR DESCRIPTION
**Patch description:**

*Re-mapping `updateAttributes` endpoint to use
`PATCH` and `PUT`(configurable) verb
*Exposing `replaceById` and `replaceOrCreate` via
`POST` and `PUT`(configurable) verb

---

##### What are the differences between this ptach for `2.x` Vs. [patch for `3.x`](https://github.com/strongloop/loopback/pull/2316):

1) Default value for `replaceOnPUT` would be set to false; please see [here](https://github.com/strongloop/loopback/pull/2435/files#diff-3bf07e630a94e80eef9557e874f96f56R606)

2) In this patch for `2.x`, we preserve `upsert` and set `pachOrCreate` as an alias only and change tests accordingly.


3) In this patch for `2.x`, we preserve `updateAttributes` and set `pachAttributes` as an alias only and change tests accordingly.

4) *Question:* JSdoc for `PersistedModel Methods` are generated based on `lib\persisted-models.js`, so once this patch gets landed I believe docs for [replaceOrCreate](https://github.com/strongloop/loopback/pull/2435/files#diff-3bf07e630a94e80eef9557e874f96f56R120), [replaceAttributes](https://github.com/strongloop/loopback/pull/2435/files#diff-3bf07e630a94e80eef9557e874f96f56R504) and [replaceById](https://github.com/strongloop/loopback/pull/2435/files#diff-3bf07e630a94e80eef9557e874f96f56R519) gets added to our API docs, are we fine with that now?

PS: I squash my commits as one single commit after getting an LGTM. Thanks!

Connect to https://github.com/strongloop-internal/scrum-loopback/issues/917

/to: @bajtos 
