### PR TITLE
Fix Patch/Put order #2640

### DIFF
--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -635,7 +635,7 @@ module.exports = function(registry) {
     };
 
     if (!options.replaceOnPUT) {
-      upsertOptions.http.push({ verb: 'put', path: '/' });
+      upsertOptions.http.unshift({ verb: 'put', path: '/' });
     }
     setRemoting(PersistedModel, 'patchOrCreate', upsertOptions);
 
@@ -802,7 +802,7 @@ module.exports = function(registry) {
     setRemoting(PersistedModel.prototype, 'patchAttributes', updateAttributesOptions);
 
     if (!options.replaceOnPUT) {
-      updateAttributesOptions.http.push({ verb: 'put', path: '/' });
+      updateAttributesOptions.http.unshift({ verb: 'put', path: '/' });
     }
 
     if (options.trackChanges || options.enableRemoteReplication) {


### PR DESCRIPTION
Changed push to unshift so the verb PUT is first and ng-lb doesn't generate the API using the patch verb on versions 2.X