### PR TITLE
Added option to set restApiRoot to "" for servers run at root.

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -400,8 +400,9 @@ module.exports = function(User) {
     var app = userModel.app;
     options.host = options.host || (app && app.get('host')) || 'localhost';
     options.port = options.port || (app && app.get('port')) || 3000;
-    options.restApiRoot = options.restApiRoot || (app && app.get('restApiRoot')) || '/api';
-
+    if(options.restApiRoot !== ""){
+      options.restApiRoot = options.restApiRoot || (app && app.get('restApiRoot')) || '/api';
+    }
     var displayPort = (
       (options.protocol === 'http' && options.port == '80') ||
       (options.protocol === 'https' && options.port == '443')


### PR DESCRIPTION
Previously, if you ran loopback at the root directory, verification urls wouldn't be generated correctly. For example:

`https://api.example.com//users/etc-etc`
instead of
`https://api.example.com/users/etc-etc`
(note the double slash)

This was due to empty strings ("") resolving to false in javascript. A simple if statement fixes it.