### PR TITLE
KeyValueModel: add API for listing keys [2.x]

### DIFF
--- a/common/models/key-value-model.js
+++ b/common/models/key-value-model.js
@@ -16,6 +16,16 @@ module.exports = function(KeyValueModel) {
     throwNotAttached(this.modelName, 'expire');
   };
 
+  // TODO add api docs
+  KeyValueModel.keys = function(filter, options, callback) {
+    throwNotAttached(this.modelName, 'keys');
+  };
+
+  // TODO add api docs
+  KeyValueModel.iterateKeys = function(filter, options) {
+    throwNotAttached(this.modelName, 'iterateKeys');
+  };
+
   KeyValueModel.setup = function() {
     KeyValueModel.base.setup.apply(this, arguments);
 
@@ -50,6 +60,15 @@ module.exports = function(KeyValueModel) {
           http: { source: 'form' }},
       ],
       http: { path: '/:key/expire', verb: 'put' },
+    });
+
+    this.remoteMethod('keys', {
+      accepts: {
+        arg: 'filter', type: 'object', required: false,
+        http: { source: 'query' },
+      },
+      returns: { arg: 'keys', type: ['string'], root: true },
+      http: { path: '/keys', verb: 'get' },
     });
   };
 };

--- a/test/key-value-model.test.js
+++ b/test/key-value-model.test.js
@@ -80,6 +80,20 @@ describe('KeyValueModel', function() {
         .send({ ttl: 10 })
         .expect(404, done);
     });
+
+    it('provides "keys(filter)" at "GET /keys"', function(done) {
+      CacheItem.set('list-key', AN_OBJECT_VALUE, function(err) {
+        if (err) return done(err);
+        request.get('/CacheItems/keys')
+          .send(AN_OBJECT_VALUE)
+          .end(function(err, res) {
+            if (err) return done(err);
+            if (res.body.error) return done(res.body.error);
+            expect(res.body).to.eql(['list-key']);
+            done();
+          });
+      });
+    });
   });
 
   function setupAppAndCacheItem() {


### PR DESCRIPTION
 - Expose "keys()" at "GET /keys"
 - Add a dummy implementation for "iterateKeys" to serve a useful error
   message when the model is not attached correctly.

Back-port of https://github.com/strongloop/loopback/pull/2638
Requires strongloop/loopback-datasource-juggler#1049
Connect to strongloop/loopback#2592