### PR TITLE
Upgrade loopback-testing to the latest ^1.4 [2.x-only]

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "karma-script-launcher": "^1.0.0",
     "loopback-boot": "^2.7.0",
     "loopback-datasource-juggler": "^2.19.1",
-    "loopback-testing": "~1.1.0",
+    "loopback-testing": "^1.4.0",
     "mocha": "^3.0.0",
     "phantomjs-prebuilt": "^2.1.7",
     "sinon": "^1.13.0",

--- a/test/access-control.integration.js
+++ b/test/access-control.integration.js
@@ -24,6 +24,7 @@ describe('access control - integration', function() {
   });
 
   lt.beforeEach.withApp(app);
+  lt.beforeEach.withUserModel('user');
 
   /*
   describe('accessToken', function() {
@@ -105,7 +106,7 @@ describe('access control - integration', function() {
 
     lt.describe.whenLoggedInAsUser(CURRENT_USER, function() {
       beforeEach(function() {
-        this.url = '/api/users/' + this.user.id + '?ok';
+        this.url = '/api/users/' + this.loggedInAccessToken.userId + '?ok';
       });
       lt.describe.whenCalledRemotely('DELETE', '/api/users/:id', function() {
         lt.it.shouldBeAllowed();
@@ -262,7 +263,7 @@ describe('access control - integration', function() {
         var self = this;
         // Create an account under the given user
         app.models.accountWithReplaceOnPUTtrue.create({
-          userId: self.user.id,
+          userId: self.loggedInAccessToken.userId,
           balance: 100
         }, function(err, act) {
           actId = act.id;
@@ -326,7 +327,7 @@ describe('access control - integration', function() {
         var self = this;
         // Create an account under the given user
         app.models.accountWithReplaceOnPUTfalse.create({
-          userId: self.user.id,
+          userId: self.loggedInAccessToken.userId,
           balance: 100,
         }, function(err, act) {
           actId = act.id;


### PR DESCRIPTION
I noticed that `npm install` in the loopback repository is producing a lot of deprecation warnings. In this patch, I am getting rid of one source of these warnings, and that's an old version of loopback-testing.

I have already updated dependencies of loopback-testing in https://github.com/strongloop-archive/loopback-testing/pull/74.

@superkhau please review