### PR TITLE
Use strong-remoting's new TypeRegistry

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -138,6 +138,9 @@ app.model = function(Model, config) {
   this.models().push(Model);
 
   if (isPublic && Model.sharedClass) {
+    this.remotes().defineObjectType(Model.modelName, function(data) {
+      return new Model(data);
+    });
     this.remotes().addClass(Model.sharedClass);
     if (Model.settings.trackChanges && Model.Change) {
       this.remotes().addClass(Model.Change.sharedClass);

--- a/lib/application.js
+++ b/lib/application.js
@@ -316,8 +316,10 @@ app.enableAuth = function(options) {
           g.f('Authentication requires model %s to be defined.', m));
       }
 
-      if (m.dataSource || m.app) return;
+      if (Model.dataSource || Model.app) return;
 
+      // Find descendants of Model that are attached,
+      // for example "Customer" extending "User" model
       for (var name in appModels) {
         var candidate = appModels[name];
         var isSubclass = candidate.prototype instanceof Model;

--- a/lib/model.js
+++ b/lib/model.js
@@ -134,11 +134,6 @@ module.exports = function(registry) {
       remotingOptions
     );
 
-    // setup a remoting type converter for this model
-    RemoteObjects.convert(typeName, function(val) {
-      return val ? new ModelCtor(val) : val;
-    });
-
     // support remoting prototype methods
     ModelCtor.sharedCtor = function(data, id, fn) {
       var ModelCtor = this;

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "ejs": "^2.3.1",
     "express": "^4.14.0",
     "inflection": "^1.6.0",
-    "loopback-connector-remote": "^2.0.0-alpha.1",
+    "loopback-connector-remote": "^2.0.0-alpha.2",
     "loopback-datasource-juggler": "^3.0.0-alpha.7",
     "isemail": "^1.2.0",
     "loopback-phase": "^1.2.0",
@@ -55,7 +55,7 @@
     "serve-favicon": "^2.2.0",
     "stable": "^0.1.5",
     "strong-globalize": "^2.6.2",
-    "strong-remoting": "^3.0.0-alpha.5",
+    "strong-remoting": "^3.0.0-alpha.6",
     "uid2": "0.0.3",
     "underscore.string": "^3.0.3"
   },

--- a/test/relations.integration.js
+++ b/test/relations.integration.js
@@ -656,6 +656,9 @@ describe('relations - integration', function() {
 
   describe('hasAndBelongsToMany', function() {
     beforeEach(function defineProductAndCategoryModels() {
+      // Disable "Warning: overriding remoting type product"
+      this.app.remotes()._typeRegistry._options.warnWhenOverridingType = false;
+
       var product = app.registry.createModel(
          'product',
          { id: 'string', name: 'string' }

--- a/test/remote-connector.test.js
+++ b/test/remote-connector.test.js
@@ -15,7 +15,10 @@ describe('RemoteConnector', function() {
     beforeEach: function(done) {
       var test = this;
       remoteApp = loopback();
-      remoteApp.set('remoting', { errorHandler: { debug: true, log: false }});
+      remoteApp.set('remoting', {
+        errorHandler: { debug: true, log: false },
+        types: { warnWhenOverridingType: false },
+      });
       remoteApp.use(loopback.rest());
       remoteApp.listen(0, function() {
         test.dataSource = loopback.createDataSource({
@@ -51,6 +54,9 @@ describe('RemoteConnector', function() {
   beforeEach(function(done) {
     var test = this;
     remoteApp = this.remoteApp = loopback();
+    remoteApp.set('remoting', {
+      types: { warnWhenOverridingType: false },
+    });
     remoteApp.use(loopback.rest());
     var ServerModel = this.ServerModel = loopback.PersistedModel.extend('TestModel');
 

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -70,7 +70,6 @@ describe('User', function() {
     app.enableAuth({ dataSource: 'db' });
     app.use(loopback.token({ model: AccessToken }));
     app.use(loopback.rest());
-    app.model(User);
 
     User.create(validCredentials, function(err, user) {
       if (err) return done(err);


### PR DESCRIPTION
The first two commits fix issues discovered by strong-remoting's duplicate checker.

The last commit reworks model registration to use the new strong-remoting API.

Requires https://github.com/strongloop/strong-remoting/pull/343

to: @gunjpan @richardpringle @deepakrkris Please review.
cc: @ritch @STRML @0candy @davidcheung

Connect to strongloop-internal/scrum-loopback#885

**TODO before merging**
 - [x] wait for https://github.com/strongloop/strong-remoting/pull/343 and
https://github.com/strongloop/loopback-connector-remote/pull/58 to be landed
 - [x] make a new alpha release of both strong-remoting and loopback-connector-remote
 - [x] bump up minimum dependency versions for these two modules in package.json



