### PR TITLE
resolve related models from correct registry

### DIFF
--- a/common/models/acl.js
+++ b/common/models/acl.js
@@ -506,19 +506,12 @@ module.exports = function(ACL) {
   };
 
   ACL.resolveRelatedModels = function() {
-    var self = this;
-    if (!self.roleModel) {
-      var reg = self.registry;
-      var builtInModels = {
-        roleModel: reg.getModel('Role'),
-        roleMappingModel: reg.getModel('RoleMapping'),
-        userModel: reg.getModel('User'),
-        applicationModel: reg.getModel('Application'),
-      };
-
-      for (var m in builtInModels) {
-        self[m] = reg.getModelByType(builtInModels[m]);
-      }
+    if (!this.roleModel) {
+      var reg = this.registry;
+      this.roleModel = reg.getModelByType('Role');
+      this.roleMappingModel = reg.getModelByType('RoleMapping');
+      this.userModel = reg.getModelByType('User');
+      this.applicationModel = reg.getModelByType('Application');
     }
   };
 

--- a/common/models/acl.js
+++ b/common/models/acl.js
@@ -395,8 +395,9 @@ module.exports = function(ACL) {
    */
 
   ACL.checkAccessForContext = function(context, callback) {
-    this.resolveRelatedModels();
-    var roleModel = this.roleModel;
+    var self = this;
+    self.resolveRelatedModels();
+    var roleModel = self.roleModel;
 
     if (!(context instanceof AccessContext)) {
       context = new AccessContext(context);
@@ -419,10 +420,9 @@ module.exports = function(ACL) {
     var req = new AccessRequest(modelName, property, accessType, ACL.DEFAULT, methodNames);
 
     var effectiveACLs = [];
-    var staticACLs = this.getStaticACLs(model.modelName, property);
+    var staticACLs = self.getStaticACLs(model.modelName, property);
 
-    var self = this;
-    this.find({ where: { model: model.modelName, property: propertyQuery,
+    self.find({ where: { model: model.modelName, property: propertyQuery,
       accessType: accessTypeQuery }}, function(err, acls) {
       if (err) {
         if (callback) callback(err);

--- a/common/models/acl.js
+++ b/common/models/acl.js
@@ -395,7 +395,8 @@ module.exports = function(ACL) {
    */
 
   ACL.checkAccessForContext = function(context, callback) {
-    var registry = this.registry;
+    this.resolveRelatedModels();
+    var roleModel = this.roleModel;
 
     if (!(context instanceof AccessContext)) {
       context = new AccessContext(context);
@@ -421,7 +422,6 @@ module.exports = function(ACL) {
     var staticACLs = this.getStaticACLs(model.modelName, property);
 
     var self = this;
-    var roleModel = registry.getModelByType(Role);
     this.find({ where: { model: model.modelName, property: propertyQuery,
       accessType: accessTypeQuery }}, function(err, acls) {
       if (err) {
@@ -506,12 +506,19 @@ module.exports = function(ACL) {
   };
 
   ACL.resolveRelatedModels = function() {
-    if (!this.roleModel) {
-      var reg = this.registry;
-      this.roleModel = reg.getModelByType(loopback.Role);
-      this.roleMappingModel = reg.getModelByType(loopback.RoleMapping);
-      this.userModel = reg.getModelByType(loopback.User);
-      this.applicationModel = reg.getModelByType(loopback.Application);
+    var self = this;
+    if (!self.roleModel) {
+      var reg = self.registry;
+      var builtInModels = {
+        roleModel: reg.getModel('Role'),
+        roleMappingModel: reg.getModel('RoleMapping'),
+        userModel: reg.getModel('User'),
+        applicationModel: reg.getModel('Application'),
+      };
+
+      for (var m in builtInModels) {
+        self[m] = reg.getModelByType(builtInModels[m]);
+      }
     }
   };
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "express": "^4.14.0",
     "inflection": "^1.6.0",
     "loopback-connector-remote": "^1.0.3",
-    "loopback-datasource-juggler": "^3.0.0-alpha.1",
+    "loopback-datasource-juggler": "strongloop/loopback-datasource-juggler#b3907caad21f82eba1e82f005e84c68116eef052",
     "loopback-phase": "^1.2.0",
     "nodemailer": "^2.5.0",
     "nodemailer-stub-transport": "^1.0.0",

--- a/test/access-control.integration.js
+++ b/test/access-control.integration.js
@@ -142,6 +142,34 @@ describe('access control - integration', function() {
   });
 
   describe('/banks', function() {
+    var SPECIAL_USER = { email: 'special@test.test', password: 'test' };
+
+    // define dynamic role that would only grant access when the authenticated user's email is equal to
+    // SPECIAL_USER's email
+
+    before(function() {
+      var roleModel = app.registry.getModel('Role');
+      var userModel = app.registry.getModel('user');
+
+      roleModel.registerResolver('$dynamic-role', function(role, context, callback) {
+        if (!(context && context.accessToken && context.accessToken.userId)) {
+          return process.nextTick(function() {
+            callback && callback(null, false);
+          });
+        }
+        var accessToken = context.accessToken;
+        userModel.findById(accessToken.userId, function(err, user) {
+          if (err) {
+            return callback(err, false);
+          }
+          if (user && user.email === SPECIAL_USER.email) {
+            return callback(null, true);
+          }
+          return callback(null, false);
+        });
+      });
+    });
+
     lt.beforeEach.givenModel('bank');
 
     lt.it.shouldBeAllowedWhenCalledAnonymously('GET', '/api/banks');
@@ -163,6 +191,7 @@ describe('access control - integration', function() {
     lt.it.shouldBeDeniedWhenCalledAnonymously('DELETE', urlForBank);
     lt.it.shouldBeDeniedWhenCalledUnauthenticated('DELETE', urlForBank);
     lt.it.shouldBeDeniedWhenCalledByUser(CURRENT_USER, 'DELETE', urlForBank);
+    lt.it.shouldBeAllowedWhenCalledByUser(SPECIAL_USER, 'DELETE', urlForBank);
 
     function urlForBank() {
       return '/api/banks/' + this.bank.id;

--- a/test/fixtures/access-control/common/models/bank.json
+++ b/test/fixtures/access-control/common/models/bank.json
@@ -22,6 +22,12 @@
       "permission": "ALLOW",
       "principalType": "ROLE",
       "principalId": "$everyone"
+    },
+    {
+      "accessType": "WRITE",
+      "permission": "ALLOW",
+      "principalType": "ROLE",
+      "principalId": "$dynamic-role"
     }
   ],
   "properties": {}

--- a/test/fixtures/access-control/server/server.js
+++ b/test/fixtures/access-control/server/server.js
@@ -5,7 +5,7 @@
 
 var loopback = require('../../../..');
 var boot = require('loopback-boot');
-var app = module.exports = loopback({ localRegistry: true });
+var app = module.exports = loopback({ localRegistry: true, loadBuiltinModels: true });
 var errorHandler = require('strong-error-handler');
 boot(app, __dirname);
 

--- a/test/fixtures/user-integration-app/server/server.js
+++ b/test/fixtures/user-integration-app/server/server.js
@@ -5,7 +5,7 @@
 
 var loopback = require('../../../../index');
 var boot = require('loopback-boot');
-var app = module.exports = loopback({ localRegistry: true });
+var app = module.exports = loopback({ localRegistry: true, loadBuiltinModels: true });
 var errorHandler = require('strong-error-handler');
 app.enableAuth();
 boot(app, __dirname);


### PR DESCRIPTION
Fixes #2627 

@bajtos 
I reused a helper-method `resolveRelatedModels()` that had been added by someone else before. Helped me figure out that there are other related models that would be resolved from the wrong registry (`RoleMapping`, `User`, `Application`).

Had to modify setup of test servers when ACL was used; forcing to `loadBuiltinModels` with localRegistry. Alternative would be to list all related Models (e.g. `Application`) in the server's `model-config.json`

That said, it is required that related models are added  to the same registry. For built-in models, that can happen via the `loadBuiltinModels` option; others should be added to `model-config.json`