### PR TITLE
test: fix change-tracking setup

### DIFF
--- a/test/remote-connector.test.js
+++ b/test/remote-connector.test.js
@@ -25,13 +25,24 @@ describe('RemoteConnector', function() {
         done();
       });
     },
+
+    // We are defining the model attached to the remote connector datasource,
+    // therefore change tracking must be disabled, only the remote API for
+    // replication should be present
+    trackChanges: false,
+    enableRemoteReplication: true,
+
     onDefine: function(Model) {
-      var RemoteModel = Model.extend('Remote' + Model.modelName, {},
-        { plural: Model.pluralModelName });
-      RemoteModel.attachTo(loopback.createDataSource({
+      var ServerModel = Model.extend('Server' + Model.modelName, {}, {
+        plural: Model.pluralModelName,
+        // This is the model running on the server & attached to a real
+        // datasource, that's the place where to keep track of changes
+        trackChanges: true,
+      });
+      ServerModel.attachTo(loopback.createDataSource({
         connector: loopback.Memory,
       }));
-      remoteApp.model(RemoteModel);
+      remoteApp.model(ServerModel);
     },
   });
 

--- a/test/util/model-tests.js
+++ b/test/util/model-tests.js
@@ -48,7 +48,8 @@ module.exports = function defineModelTestsWithDataSource(options) {
         'domain': String,
         'email': String,
       }, {
-        trackChanges: true,
+        trackChanges: options.trackChanges !== false,
+        enableRemoteReplication: options.enableRemoteReplication,
       });
 
       User.attachTo(dataSource);


### PR DESCRIPTION
The remote-connector test has misconfigured the client (remote) model, where the client model was trying to keep track of changes. That's redundant because it's up to the server model (attached directly to the database) to track changes.

This patch fixes that configuration and also cleans up the test code a little bit to make it easier to distinguish between the remote (client) model and the server model.

/to @0candy Please review. Feel free to make any small improvements yourself, and also please back-port to 2.x if appropriate.

/cc @ritch 