### PR TITLE
Support 'alias' in mail transport config.

### DIFF
--- a/lib/connectors/mail.js
+++ b/lib/connectors/mail.js
@@ -59,10 +59,11 @@ MailConnector.prototype.DataAccessObject = Mailer;
  * Example:
  *
  *   Email.setupTransport({
- *       type: 'SMTP',
+ *       type: "SMTP",
  *       host: "smtp.gmail.com", // hostname
  *       secureConnection: true, // use SSL
  *       port: 465, // port for secure SMTP
+ *       alias: "gmail", // optional alias for use with 'transport' option when sending
  *       auth: {
  *           user: "gmail.user@gmail.com",
  *           pass: "userpass"
@@ -88,7 +89,7 @@ MailConnector.prototype.setupTransport = function(setting) {
     transport = mailer.createTransport(transportModule(setting));
   }
 
-  connector.transportsIndex[setting.type] = transport;
+  connector.transportsIndex[setting.alias || setting.type] = transport;
   connector.transports.push(transport);
 };
 
@@ -127,7 +128,8 @@ MailConnector.prototype.defaultTransport = function() {
  *   to: "bar@blurdybloop.com, baz@blurdybloop.com", // list of receivers
  *   subject: "Hello ✔", // Subject line
  *   text: "Hello world ✔", // plaintext body
- *   html: "<b>Hello world ✔</b>" // html body
+ *   html: "<b>Hello world ✔</b>", // html body
+ *   transport: "gmail", // See 'alias' option above in setupTransport
  * }
  *
  * See https://github.com/andris9/Nodemailer for other supported options.

--- a/test/email.test.js
+++ b/test/email.test.js
@@ -38,6 +38,14 @@ describe('Email connector', function() {
     assert(connector.transportForName('smtp'));
   });
 
+  it('should set up a aliased transport for SMTP' , function() {
+    var connector = new MailConnector({transport:
+        {type: 'smtp', service: 'ses-us-east-1', alias: 'ses-smtp'}
+    });
+
+    assert(connector.transportForName('ses-smtp'));
+  });
+
 });
 
 describe('Email and SMTP', function() {


### PR DESCRIPTION
Useful if you need to set up multiple transports of the same type.

For instance, we have to use a separate email service for some domains in China.