### PR TITLE
Avoid calling deprecated methds

### DIFF
--- a/test/remoting.integration.js
+++ b/test/remoting.integration.js
@@ -99,9 +99,9 @@ describe('remoting - integration', function() {
         ')',
         formatReturns(m),
         ' ',
-        m.getHttpMethod(),
+        m.getEndpoints()[0].verb,
         ' ',
-        m.getFullPath()
+        m.getEndpoints()[0].fullPath
       ].join('');
     }
 


### PR DESCRIPTION
*Avoid calling deprecated `getHttpMethod` and `getFullPath`

This is the fix for deprecated messages. But please let me bring up the status of https://github.com/strongloop/loopback/pull/2435 with Quentin in our group chat and if we are all good, we can land https://github.com/strongloop/loopback/pull/2435 instead.

/to: @bajtos 

Thanks!