### PR TITLE
Expose new method for disabling remote methods.

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -15,6 +15,8 @@ var SharedClass = require('strong-remoting').SharedClass;
 var extend = require('util')._extend;
 var format = require('util').format;
 
+var deprecated = require('depd')('loopback');
+
 module.exports = function(registry) {
   /**
    * The base class for **all models**.
@@ -436,7 +438,22 @@ module.exports = function(registry) {
    */
 
   Model.disableRemoteMethod = function(name, isStatic) {
-    this.sharedClass.disableMethod(name, isStatic || false);
+    deprecated('Model.disableRemoteMethod is deprecated. ' +
+      'Use Model.disableRemoteMethodByName instead.');
+    var key = this.sharedClass.getKeyFromMethodNameAndTarget(name, isStatic);
+    this.sharedClass.disableMethodByName(key);
+    this.emit('remoteMethodDisabled', this.sharedClass, key);
+  };
+
+  /**
+   * Disable remote invocation for the method with the given name.
+   *
+   * @param {String} name The name of the method (include "prototype." if the method is defined on the prototype).
+   *
+   */
+
+  Model.disableRemoteMethodByName = function(name) {
+    this.sharedClass.disableMethodByName(name);
     this.emit('remoteMethodDisabled', this.sharedClass, name);
   };
 

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -672,7 +672,7 @@ describe('app', function() {
         disabledRemoteMethod = methodName;
       });
       app.model(Color);
-      app.models.Color.disableRemoteMethod('findOne');
+      app.models.Color.disableRemoteMethodByName('findOne');
       expect(remoteMethodDisabledClass).to.exist;
       expect(remoteMethodDisabledClass).to.eql(Color.sharedClass);
       expect(disabledRemoteMethod).to.exist;

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -698,7 +698,21 @@ describe.onServer('Remote Methods', function() {
       var callbackSpy = require('sinon').spy();
       var TestModel = app.models.TestModelForDisablingRemoteMethod;
       TestModel.on('remoteMethodDisabled', callbackSpy);
-      TestModel.disableRemoteMethod('findOne');
+      TestModel.disableRemoteMethod('findOne', true);
+
+      expect(callbackSpy).to.have.been.calledWith(TestModel.sharedClass, 'findOne');
+    });
+
+    it('emits a `remoteMethodDisabled` event from disableRemoteMethodByName', function() {
+      var app = loopback();
+      var model = PersistedModel.extend('TestModelForDisablingRemoteMethod');
+      app.dataSource('db', { connector: 'memory' });
+      app.model(model, { dataSource: 'db' });
+
+      var callbackSpy = require('sinon').spy();
+      var TestModel = app.models.TestModelForDisablingRemoteMethod;
+      TestModel.on('remoteMethodDisabled', callbackSpy);
+      TestModel.disableRemoteMethodByName('findOne');
 
       expect(callbackSpy).to.have.been.calledWith(TestModel.sharedClass, 'findOne');
     });


### PR DESCRIPTION
There is a new `SharedClass` method available in strong-remoting for disabling a method by name instead of specifying the `isStatic` boolean. 

I have exposed the method on the `Model` Class such that it can be used for a spike related to #651.

@bajtos, please review 