### PR TITLE
Fix token middleware to not trigger CLS init

### DIFF
--- a/server/middleware/token.js
+++ b/server/middleware/token.js
@@ -124,7 +124,7 @@ function token(options) {
     TokenModel.findForRequest(req, options, function(err, token) {
       req.accessToken = token || null;
       rewriteUserLiteral(req, currentUserLiteral);
-      var ctx = loopback.getCurrentContext();
+      var ctx = req.loopbackContext;
       if (ctx) ctx.set('accessToken', token);
       next(err);
     });


### PR DESCRIPTION
Rework the token middleware to access current context via `req.loopbackContext` instead of `loopback.getCurentContext()`. That way the CLS/AsyncListener machinery is configured only in applications that are using current context.

This is in line with what we are doing in master, see https://github.com/strongloop/loopback/blob/32ecd2fc5c93325e41ca41a3f232db4a3f40bd10/server/middleware/token.js#L127

Connect to strongloop-internal/scrum-loopback#989

@raymondfeng @ritch PTAL