### PR TITLE
Fix token middleware crash [2.x]

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "chai": "^3.5.0",
     "es5-shim": "^4.1.0",
     "eslint-config-loopback": "^1.0.0",
+    "express-session": "^1.14.0",
     "grunt": "^1.0.1",
     "grunt-browserify": "^5.0.0",
     "grunt-cli": "^1.2.0",

--- a/server/middleware/token.js
+++ b/server/middleware/token.js
@@ -125,7 +125,7 @@ function token(options) {
       req.accessToken = token || null;
       rewriteUserLiteral(req, currentUserLiteral);
       var ctx = req.loopbackContext;
-      if (ctx) ctx.set('accessToken', token);
+      if (ctx && ctx.active) ctx.set('accessToken', token);
       next(err);
     });
   };

--- a/test/access-token.test.js
+++ b/test/access-token.test.js
@@ -6,6 +6,8 @@
 var cookieParser = require('cookie-parser');
 var loopback = require('../');
 var extend = require('util')._extend;
+var session = require('express-session');
+
 var Token = loopback.AccessToken.extend('MyToken');
 var ds = loopback.createDataSource({connector: loopback.Memory});
 Token.attachTo(ds);
@@ -506,6 +508,29 @@ describe('app.enableAuth()', function() {
 
         done();
       });
+  });
+
+  // See https://github.com/strongloop/loopback-context/issues/6
+  it('checks whether context is active', function(done) {
+    var app = loopback();
+
+    app.enableAuth();
+    app.use(loopback.context());
+    app.use(session({
+      secret: 'kitty',
+      saveUninitialized: true,
+      resave: true
+    }));
+    app.use(loopback.token({ model: Token }));
+    app.get('/', function(req, res) { res.send('OK'); });
+    app.use(loopback.rest());
+
+    request(app)
+      .get('/')
+      .set('authorization', this.token.id)
+      .set('cookie', 'connect.sid=s%3AFTyno9_MbGTJuOwdh9bxsYCVxlhlulTZ.PZvp85jzLXZBCBkhCsSfuUjhij%2Fb0B1K2RYZdxSQU0c')
+      .expect(200, 'OK')
+      .end(done);
   });
 });
 


### PR DESCRIPTION
Fix token middleware to check if `req.loopbackContext` is active.

The context is not active for example when express-session calls
`setImmediate` which breaks CLS.

This patch supersedes https://github.com/strongloop/loopback/pull/2636
Related: strongloop/loopback-context#6

cc @azatoth