### PR TITLE
need to check if the context is active

### DIFF
--- a/server/middleware/token.js
+++ b/server/middleware/token.js
@@ -125,7 +125,7 @@ function token(options) {
       req.accessToken = token || null;
       rewriteUserLiteral(req, currentUserLiteral);
       var ctx = req.loopbackContext;
-      if (ctx) ctx.set('accessToken', token);
+      if (ctx && ctx.active) ctx.set('accessToken', token);
       next(err);
     });
   };


### PR DESCRIPTION
if you for example load the explorer, you don't have any active context,
and it will fail here then with the message:
  "Error: No context available. ns.run() or ns.bind() must be called
  first."

Fix https://github.com/strongloop/loopback-context/issues/6