### PR TITLE
Call new disable remote method from model class.

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -429,14 +429,12 @@ module.exports = function(registry) {
   /**
    * Disable remote invocation for the method with the given name.
    *
-   * @param {String} name The name of the method.
-   * @param {Boolean} isStatic Is the method static (eg. `MyModel.myMethod`)? Pass
-   * `false` if the method defined on the prototype (eg.
-   * `MyModel.prototype.myMethod`).
+   * @param {String} name The name of the method (include `prototype.` if the method is defined on the prototype).
+   *
    */
 
   Model.disableRemoteMethod = function(name, isStatic) {
-    this.sharedClass.disableMethod(name, isStatic || false);
+    this.sharedClass.disableMethodByName(name);
     this.emit('remoteMethodDisabled', this.sharedClass, name);
   };
 


### PR DESCRIPTION
There is a new `SharedClass` method available in strong-remoting for disabling a method by name instead of specifying the `isStatic` boolean. 

I have exposed the method on the `Model` Class such that it can be used for a spike related to #651.

@bajtos, please review 