### PR TITLE
Make things support multi-owner

### DIFF
--- a/common/models/role.js
+++ b/common/models/role.js
@@ -218,7 +218,7 @@ module.exports = function(Role) {
           }
           var checkFinish = function() {
             if (relTries === modelClass.relations.length) {
-              debug('No matching belongsTo relation found for model %j and user: %j', modelId, userId);
+              debug('No matching belongsTo relation in model %j and user: %j', modelId, userId);
               if (callback) callback(null, false);
             }
           };

--- a/common/models/role.js
+++ b/common/models/role.js
@@ -210,30 +210,30 @@ module.exports = function(Role) {
         if (callback) callback(null, matches(ownerId, userId));
         return;
       } else {
-        var rel_tries = 0;
+        var relTries = 0;
         var matched = false;
         function processRelatedUser(err, user) {
-          if(matched) {
+          if (matched) {
             return;
           }
           var checkFinish = function() {
-            if(rel_tries === modelClass.relations.length) {
+            if (relTries === modelClass.relations.length) {
               debug('No matching belongsTo relation found for model %j and user: %j', modelId, userId);
               if (callback) callback(null, false);
             }
-          }
+          };
           if (!err && user) {
-            rel_tries++;
+            relTries++;
             debug('User found: %j', user.id);
             var result = matches(user.id, userId);
             debug('User matches result: %s !', result);
-            if(result) {
+            if (result) {
               matched = true;
               if (callback) callback(null, matches(user.id, userId));
             }
             checkFinish();
           } else {
-            rel_tries++;
+            relTries++;
             checkFinish();
           }
         }

--- a/test/role.test.js
+++ b/test/role.test.js
@@ -303,6 +303,7 @@ describe('role model', function() {
     var Album = app.registry.createModel('Album', {
       name: String,
       userId: Number,
+      customerId: Number,
     }, {
       relations: {
         user: {
@@ -311,109 +312,69 @@ describe('role model', function() {
           foreignKey: 'userId',
         },
       },
+      relations: {
+        customer: {
+          type: 'belongsTo',
+          model: 'User',
+          foreignKey: 'customerId',
+        },
+      },
     });
     app.model(Album, { dataSource: 'db' });
 
     User.create({ name: 'Raymond', email: 'x@y.com', password: 'foobar' }, function(err, user) {
-      if (err) return done(err);
-      async.parallel([
-        function(next) {
-          Role.isInRole(
-            'returnPromise',
-            { principalType: ACL.USER, principalId: user.id },
-            function(err, yes) {
-              if (err) return next(err);
-              assert(yes);
-              next();
-            });
-        },
-        function(next) {
-          Role.isInRole(
-            Role.AUTHENTICATED,
-            { principalType: ACL.USER, principalId: user.id },
-            function(err, yes) {
-              if (err) next(err);
-              assert(yes);
-              next();
-            });
-        },
-        function(next) {
-          Role.isInRole(
-            Role.AUTHENTICATED,
-            { principalType: ACL.USER, principalId: null },
-            function(err, yes) {
-              if (err) next(err);
-              assert(!yes);
-              next();
-            });
-        },
-        function(next) {
-          Role.isInRole(
-            Role.UNAUTHENTICATED,
-            { principalType: ACL.USER, principalId: user.id },
-            function(err, yes) {
-              if (err) return next(err);
-              assert(!yes);
-              next();
-            });
-        },
-        function(next) {
-          Role.isInRole(
-            Role.UNAUTHENTICATED,
-            { principalType: ACL.USER, principalId: null },
-            function(err, yes) {
-              if (err) return next(err);
-              assert(yes);
-              next();
-            });
-        },
-        function(next) {
-          Role.isInRole(
-            Role.EVERYONE,
-            { principalType: ACL.USER, principalId: user.id },
-            function(err, yes) {
-              if (err) return next(err);
-              assert(yes);
-              next();
-            });
-        },
-        function(next) {
-          Role.isInRole(
-            Role.EVERYONE,
-            { principalType: ACL.USER, principalId: null },
-            function(err, yes) {
-              if (err) return next(err);
-              assert(yes);
-              next();
-            });
-        },
-        function(next) {
-          Album.create({ name: 'Album 1', userId: user.id }, function(err, album1) {
-            if (err) return done(err);
-            var role = {
-              principalType: ACL.USER, principalId: user.id,
-              model: Album, id: album1.id,
-            };
-            Role.isInRole(Role.OWNER, role, function(err, yes) {
-              if (err) return next(err);
-              assert(yes);
+      User.create({ name: 'Eric', email: 'z@y.com', password: 'foobar' }, function(err, user2) {
+        Role.isInRole('returnPromise', { principalType: ACL.USER, principalId: user.id },
+        function(err, yes) {
+          assert(!err && yes);
+        });
 
-              Album.create({ name: 'Album 2' }, function(err, album2) {
-                if (err) return next(err);
-                role = {
-                  principalType: ACL.USER, principalId: user.id,
-                  model: Album, id: album2.id,
-                };
-                Role.isInRole(Role.OWNER, role, function(err, yes) {
-                  if (err) return next(err);
-                  assert(!yes);
-                  next();
-                });
-              });
+        Role.isInRole(Role.AUTHENTICATED, { principalType: ACL.USER, principalId: user.id },
+        function(err, yes) {
+          assert(!err && yes);
+        });
+
+        Role.isInRole(Role.AUTHENTICATED, { principalType: ACL.USER, principalId: null },
+        function(err, yes) {
+          assert(!err && !yes);
+        });
+
+        Role.isInRole(Role.UNAUTHENTICATED, { principalType: ACL.USER, principalId: user.id },
+        function(err, yes) {
+          assert(!err && !yes);
+        });
+        Role.isInRole(Role.UNAUTHENTICATED, { principalType: ACL.USER, principalId: null },
+        function(err, yes) {
+          assert(!err && yes);
+        });
+
+        Role.isInRole(Role.EVERYONE, { principalType: ACL.USER, principalId: user.id },
+        function(err, yes) {
+          assert(!err && yes);
+        });
+
+        Role.isInRole(Role.EVERYONE, { principalType: ACL.USER, principalId: null },
+        function(err, yes) {
+          assert(!err && yes);
+        });
+
+        Album.create({ name: 'Album 1', userId: user.id, customerId: user2.id }, function(err, album1) {
+          var role = { principalType: ACL.USER, principalId: user.id, model: Album, id: album1.id };
+          Role.isInRole(Role.OWNER, role, function(err, yes) {
+            assert(!err && yes);
+          });
+          role = { principalType: ACL.USER, principalId: user2.id, model: Album, id: album1.id };
+          Role.isInRole(Role.OWNER, role, function(err, yes) {
+            assert(!err && yes);
+          });
+          Album.create({ name: 'Album 2' }, function(err, album2) {
+            role = { principalType: ACL.USER, principalId: user.id, model: Album, id: album2.id };
+            Role.isInRole(Role.OWNER, role, function(err, yes) {
+              assert(!err && !yes);
             });
           });
-        },
-      ], done);
+        });
+      });
     });
   });
 

--- a/test/role.test.js
+++ b/test/role.test.js
@@ -358,7 +358,8 @@ describe('role model', function() {
           assert(!err && yes);
         });
 
-        Album.create({ name: 'Album 1', userId: user.id, customerId: user2.id }, function(err, album1) {
+        Album.create({ name: 'Album 1', userId: user.id, customerId: user2.id },
+        function(err, album1) {
           var role = { principalType: ACL.USER, principalId: user.id, model: Album, id: album1.id };
           Role.isInRole(Role.OWNER, role, function(err, yes) {
             assert(!err && yes);


### PR DESCRIPTION
When a model has two or more "belongsTo"  relations, $owner will check
them all, instead of only checking the first one.
