### PR TITLE
Fix double-slash in confirmation URL [2.x]

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -401,14 +401,18 @@ module.exports = function(User) {
       (options.protocol === 'https' && options.port == '443')
     ) ? '' : ':' + options.port;
 
+    var urlPath = joinUrlPath(
+      options.restApiRoot,
+      userModel.http.path,
+      userModel.sharedClass.find('confirm', true).http.path
+    );
+
     options.verifyHref = options.verifyHref ||
       options.protocol +
       '://' +
       options.host +
       displayPort +
-      options.restApiRoot +
-      userModel.http.path +
-      userModel.sharedClass.find('confirm', true).http.path +
+      urlPath +
       '?uid=' +
       options.user.id +
       '&redirect=' +
@@ -766,4 +770,14 @@ function emailValidator(err, done) {
   if (value === '') return;
   if (!isEmail(value))
     return err('email');
+}
+
+function joinUrlPath(args) {
+  var result = arguments[0];
+  for (var ix = 1; ix < arguments.length; ix++) {
+    var next = arguments[ix];
+    result += result[result.length - 1] === '/' && next[0] === '/' ?
+      next.slice(1) : next;
+  }
+  return result;
 }

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -1551,6 +1551,41 @@ describe('User', function() {
 
         done();
       });
+
+      it('should squash "//" when restApiRoot is "/"', function(done) {
+        var emailBody;
+        User.afterRemote('create', function(ctx, user, next) {
+          assert(user, 'afterRemote should include result');
+
+          var options = {
+            type: 'email',
+            to: user.email,
+            from: 'noreply@myapp.org',
+            redirect: '/',
+            host: 'myapp.org',
+            port: 3000,
+            restApiRoot: '/',
+          };
+
+          user.verify(options, function(err, result) {
+            if (err) return next(err);
+            emailBody = result.email.response.toString('utf-8');
+            next();
+          });
+        });
+
+        request(app)
+          .post('/test-users')
+          .expect('Content-Type', /json/)
+          .expect(200)
+          .send({email: 'user@example.com', password: 'pass'})
+          .end(function(err, res) {
+            if (err) return done(err);
+            expect(emailBody)
+              .to.contain('http://myapp.org:3000/test-users/confirm');
+            done();
+          });
+      });
     });
 
     describe('User.confirm(options, fn)', function() {


### PR DESCRIPTION
Fix the code building the URL used in the email-verification email
to prevent double-slash in the URL when e.g. restApiRoot is '/'.

Before:

    http://example.com//users/confirm?...

Now:

    http://example.com/users/confirm?...

This patch is based on #2712 from @jonathan-chin  

Connect to #2452

@loay @richardpringle please review