### PR TITLE
adding additional check of string for case insentive emails

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -618,7 +618,8 @@ module.exports = function(User) {
 
     // Access token to normalize email credentials
     UserModel.observe('access', function normalizeEmailCase(ctx, next) {
-      if (!ctx.Model.settings.caseSensitiveEmail && ctx.query.where && ctx.query.where.email) {
+      if (!ctx.Model.settings.caseSensitiveEmail && ctx.query.where &&
+          ctx.query.where.email && typeof(ctx.query.where.email) === 'string') {
         ctx.query.where.email = ctx.query.where.email.toLowerCase();
       }
       next();


### PR DESCRIPTION
Issue:

This line doesn't work when we have `caseSensitiveEmail` set to `false` and we make queries like,

`User.findOne({where: {email: {inq: ["hello@test.com"]}}})`

Additional check for string is required. 
