### PR TITLE
Fix app.enableAuth and test/user [2.x]

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -327,8 +327,10 @@ app.enableAuth = function(options) {
           g.f('Authentication requires model %s to be defined.', m));
       }
 
-      if (m.dataSource || m.app) return;
+      if (Model.dataSource || Model.app) return;
 
+      // Find descendants of Model that are attached,
+      // for example "Customer" extending "User" model
       for (var name in appModels) {
         var candidate = appModels[name];
         var isSubclass = candidate.prototype instanceof Model;

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -66,7 +66,6 @@ describe('User', function() {
     app.enableAuth({ dataSource: 'db' });
     app.use(loopback.token({ model: AccessToken }));
     app.use(loopback.rest());
-    app.model(User);
 
     User.create(validCredentials, function(err, user) {
       if (err) return done(err);


### PR DESCRIPTION
This is a partial back-port of #2696.

- Fix a typo in "app.enableAuth" that caused the method to not detect
the situation when e.g. the built-in User model is already attached
to a datasource.

- don't attach User model twice in `test/user.test.js`

@gunjpan @richardpringle @deepakrkris since you are reviewing the other pull request, could one of you review this one too?