### PR TITLE
Temporarily disable Karma tests on Windows CI

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -224,6 +224,10 @@ module.exports = function(grunt) {
     });
   });
 
+  grunt.registerTask('skip-karma-on-windows', function() {
+    console.log('*** SKIPPING PHANTOM-JS BASED TESTS ON WINDOWS ***');
+  });
+
   grunt.registerTask('e2e', ['e2e-server', 'karma:e2e']);
 
   // Default task.
@@ -232,7 +236,9 @@ module.exports = function(grunt) {
   grunt.registerTask('test', [
     'eslint',
     process.env.JENKINS_HOME ? 'mochaTest:unit-xml' : 'mochaTest:unit',
-    'karma:unit-once']);
+    process.env.JENKINS_HOME && /^win/.test(process.platform) ?
+      'skip-karma-on-windows' : 'karma:unit-once',
+  ]);
 
   // alias for sl-ci-run and `npm test`
   grunt.registerTask('mocha-and-karma', ['test']);


### PR DESCRIPTION
We are observing frequent test failures on Windows CI, where PhantomJS cannot start because there are no free handles available. Finding and fixing the process leaking handles is non-trivial and will take long time.

This commit disables Karma tests on Windows CI machines to prevent build failures that we are ignoring anyways.

See also https://github.com/strongloop-internal/scrum-loopback/issues/1052

@superkhau please review
cc @rmg