### PR TITLE
Fix context within listByPrincipalType role method

### DIFF
--- a/common/models/role.js
+++ b/common/models/role.js
@@ -78,26 +78,27 @@ module.exports = function(Role) {
         };
 
         var model = relsToModels[rel];
-        listByPrincipalType(model, relsToTypes[rel], query, callback);
+        listByPrincipalType(this, model, relsToTypes[rel], query, callback);
       };
     });
 
     /**
      * Fetch all models assigned to this role
      * @private
+     * @param {object} Context role context
      * @param {*} model model type to fetch
      * @param {String} [principalType] principalType used in the rolemapping for model
      * @param {object} [query] query object passed to model find call
      * @param  {Function} [callback] callback function called with `(err, models)` arguments.
      */
-    function listByPrincipalType(model, principalType, query, callback) {
+    function listByPrincipalType(context, model, principalType, query, callback) {
       if (callback === undefined) {
         callback = query;
         query = {};
       }
 
       roleModel.roleMappingModel.find({
-        where: { roleId: this.id, principalType: principalType },
+        where: { roleId: context.id, principalType: principalType },
       }, function(err, mappings) {
         var ids;
         if (err) {

--- a/test/role.test.js
+++ b/test/role.test.js
@@ -616,6 +616,84 @@ describe('role model', function() {
       });
     });
 
+    it('should fetch all models only assigned to the role', function(done) {
+      var principalTypesToModels = {};
+      var mappings;
+
+      principalTypesToModels[RoleMapping.USER] = User;
+      principalTypesToModels[RoleMapping.APPLICATION] = Application;
+      principalTypesToModels[RoleMapping.ROLE] = Role;
+      mappings = Object.keys(principalTypesToModels);
+
+      async.each(mappings, function(principalType, eachCallback) {
+        var Model = principalTypesToModels[principalType];
+
+        async.waterfall([
+          // Create models
+          function(next) {
+            Model.create([
+                { name: 'test', email: 'x@y.com', password: 'foobar' },
+                { name: 'test2', email: 'f@v.com', password: 'bargoo' },
+                { name: 'test3', email: 'd@t.com', password: 'bluegoo' }],
+              function(err, models) {
+                if (err) return next(err);
+                next(null, models);
+              });
+          },
+
+          // Create Roles
+          function(models, next) {
+            var uniqueRoleName = 'testRoleFor' + principalType;
+            var otherUniqueRoleName = 'otherTestRoleFor' + principalType;
+            Role.create([
+                { name: uniqueRoleName },
+                { name: otherUniqueRoleName }],
+              function(err, roles) {
+                if (err) return next(err);
+                next(null, models, roles);
+              });
+          },
+
+          // Create principles
+          function(models, roles, next) {
+            async.parallel([
+              function(callback) {
+                roles[0].principals.create(
+                  { principalType: principalType, principalId: models[0].id },
+                  function(err, p) {
+                    if (err) return callback(err);
+                    callback(p);
+                  });
+              },
+              function(callback) {
+                roles[1].principals.create(
+                  { principalType: principalType, principalId: models[1].id },
+                  function(err, p) {
+                    if (err) return callback(err);
+                    callback(p);
+                  });
+              }],
+            function(err, principles) {
+              next(null, models, roles, principles);
+            });
+          },
+
+          // Run tests against unique Role
+          function(models, roles, principles, next) {
+            var pluralName = Model.pluralModelName.toLowerCase();
+            uniqueRole = roles[0];
+            uniqueRole[pluralName](function(err, models) {
+              if (err) return done(err);
+              assert.equal(models.length, 1);
+              next();
+            });
+          }],
+        eachCallback);
+      }, function(err) {
+        done();
+      });
+    });
+
     it('should apply query', function(done) {
       User.create({ name: 'Raymond', email: 'x@y.com', password: 'foobar' }, function(err, user) {
         if (err) return done(err);


### PR DESCRIPTION
- Fix for current implimentation that returned all models that had any
  assigned roles. Context was not carried into listByPrincipalType,
  setting roleId as null.
