### PR TITLE
Allow disabling node-continuation-local-storage initialization

### DIFF
--- a/lib/loopback.js
+++ b/lib/loopback.js
@@ -203,7 +203,9 @@ loopback.template = function(file) {
   });
 };
 
-require('../server/current-context')(loopback);
+if (!process.loopbackClsDisabled) {
+  require('../server/current-context')(loopback);
+}
 
 /**
  * Create a named vanilla JavaScript class constructor with an attached


### PR DESCRIPTION
node-continuation-local-storage and async-listener both install their hooks as soon as they are required.

This PR provides a way to disable those hooks.

It is very useful when not using cls/`getCurrentContext`in loopback removing some overhead.