### PR TITLE
Add instructions for upgrading context

### DIFF
--- a/3.0-RELEASE-NOTES.md
+++ b/3.0-RELEASE-NOTES.md
@@ -162,8 +162,37 @@ We have removed the following current-context-related APIs:
  - `loopback.createContext`
  - `loopback.runInContext`
 
-Additionaly, `loopback#context` middleware and `remoting.context` server
+Additionally, `loopback#context` middleware and `remoting.context` server
 config were removed too.
+
+#### Upgrading from 2.x to 3.x
+
+When upgrading from LoopBack 2.x, you need to disable or remove
+`remoting.context` configuration in your server config.
+
+```js
+{
+  "remoting": {
+    "context": false, // or remove completely
+    // etc.
+  },
+  // etc.
+}
+```
+
+Without this change, you will see the following error on the first HTTP request
+received:
+
+```
+Unhandled error for request GET /api/Users:
+Error: remoting.context option was removed in version 3.0.
+See https://docs.strongloop.com/display/APIC/Using%20current%20context for more
+details.
+    at restApiHandler (.../node_modules/loopback/server/middleware/rest.js:44:15)
+    at Layer.handle [as handle_request] (.../node_modules/express/lib/router/layer.js:95:5)
+```
+
+#### Setting up "current context" in 3.x
 
 To setup "current context" feature in your LoopBack 3.x application, you
 should use [loopback-context](https://www.npmjs.com/package/loopback-context)


### PR DESCRIPTION
Describe how to upgrade LoopBack 2.x apps to 3.x and prevent "Error: remoting.context option was removed in version 3.0."

@0candy please review

@rogersnm would this additional information help you solve the issue described in #2610?

Connect to #2610