### PR TITLE
Fix performance of globalization

### DIFF
--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -16,6 +16,18 @@ var debug = require('debug')('loopback:persisted-model');
 var PassThrough = require('stream').PassThrough;
 var utils = require('./utils');
 
+// workaround for low performance of strong-globalize
+// see https://github.com/strongloop/strong-globalize/issues/66
+var stringCache = Object.create(null);
+g.s = function(str) {
+  assert.equal(1, arguments.length, 'g.s() does not support parameters');
+  if (str in stringCache)
+    return stringCache[str];
+  var result = g.t(str);
+  stringCache[str] = result;
+  return result;
+};
+
 module.exports = function(registry) {
   var Model = registry.getModel('Model');
 
@@ -615,7 +627,7 @@ module.exports = function(registry) {
     }
 
     setRemoting(PersistedModel, 'create', {
-      description: g.f('Create a new instance of the model and persist it into the data source.'),
+      description: g.s('Create a new instance of the model and persist it into the data source.'),
       accessType: 'WRITE',
       accepts: { arg: 'data', type: 'object', http: { source: 'body' }, description:
         'Model instance data' },
@@ -625,7 +637,7 @@ module.exports = function(registry) {
 
     var upsertOptions = {
       aliases: ['upsert', 'updateOrCreate'],
-      description: g.f('Patch an existing model instance or insert a new one ' +
+      description: g.s('Patch an existing model instance or insert a new one ' +
         'into the data source.'),
       accessType: 'WRITE',
       accepts: { arg: 'data', type: 'object', http: { source: 'body' }, description:
@@ -655,7 +667,7 @@ module.exports = function(registry) {
     setRemoting(PersistedModel, 'replaceOrCreate', replaceOrCreateOptions);
 
     setRemoting(PersistedModel, 'exists', {
-      description: g.f('Check whether a model instance exists in the data source.'),
+      description: g.s('Check whether a model instance exists in the data source.'),
       accessType: 'READ',
       accepts: { arg: 'id', type: 'any', description: 'Model id', required: true },
       returns: { arg: 'exists', type: 'boolean' },
@@ -686,13 +698,13 @@ module.exports = function(registry) {
     });
 
     setRemoting(PersistedModel, 'findById', {
-      description: g.f('Find a model instance by {{id}} from the data source.'),
+      description: g.s('Find a model instance by {{id}} from the data source.'),
       accessType: 'READ',
       accepts: [
         { arg: 'id', type: 'any', description: 'Model id', required: true,
           http: { source: 'path' }},
         { arg: 'filter', type: 'object',
-          description: g.f('Filter defining fields and include') },
+          description: g.s('Filter defining fields and include') },
       ],
       returns: { arg: 'data', type: typeName, root: true },
       http: { verb: 'get', path: '/:id' },
@@ -720,7 +732,7 @@ module.exports = function(registry) {
 
 
     setRemoting(PersistedModel, 'find', {
-      description: g.f('Find all instances of the model matched by filter from the data source.'),
+      description: g.s('Find all instances of the model matched by filter from the data source.'),
       accessType: 'READ',
       accepts: { arg: 'filter', type: 'object', description:
         'Filter defining fields, where, include, order, offset, and limit' },
@@ -729,7 +741,7 @@ module.exports = function(registry) {
     });
 
     setRemoting(PersistedModel, 'findOne', {
-      description: g.f('Find first instance of the model matched by filter from the data source.'),
+      description: g.s('Find first instance of the model matched by filter from the data source.'),
       accessType: 'READ',
       accepts: { arg: 'filter', type: 'object', description:
         'Filter defining fields, where, include, order, offset, and limit' },
@@ -739,7 +751,7 @@ module.exports = function(registry) {
     });
 
     setRemoting(PersistedModel, 'destroyAll', {
-      description: g.f('Delete all matching records.'),
+      description: g.s('Delete all matching records.'),
       accessType: 'WRITE',
       accepts: { arg: 'where', type: 'object', description: 'filter.where object' },
       returns: {
@@ -754,17 +766,17 @@ module.exports = function(registry) {
 
     setRemoting(PersistedModel, 'updateAll', {
       aliases: ['update'],
-      description: g.f('Update instances of the model matched by {{where}} from the data source.'),
+      description: g.s('Update instances of the model matched by {{where}} from the data source.'),
       accessType: 'WRITE',
       accepts: [
         { arg: 'where', type: 'object', http: { source: 'query' },
-          description: 'Criteria to match model instances' },
+          description: g.s('Criteria to match model instances') },
         { arg: 'data', type: 'object', http: { source: 'body' },
-          description: g.f('An object of model property name/value pairs') },
+          description: g.s('An object of model property name/value pairs') },
       ],
       returns: {
         arg: 'count',
-        description: g.f('The number of instances updated'),
+        description: g.s('The number of instances updated'),
         type: 'object',
         root: true,
       },
@@ -773,7 +785,7 @@ module.exports = function(registry) {
 
     setRemoting(PersistedModel, 'deleteById', {
       aliases: ['destroyById', 'removeById'],
-      description: g.f('Delete a model instance by {{id}} from the data source.'),
+      description: g.s('Delete a model instance by {{id}} from the data source.'),
       accessType: 'WRITE',
       accepts: { arg: 'id', type: 'any', description: 'Model id', required: true,
                 http: { source: 'path' }},
@@ -782,7 +794,7 @@ module.exports = function(registry) {
     });
 
     setRemoting(PersistedModel, 'count', {
-      description: g.f('Count instances of the model matched by where from the data source.'),
+      description: g.s('Count instances of the model matched by where from the data source.'),
       accessType: 'READ',
       accepts: { arg: 'where', type: 'object', description: 'Criteria to match model instances' },
       returns: { arg: 'count', type: 'number' },
@@ -791,7 +803,7 @@ module.exports = function(registry) {
 
     var updateAttributesOptions = {
       aliases: ['updateAttributes'],
-      description: g.f('Patch attributes for a model instance and persist it into ' +
+      description: g.s('Patch attributes for a model instance and persist it into ' +
         'the data source.'),
       accessType: 'WRITE',
       accepts: { arg: 'data', type: 'object', http: { source: 'body' }, description: 'An object of model property name/value pairs' },
@@ -807,7 +819,7 @@ module.exports = function(registry) {
 
     if (options.trackChanges || options.enableRemoteReplication) {
       setRemoting(PersistedModel, 'diff', {
-        description: g.f('Get a set of deltas and conflicts since the given checkpoint.'),
+        description: g.s('Get a set of deltas and conflicts since the given checkpoint.'),
         accessType: 'READ',
         accepts: [
           { arg: 'since', type: 'number', description: 'Find deltas since this checkpoint' },
@@ -819,7 +831,7 @@ module.exports = function(registry) {
       });
 
       setRemoting(PersistedModel, 'changes', {
-        description: g.f('Get the changes to a model since a given checkpoint.' +
+        description: g.s('Get the changes to a model since a given checkpoint.' +
           'Provide a filter object to reduce the number of results returned.'),
         accessType: 'READ',
         accepts: [
@@ -833,7 +845,7 @@ module.exports = function(registry) {
       });
 
       setRemoting(PersistedModel, 'checkpoint', {
-        description: g.f('Create a checkpoint.'),
+        description: g.s('Create a checkpoint.'),
         // The replication algorithm needs to create a source checkpoint,
         // even though it is otherwise not making any source changes.
         // We need to allow this method for users that don't have full
@@ -844,14 +856,14 @@ module.exports = function(registry) {
       });
 
       setRemoting(PersistedModel, 'currentCheckpoint', {
-        description: g.f('Get the current checkpoint.'),
+        description: g.s('Get the current checkpoint.'),
         accessType: 'READ',
         returns: { arg: 'checkpoint', type: 'object', root: true },
         http: { verb: 'get', path: '/checkpoint' },
       });
 
       setRemoting(PersistedModel, 'createUpdates', {
-        description: g.f('Create an update list from a delta list.'),
+        description: g.s('Create an update list from a delta list.'),
         // This operation is read-only, it does not change any local data.
         // It is called by the replication algorithm to compile a list
         // of changes to apply on the target.
@@ -862,14 +874,14 @@ module.exports = function(registry) {
       });
 
       setRemoting(PersistedModel, 'bulkUpdate', {
-        description: g.f('Run multiple updates at once. Note: this is not atomic.'),
+        description: g.s('Run multiple updates at once. Note: this is not atomic.'),
         accessType: 'WRITE',
         accepts: { arg: 'updates', type: 'array' },
         http: { verb: 'post', path: '/bulk-update' },
       });
 
       setRemoting(PersistedModel, 'findLastChange', {
-        description: g.f('Get the most recent change record for this instance.'),
+        description: g.s('Get the most recent change record for this instance.'),
         accessType: 'READ',
         accepts: {
           arg: 'id', type: 'any', required: true, http: { source: 'path' },
@@ -881,7 +893,7 @@ module.exports = function(registry) {
 
       setRemoting(PersistedModel, 'updateLastChange', {
         description: [
-          g.f('Update the properties of the most recent change record ' +
+          g.s('Update the properties of the most recent change record ' +
           'kept for this instance.'),
         ],
         accessType: 'WRITE',
@@ -892,7 +904,7 @@ module.exports = function(registry) {
           },
           {
             arg: 'data', type: 'object', http: { source: 'body' },
-            description: g.f('An object of Change property name/value pairs'),
+            description: g.s('An object of Change property name/value pairs'),
           },
         ],
         returns: { arg: 'result', type: this.Change.modelName, root: true },
@@ -901,7 +913,7 @@ module.exports = function(registry) {
     }
 
     setRemoting(PersistedModel, 'createChangeStream', {
-      description: g.f('Create a change stream.'),
+      description: g.s('Create a change stream.'),
       accessType: 'READ',
       http: [
         { verb: 'post', path: '/change-stream' },

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -227,8 +227,8 @@ Registry.prototype.configureModel = function(ModelCtor, config) {
   // configuration, so that the datasource picks up updated relations
   if (config.dataSource) {
     assert(config.dataSource instanceof DataSource,
-        g.f('Cannot configure %s: {{config.dataSource}} must be an instance ' +
-          'of {{DataSource}}', ModelCtor.modelName));
+        'Cannot configure ' + ModelCtor.modelName +
+        ': config.dataSource must be an instance of DataSource');
     ModelCtor.attachTo(config.dataSource);
     debug('Attached model `%s` to dataSource `%s`',
       modelName, config.dataSource.name);


### PR DESCRIPTION
This is forward-port of #2613.

- Revert globalization of assert() messages
- Cache remoting descriptions to speed up tests

See https://github.com/strongloop/strong-globalize/issues/66

Before this change:

```
$ mocha
(...)
real   	1m16.151s
user   	1m15.891s
sys    	0m0.876s
```

After the change:

```
$ mocha
(...)
real   	0m27.291s
user   	0m27.081s
sys    	0m0.626s
```