### PR TITLE
Revert globalization of Swagger descriptions

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -670,12 +670,12 @@ module.exports = function(User) {
     UserModel.remoteMethod(
       'login',
       {
-        description: g.f('Login a user with username/email and password.'),
+        description: 'Login a user with username/email and password.',
         accepts: [
           { arg: 'credentials', type: 'object', required: true, http: { source: 'body' }},
           { arg: 'include', type: ['string'], http: { source: 'query' },
-            description: g.f('Related objects to include in the response. ' +
-            'See the description of return value for more details.') },
+            description: 'Related objects to include in the response. ' +
+            'See the description of return value for more details.' },
         ],
         returns: {
           arg: 'accessToken', type: 'object', root: true,
@@ -693,7 +693,7 @@ module.exports = function(User) {
     UserModel.remoteMethod(
       'logout',
       {
-        description: g.f('Logout a user with access token.'),
+        description: 'Logout a user with access token.',
         accepts: [
           { arg: 'access_token', type: 'string', required: true, http: function(ctx) {
             var req = ctx && ctx.req;
@@ -701,8 +701,8 @@ module.exports = function(User) {
             var tokenID = accessToken && accessToken.id;
 
             return tokenID;
-          }, description: g.f('Do not supply this argument, it is automatically extracted ' +
-            'from request headers.'),
+          }, description: 'Do not supply this argument, it is automatically extracted ' +
+            'from request headers.',
           },
         ],
         http: { verb: 'all' },
@@ -712,7 +712,7 @@ module.exports = function(User) {
     UserModel.remoteMethod(
       'confirm',
       {
-        description: g.f('Confirm a user registration with email verification token.'),
+        description: 'Confirm a user registration with email verification token.',
         accepts: [
           { arg: 'uid', type: 'string', required: true },
           { arg: 'token', type: 'string', required: true },
@@ -725,7 +725,7 @@ module.exports = function(User) {
     UserModel.remoteMethod(
       'resetPassword',
       {
-        description: g.f('Reset password for a user with email.'),
+        description: 'Reset password for a user with email.',
         accepts: [
           { arg: 'options', type: 'object', required: true, http: { source: 'body' }},
         ],

--- a/lib/model.js
+++ b/lib/model.js
@@ -13,6 +13,7 @@ var assert = require('assert');
 var RemoteObjects = require('strong-remoting');
 var SharedClass = require('strong-remoting').SharedClass;
 var extend = require('util')._extend;
+var format = require('util').format;
 
 module.exports = function(registry) {
   /**
@@ -454,7 +455,7 @@ module.exports = function(registry) {
       http: { verb: 'get', path: '/' + pathName },
       accepts: { arg: 'refresh', type: 'boolean', http: { source: 'query' }},
       accessType: 'READ',
-      description: g.f('Fetches belongsTo relation %s.', relationName),
+      description: format('Fetches belongsTo relation %s.', relationName),
       returns: { arg: relationName, type: modelName, root: true },
     }, fn);
   };
@@ -478,7 +479,7 @@ module.exports = function(registry) {
       isStatic: false,
       http: { verb: 'get', path: '/' + pathName },
       accepts: { arg: 'refresh', type: 'boolean', http: { source: 'query' }},
-      description: g.f('Fetches hasOne relation %s.', relationName),
+      description: format('Fetches hasOne relation %s.', relationName),
       accessType: 'READ',
       returns: { arg: relationName, type: relation.modelTo.modelName, root: true },
       rest: { after: convertNullToNotFoundError.bind(null, toModelName) },
@@ -488,7 +489,7 @@ module.exports = function(registry) {
       isStatic: false,
       http: { verb: 'post', path: '/' + pathName },
       accepts: { arg: 'data', type: toModelName, http: { source: 'body' }},
-      description: g.f('Creates a new instance in %s of this model.', relationName),
+      description: format('Creates a new instance in %s of this model.', relationName),
       accessType: 'WRITE',
       returns: { arg: 'data', type: toModelName, root: true },
     });
@@ -497,7 +498,7 @@ module.exports = function(registry) {
       isStatic: false,
       http: { verb: 'put', path: '/' + pathName },
       accepts: { arg: 'data', type: toModelName, http: { source: 'body' }},
-      description: g.f('Update %s of this model.', relationName),
+      description: format('Update %s of this model.', relationName),
       accessType: 'WRITE',
       returns: { arg: 'data', type: toModelName, root: true },
     });
@@ -505,7 +506,7 @@ module.exports = function(registry) {
     define('__destroy__' + relationName, {
       isStatic: false,
       http: { verb: 'delete', path: '/' + pathName },
-      description: g.f('Deletes %s of this model.', relationName),
+      description: format('Deletes %s of this model.', relationName),
       accessType: 'WRITE',
     });
   };
@@ -519,10 +520,10 @@ module.exports = function(registry) {
       isStatic: false,
       http: { verb: 'get', path: '/' + pathName + '/:fk' },
       accepts: { arg: 'fk', type: 'any',
-        description: g.f('Foreign key for %s', relationName),
+        description: format('Foreign key for %s', relationName),
         required: true,
         http: { source: 'path' }},
-      description: g.f('Find a related item by id for %s.', relationName),
+      description: format('Find a related item by id for %s.', relationName),
       accessType: 'READ',
       returns: { arg: 'result', type: toModelName, root: true },
       rest: { after: convertNullToNotFoundError.bind(null, toModelName) },
@@ -533,10 +534,10 @@ module.exports = function(registry) {
       isStatic: false,
       http: { verb: 'delete', path: '/' + pathName + '/:fk' },
       accepts: { arg: 'fk', type: 'any',
-        description: g.f('Foreign key for %s', relationName),
+        description: format('Foreign key for %s', relationName),
         required: true,
         http: { source: 'path' }},
-      description: g.f('Delete a related item by id for %s.', relationName),
+      description: format('Delete a related item by id for %s.', relationName),
       accessType: 'WRITE',
       returns: [],
     }, destroyByIdFunc);
@@ -547,12 +548,12 @@ module.exports = function(registry) {
       http: { verb: 'put', path: '/' + pathName + '/:fk' },
       accepts: [
         { arg: 'fk', type: 'any',
-          description: g.f('Foreign key for %s', relationName),
+          description: format('Foreign key for %s', relationName),
           required: true,
           http: { source: 'path' }},
         { arg: 'data', type: toModelName, http: { source: 'body' }},
       ],
-      description: g.f('Update a related item by id for %s.', relationName),
+      description: format('Update a related item by id for %s.', relationName),
       accessType: 'WRITE',
       returns: { arg: 'result', type: toModelName, root: true },
     }, updateByIdFunc);
@@ -571,10 +572,10 @@ module.exports = function(registry) {
         isStatic: false,
         http: { verb: 'put', path: '/' + pathName + '/rel/:fk' },
         accepts: [{ arg: 'fk', type: 'any',
-          description: g.f('Foreign key for %s', relationName),
+          description: format('Foreign key for %s', relationName),
           required: true,
           http: { source: 'path' }}].concat(accepts),
-        description: g.f('Add a related item by id for %s.', relationName),
+        description: format('Add a related item by id for %s.', relationName),
         accessType: 'WRITE',
         returns: { arg: relationName, type: modelThrough.modelName, root: true },
       }, addFunc);
@@ -584,10 +585,10 @@ module.exports = function(registry) {
         isStatic: false,
         http: { verb: 'delete', path: '/' + pathName + '/rel/:fk' },
         accepts: { arg: 'fk', type: 'any',
-          description: g.f('Foreign key for %s', relationName),
+          description: format('Foreign key for %s', relationName),
           required: true,
           http: { source: 'path' }},
-        description: g.f('Remove the %s relation to an item by id.', relationName),
+        description: format('Remove the %s relation to an item by id.', relationName),
         accessType: 'WRITE',
         returns: [],
       }, removeFunc);
@@ -599,10 +600,10 @@ module.exports = function(registry) {
         isStatic: false,
         http: { verb: 'head', path: '/' + pathName + '/rel/:fk' },
         accepts: { arg: 'fk', type: 'any',
-        description: g.f('Foreign key for %s', relationName),
+        description: format('Foreign key for %s', relationName),
         required: true,
           http: { source: 'path' }},
-        description: g.f('Check the existence of %s relation to an item by id.', relationName),
+        description: format('Check the existence of %s relation to an item by id.', relationName),
         accessType: 'READ',
         returns: { arg: 'exists', type: 'boolean', root: true },
         rest: {
@@ -645,7 +646,7 @@ module.exports = function(registry) {
       isStatic: isStatic,
       http: { verb: 'get', path: '/' + pathName },
       accepts: { arg: 'filter', type: 'object' },
-      description: g.f('Queries %s of %s.', scopeName, this.modelName),
+      description: format('Queries %s of %s.', scopeName, this.modelName),
       accessType: 'READ',
       returns: { arg: scopeName, type: [toModelName], root: true },
     });
@@ -654,7 +655,7 @@ module.exports = function(registry) {
       isStatic: isStatic,
       http: { verb: 'post', path: '/' + pathName },
       accepts: { arg: 'data', type: toModelName, http: { source: 'body' }},
-      description: g.f('Creates a new instance in %s of this model.', scopeName),
+      description: format('Creates a new instance in %s of this model.', scopeName),
       accessType: 'WRITE',
       returns: { arg: 'data', type: toModelName, root: true },
     });
@@ -662,7 +663,7 @@ module.exports = function(registry) {
     define('__delete__' + scopeName, {
       isStatic: isStatic,
       http: { verb: 'delete', path: '/' + pathName },
-      description: g.f('Deletes all %s of this model.', scopeName),
+      description: format('Deletes all %s of this model.', scopeName),
       accessType: 'WRITE',
     });
 
@@ -670,8 +671,8 @@ module.exports = function(registry) {
       isStatic: isStatic,
       http: { verb: 'get', path: '/' + pathName + '/count' },
       accepts: { arg: 'where', type: 'object',
-      description: g.f('Criteria to match model instances') },
-      description: g.f('Counts %s of %s.', scopeName, this.modelName),
+      description: 'Criteria to match model instances' },
+      description: format('Counts %s of %s.', scopeName, this.modelName),
       accessType: 'READ',
       returns: { arg: 'count',  type: 'number' },
     });
@@ -718,7 +719,7 @@ module.exports = function(registry) {
         acceptArgs = [
           {
             arg: paramName, type: 'any', http: { source: 'path' },
-            description: g.f('Foreign key for %s.',  relation.name),
+            description: format('Foreign key for %s.',  relation.name),
             required: true,
           },
         ];

--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -615,7 +615,7 @@ module.exports = function(registry) {
     }
 
     setRemoting(PersistedModel, 'create', {
-      description: g.f('Create a new instance of the model and persist it into the data source.'),
+      description: 'Create a new instance of the model and persist it into the data source.',
       accessType: 'WRITE',
       accepts: { arg: 'data', type: 'object', http: { source: 'body' }, description:
         'Model instance data' },
@@ -625,8 +625,8 @@ module.exports = function(registry) {
 
     var upsertOptions = {
       aliases: ['upsert', 'updateOrCreate'],
-      description: g.f('Patch an existing model instance or insert a new one ' +
-        'into the data source.'),
+      description: 'Patch an existing model instance or insert a new one ' +
+        'into the data source.',
       accessType: 'WRITE',
       accepts: { arg: 'data', type: 'object', http: { source: 'body' }, description:
         'Model instance data' },
@@ -655,7 +655,7 @@ module.exports = function(registry) {
     setRemoting(PersistedModel, 'replaceOrCreate', replaceOrCreateOptions);
 
     setRemoting(PersistedModel, 'exists', {
-      description: g.f('Check whether a model instance exists in the data source.'),
+      description: 'Check whether a model instance exists in the data source.',
       accessType: 'READ',
       accepts: { arg: 'id', type: 'any', description: 'Model id', required: true },
       returns: { arg: 'exists', type: 'boolean' },
@@ -686,13 +686,13 @@ module.exports = function(registry) {
     });
 
     setRemoting(PersistedModel, 'findById', {
-      description: g.f('Find a model instance by {{id}} from the data source.'),
+      description: 'Find a model instance by {{id}} from the data source.',
       accessType: 'READ',
       accepts: [
         { arg: 'id', type: 'any', description: 'Model id', required: true,
           http: { source: 'path' }},
         { arg: 'filter', type: 'object',
-          description: g.f('Filter defining fields and include') },
+          description: 'Filter defining fields and include' },
       ],
       returns: { arg: 'data', type: typeName, root: true },
       http: { verb: 'get', path: '/:id' },
@@ -720,7 +720,7 @@ module.exports = function(registry) {
 
 
     setRemoting(PersistedModel, 'find', {
-      description: g.f('Find all instances of the model matched by filter from the data source.'),
+      description: 'Find all instances of the model matched by filter from the data source.',
       accessType: 'READ',
       accepts: { arg: 'filter', type: 'object', description:
         'Filter defining fields, where, include, order, offset, and limit' },
@@ -729,7 +729,7 @@ module.exports = function(registry) {
     });
 
     setRemoting(PersistedModel, 'findOne', {
-      description: g.f('Find first instance of the model matched by filter from the data source.'),
+      description: 'Find first instance of the model matched by filter from the data source.',
       accessType: 'READ',
       accepts: { arg: 'filter', type: 'object', description:
         'Filter defining fields, where, include, order, offset, and limit' },
@@ -739,7 +739,7 @@ module.exports = function(registry) {
     });
 
     setRemoting(PersistedModel, 'destroyAll', {
-      description: g.f('Delete all matching records.'),
+      description: 'Delete all matching records.',
       accessType: 'WRITE',
       accepts: { arg: 'where', type: 'object', description: 'filter.where object' },
       returns: {
@@ -754,17 +754,17 @@ module.exports = function(registry) {
 
     setRemoting(PersistedModel, 'updateAll', {
       aliases: ['update'],
-      description: g.f('Update instances of the model matched by {{where}} from the data source.'),
+      description: 'Update instances of the model matched by {{where}} from the data source.',
       accessType: 'WRITE',
       accepts: [
         { arg: 'where', type: 'object', http: { source: 'query' },
           description: 'Criteria to match model instances' },
         { arg: 'data', type: 'object', http: { source: 'body' },
-          description: g.f('An object of model property name/value pairs') },
+          description: 'An object of model property name/value pairs' },
       ],
       returns: {
         arg: 'count',
-        description: g.f('The number of instances updated'),
+        description: 'The number of instances updated',
         type: 'object',
         root: true,
       },
@@ -773,7 +773,7 @@ module.exports = function(registry) {
 
     setRemoting(PersistedModel, 'deleteById', {
       aliases: ['destroyById', 'removeById'],
-      description: g.f('Delete a model instance by {{id}} from the data source.'),
+      description: 'Delete a model instance by {{id}} from the data source.',
       accessType: 'WRITE',
       accepts: { arg: 'id', type: 'any', description: 'Model id', required: true,
                 http: { source: 'path' }},
@@ -782,7 +782,7 @@ module.exports = function(registry) {
     });
 
     setRemoting(PersistedModel, 'count', {
-      description: g.f('Count instances of the model matched by where from the data source.'),
+      description: 'Count instances of the model matched by where from the data source.',
       accessType: 'READ',
       accepts: { arg: 'where', type: 'object', description: 'Criteria to match model instances' },
       returns: { arg: 'count', type: 'number' },
@@ -791,8 +791,8 @@ module.exports = function(registry) {
 
     var updateAttributesOptions = {
       aliases: ['updateAttributes'],
-      description: g.f('Patch attributes for a model instance and persist it into ' +
-        'the data source.'),
+      description: 'Patch attributes for a model instance and persist it into ' +
+        'the data source.',
       accessType: 'WRITE',
       accepts: { arg: 'data', type: 'object', http: { source: 'body' }, description: 'An object of model property name/value pairs' },
       returns: { arg: 'data', type: typeName, root: true },
@@ -807,7 +807,7 @@ module.exports = function(registry) {
 
     if (options.trackChanges || options.enableRemoteReplication) {
       setRemoting(PersistedModel, 'diff', {
-        description: g.f('Get a set of deltas and conflicts since the given checkpoint.'),
+        description: 'Get a set of deltas and conflicts since the given checkpoint.',
         accessType: 'READ',
         accepts: [
           { arg: 'since', type: 'number', description: 'Find deltas since this checkpoint' },
@@ -819,8 +819,8 @@ module.exports = function(registry) {
       });
 
       setRemoting(PersistedModel, 'changes', {
-        description: g.f('Get the changes to a model since a given checkpoint.' +
-          'Provide a filter object to reduce the number of results returned.'),
+        description: 'Get the changes to a model since a given checkpoint.' +
+          'Provide a filter object to reduce the number of results returned.',
         accessType: 'READ',
         accepts: [
           { arg: 'since', type: 'number', description:
@@ -833,7 +833,7 @@ module.exports = function(registry) {
       });
 
       setRemoting(PersistedModel, 'checkpoint', {
-        description: g.f('Create a checkpoint.'),
+        description: 'Create a checkpoint.',
         // The replication algorithm needs to create a source checkpoint,
         // even though it is otherwise not making any source changes.
         // We need to allow this method for users that don't have full
@@ -844,14 +844,14 @@ module.exports = function(registry) {
       });
 
       setRemoting(PersistedModel, 'currentCheckpoint', {
-        description: g.f('Get the current checkpoint.'),
+        description: 'Get the current checkpoint.',
         accessType: 'READ',
         returns: { arg: 'checkpoint', type: 'object', root: true },
         http: { verb: 'get', path: '/checkpoint' },
       });
 
       setRemoting(PersistedModel, 'createUpdates', {
-        description: g.f('Create an update list from a delta list.'),
+        description: 'Create an update list from a delta list.',
         // This operation is read-only, it does not change any local data.
         // It is called by the replication algorithm to compile a list
         // of changes to apply on the target.
@@ -862,14 +862,14 @@ module.exports = function(registry) {
       });
 
       setRemoting(PersistedModel, 'bulkUpdate', {
-        description: g.f('Run multiple updates at once. Note: this is not atomic.'),
+        description: 'Run multiple updates at once. Note: this is not atomic.',
         accessType: 'WRITE',
         accepts: { arg: 'updates', type: 'array' },
         http: { verb: 'post', path: '/bulk-update' },
       });
 
       setRemoting(PersistedModel, 'findLastChange', {
-        description: g.f('Get the most recent change record for this instance.'),
+        description: 'Get the most recent change record for this instance.',
         accessType: 'READ',
         accepts: {
           arg: 'id', type: 'any', required: true, http: { source: 'path' },
@@ -880,10 +880,9 @@ module.exports = function(registry) {
       });
 
       setRemoting(PersistedModel, 'updateLastChange', {
-        description: [
-          g.f('Update the properties of the most recent change record ' +
-          'kept for this instance.'),
-        ],
+        description:
+          'Update the properties of the most recent change record ' +
+          'kept for this instance.',
         accessType: 'WRITE',
         accepts: [
           {
@@ -892,7 +891,7 @@ module.exports = function(registry) {
           },
           {
             arg: 'data', type: 'object', http: { source: 'body' },
-            description: g.f('An object of Change property name/value pairs'),
+            description: 'An object of Change property name/value pairs',
           },
         ],
         returns: { arg: 'result', type: this.Change.modelName, root: true },
@@ -901,7 +900,7 @@ module.exports = function(registry) {
     }
 
     setRemoting(PersistedModel, 'createChangeStream', {
-      description: g.f('Create a change stream.'),
+      description: 'Create a change stream.',
       accessType: 'READ',
       http: [
         { verb: 'post', path: '/change-stream' },


### PR DESCRIPTION
This is a forward-port of #2621:

> As discussed in SlackChat, Swagger descriptions should not be globalized. Translating Swagger is an open problem, see e.g. OAI/OpenAPI-Specification#274

@0candy please review