### PR TITLE
fix for issue 2521

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -546,7 +546,8 @@ module.exports = function(User) {
         UserModel.emit('resetPasswordRequest', {
           email: options.email,
           accessToken: accessToken,
-          user: user
+          user: user,
+          options: options
         });
       });
     });


### PR DESCRIPTION
Passing the options through to the event handler allows for far more flexibility.  Since getCurrentContext is on it's way out and currently acting more strangely than usual, this is a good alternative I think.
