### PR TITLE
Backport/ Allow resetPassword if EmailVerified

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -566,7 +566,14 @@ module.exports = function(User) {
       }
       // create a short lived access token for temp login to change password
       // TODO(ritch) - eventually this should only allow password change
-      user.accessTokens.create({ttl: ttl}, function(err, accessToken) {
+      if (UserModel.settings.emailVerificationRequired && !user.emailVerified) {
+        err = new Error(g.f('Email has not been verified'));
+        err.statusCode = 401;
+        err.code = 'RESET_FAILED_EMAIL_NOT_VERIFIED';
+        return cb(err);
+      }
+
+      user.accessTokens.create({ ttl: ttl }, function(err, accessToken) {
         if (err) {
           return cb(err);
         }

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -2121,6 +2121,43 @@ describe('User', function() {
     });
   });
 
+  describe('password reset with/without email verification', function() {
+    it('allows resetPassword by email if email verification is required and done',
+    function(done) {
+      User.settings.emailVerificationRequired = true;
+      var email = validCredentialsEmailVerified.email;
+
+      User.resetPassword({ email: email }, function(err, info) {
+        if (err) return done(err);
+        done();
+      });
+    });
+
+    it('disallows resetPassword by email if email verification is required and not done',
+    function(done) {
+      User.settings.emailVerificationRequired = true;
+      var email = validCredentialsEmail;
+
+      User.resetPassword({ email: email }, function(err) {
+        assert(err);
+        assert.equal(err.code, 'RESET_FAILED_EMAIL_NOT_VERIFIED');
+        assert.equal(err.statusCode, 401);
+        done();
+      });
+    });
+
+    it('allows resetPassword by email if email verification is not required',
+    function(done) {
+      User.settings.emailVerificationRequired = false;
+      var email = validCredentialsEmail;
+
+      User.resetPassword({ email: email }, function(err) {
+        if (err) return done(err);
+        done();
+      });
+    });
+  });
+
   describe('ctor', function() {
     it('exports default Email model', function() {
       expect(User.email, 'User.email').to.be.a('function');


### PR DESCRIPTION

Allow resetPassword by email only if email verification was done
backport of https://github.com/strongloop/loopback/pull/2671