### PR TITLE
Fix token middleware crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "cookie-parser": "^1.3.4",
     "es5-shim": "^4.1.0",
     "eslint-config-loopback": "^1.0.0",
+    "express-session": "^1.14.0",
     "grunt": "^1.0.1",
     "grunt-browserify": "^5.0.0",
     "grunt-cli": "^1.2.0",

--- a/server/middleware/context.js
+++ b/server/middleware/context.js
@@ -3,6 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+var g = require('strong-globalize')();
+
 module.exports = function() {
   throw new Error(g.f(
     '%s middleware was removed in version 3.0. See %s for more details.',

--- a/server/middleware/token.js
+++ b/server/middleware/token.js
@@ -125,7 +125,7 @@ function token(options) {
       req.accessToken = token || null;
       rewriteUserLiteral(req, currentUserLiteral);
       var ctx = req.loopbackContext;
-      if (ctx) ctx.set('accessToken', token);
+      if (ctx && ctx.active) ctx.set('accessToken', token);
       next(err);
     });
   };


### PR DESCRIPTION
Fix token middleware to check if `req.loopbackContext` is active.

The context is not active for example when express-session calls setImmediate which breaks CLS.

This is a back-port of #2649 
Related: strongloop/loopback-context#6

cc @azatoth