### PR TITLE
Fixes 'this' binding for role connection to users/applications/roles 

### DIFF
--- a/common/models/role.js
+++ b/common/models/role.js
@@ -80,7 +80,7 @@ module.exports = function(Role) {
         };
 
         var model = relsToModels[rel];
-        listByPrincipalType(model, relsToTypes[rel], query, callback);
+        listByPrincipalType.call(this, model, relsToTypes[rel], query, callback);
       };
     });
 

--- a/common/models/role.js
+++ b/common/models/role.js
@@ -80,26 +80,27 @@ module.exports = function(Role) {
         };
 
         var model = relsToModels[rel];
-        listByPrincipalType.call(this, model, relsToTypes[rel], query, callback);
+        listByPrincipalType(this, model, relsToTypes[rel], query, callback);
       };
     });
 
     /**
      * Fetch all models assigned to this role
      * @private
+     * @param {object} model context
      * @param {*} model model type to fetch
      * @param {String} [principalType] principalType used in the rolemapping for model
      * @param {object} [query] query object passed to model find call
      * @param  {Function} [callback] callback function called with `(err, models)` arguments.
      */
-    function listByPrincipalType(model, principalType, query, callback) {
+    function listByPrincipalType(self, model, principalType, query, callback) {
       if (callback === undefined) {
         callback = query;
         query = {};
       }
 
       roleModel.roleMappingModel.find({
-        where: {roleId: this.id, principalType: principalType}
+        where: {roleId: self.id, principalType: principalType}
       }, function(err, mappings) {
         var ids;
         if (err) {

--- a/test/role.test.js
+++ b/test/role.test.js
@@ -581,38 +581,82 @@ describe('role model', function() {
     });
 
     it('should fetch all models assigned to the role', function(done) {
+
       var principalTypesToModels = {};
-      var runs = 0;
       var mappings;
 
       principalTypesToModels[RoleMapping.USER] = User;
       principalTypesToModels[RoleMapping.APPLICATION] = Application;
       principalTypesToModels[RoleMapping.ROLE] = Role;
-
       mappings = Object.keys(principalTypesToModels);
 
-      mappings.forEach(function(principalType) {
-        var Model = principalTypesToModels[principalType];
-        Model.create({ name: 'test', email: 'x@y.com', password: 'foobar' }, function(err, model) {
-          if (err) return done(err);
-          var uniqueRoleName = 'testRoleFor' + principalType;
-          Role.create({ name: uniqueRoleName }, function(err, role) {
-            if (err) return done(err);
-            role.principals.create({ principalType: principalType, principalId: model.id },
-            function(err, p) {
-              if (err) return done(err);
-              var pluralName = Model.pluralModelName.toLowerCase();
-              role[pluralName](function(err, models) {
-                if (err) return done(err);
-                assert.equal(models.length, 1);
+      async.each(mappings, function(principalType, eachCallback) {
 
-                if (++runs === mappings.length) {
-                  done();
-                }
+        var Model = principalTypesToModels[principalType];
+
+        async.waterfall([
+          // Create models
+          function(next) {
+            Model.create([
+                { name: 'test', email: 'x@y.com', password: 'foobar' },
+                { name: 'test2', email: 'f@v.com', password: 'bargoo' },
+                { name: 'test3', email: 'd@t.com', password: 'bluegoo' }
+              ], function(err, models) {
+                if (err) return next(err);
+                next(null, models);
               });
+          },
+
+          // Create Roles
+          function(models, next) {
+            var uniqueRoleName = 'testRoleFor' + principalType;
+            var otherUniqueRoleName = 'otherTestRoleFor' + principalType;
+            Role.create([
+                { name: uniqueRoleName },
+                { name: otherUniqueRoleName }
+              ], function(err, roles) {
+                if (err) return next(err);
+                next(null, models, roles);
+              });
+          },
+
+          // Create principles
+          function(models, roles, next){
+            async.parallel([
+              function(callback){
+                roles[0].principals.create({ principalType: principalType, principalId: models[0].id },
+                  function(err, p) {
+                    if (err) return callback(err);
+                    callback(p);
+                  });
+              },
+              function(callback){
+                roles[1].principals.create({ principalType: principalType, principalId: models[1].id },
+                  function(err, p) {
+                    if (err) return callback(err);
+                    callback(p);
+                  });
+              }
+            ],
+            function(err, principles) {
+              next(null, models, roles, principles)
             });
-          });
-        });
+          },
+
+          // Run tests against unique Role     
+          function(models, roles, principles, next){
+            var pluralName = Model.pluralModelName.toLowerCase();
+            uniqueRole = roles[0];
+            uniqueRole[pluralName](function(err, models) {
+              if (err) return done(err);
+              assert.equal(models.length, 1);
+              next();
+            });
+          }
+        ], eachCallback);
+      
+      }, function(err){
+        done()
       });
     });
 


### PR DESCRIPTION
`listByPrincipalType()` loses `this` context of the `Role` and as a result the `where: this.id` in the filter is undefined and ignored. As a result the function returns any models with any assigned role rather than the role specified by `roleId`.

This commit simply adds `listByPrincipalType.call(this, ...)` to bind the `Role` instance as it's context.  