### PR TITLE
Reorder PATCH Vs PUT endpoints

### DIFF
--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -635,7 +635,7 @@ module.exports = function(registry) {
     };
 
     if (!options.replaceOnPUT) {
-      upsertOptions.http.push({ verb: 'put', path: '/' });
+      upsertOptions.http.unshift({ verb: 'put', path: '/' });
     }
     setRemoting(PersistedModel, 'patchOrCreate', upsertOptions);
 
@@ -802,7 +802,7 @@ module.exports = function(registry) {
     setRemoting(PersistedModel.prototype, 'patchAttributes', updateAttributesOptions);
 
     if (!options.replaceOnPUT) {
-      updateAttributesOptions.http.push({ verb: 'put', path: '/' });
+      updateAttributesOptions.http.unshift({ verb: 'put', path: '/' });
     }
 
     if (options.trackChanges || options.enableRemoteReplication) {

--- a/test/remoting.integration.js
+++ b/test/remoting.integration.js
@@ -198,15 +198,26 @@ describe('With model.settings.replaceOnPUT false', function() {
     var methods = getFormattedMethodsExcludingRelations(storeClass.methods);
 
     var expectedMethods = [
-      'patchOrCreate(data:object):storeWithReplaceOnPUTfalse PATCH /stores-updating',
+      'create(data:object):storeWithReplaceOnPUTfalse POST /stores-updating',
       'patchOrCreate(data:object):storeWithReplaceOnPUTfalse PUT /stores-updating',
+      'patchOrCreate(data:object):storeWithReplaceOnPUTfalse PATCH /stores-updating',
       'replaceOrCreate(data:object):storeWithReplaceOnPUTfalse POST /stores-updating/replaceOrCreate',
+      'exists(id:any):boolean GET /stores-updating/:id/exists',
+      'exists(id:any):boolean HEAD /stores-updating/:id',
+      'findById(id:any,filter:object):storeWithReplaceOnPUTfalse GET /stores-updating/:id',
       'replaceById(id:any,data:object):storeWithReplaceOnPUTfalse POST /stores-updating/:id/replace',
-      'prototype.patchAttributes(data:object):storeWithReplaceOnPUTfalse PATCH /stores-updating/:id',
+      'find(filter:object):storeWithReplaceOnPUTfalse GET /stores-updating',
+      'findOne(filter:object):storeWithReplaceOnPUTfalse GET /stores-updating/findOne',
+      'updateAll(where:object,data:object):object POST /stores-updating/update',
+      'deleteById(id:any):object DELETE /stores-updating/:id',
+      'count(where:object):number GET /stores-updating/count',
       'prototype.patchAttributes(data:object):storeWithReplaceOnPUTfalse PUT /stores-updating/:id',
+      'prototype.patchAttributes(data:object):storeWithReplaceOnPUTfalse PATCH /stores-updating/:id',
+      'createChangeStream(options:object):ReadableStream POST /stores-updating/change-stream',
+      'createChangeStream(options:object):ReadableStream GET /stores-updating/change-stream',
     ];
 
-    expect(methods).to.include.members(expectedMethods);
+    expect(methods).to.eql(expectedMethods);
   });
 });
 


### PR DESCRIPTION
*Reorder PATCH Vs PUT endpoints for update* methods

I thought we may not need to land it to `master`; on the second thought I guess it needs to be fixed on both `master` and `2.x`.

Connect to https://github.com/strongloop/loopback/issues/2640

Needs to be backported to `2.x`

/@bajtos 