### PR TITLE
Update tests to use registry for model creation [2.x]

### DIFF
--- a/example/colors/app.js
+++ b/example/colors/app.js
@@ -14,9 +14,9 @@ var schema = {
   name: String
 };
 
-var Color = app.model('color', schema);
-
-app.dataSource('db', {adapter: 'memory'}).attach(Color);
+app.dataSource('db', { connector: 'memory' });
+var Color = app.registry.createModel('color', schema);
+app.model(Color, { dataSource: 'db' });
 
 Color.create({name: 'red'});
 Color.create({name: 'green'});

--- a/example/replication/app.js
+++ b/example/replication/app.js
@@ -5,9 +5,11 @@
 
 var loopback = require('../../');
 var app = loopback();
-var db = app.dataSource('db', {connector: loopback.Memory});
-var Color = app.model('color', {dataSource: 'db', options: {trackChanges: true}});
-var Color2 = app.model('color2', {dataSource: 'db', options: {trackChanges: true}});
+var db = app.dataSource('db', { connector: 'memory' });
+var Color = app.registry.createModel('color', {}, { trackChanges: true });
+app.model(Color, { dataSource: 'db' });
+var Color2 = app.registry.createModel('color2', {}, { trackChanges: true });
+app.model(Color2, { dataSource: 'db' });
 var target = Color2;
 var source = Color;
 var SPEED = process.env.SPEED || 100;

--- a/test/acl.test.js
+++ b/test/acl.test.js
@@ -363,18 +363,16 @@ describe('security ACLs', function() {
 });
 
 describe('access check', function() {
-  var app;
-  before(function() {
-    app = loopback();
-    app.use(loopback.rest());
-    app.enableAuth();
-    app.dataSource('test', {connector: 'memory'});
-  });
-
   it('should occur before other remote hooks', function(done) {
-    var MyTestModel = app.model('MyTestModel', {base: 'PersistedModel', dataSource: 'test'});
+    var app = loopback();
+    var MyTestModel = app.registry.createModel('MyTestModel');
     var checkAccessCalled = false;
     var beforeHookCalled = false;
+
+    app.use(loopback.rest());
+    app.enableAuth();
+    app.dataSource('test', { connector: 'memory' });
+    app.model(MyTestModel, { dataSource: 'test' });
 
     // fake / spy on the checkAccess method
     MyTestModel.checkAccess = function() {

--- a/test/change-stream.test.js
+++ b/test/change-stream.test.js
@@ -7,9 +7,10 @@ describe('PersistedModel.createChangeStream()', function() {
   describe('configured to source changes locally', function() {
     before(function() {
       var test = this;
-      var app = loopback({localRegistry: true});
-      var ds = app.dataSource('ds', {connector: 'memory'});
-      this.Score = app.model('Score', {
+      var app = loopback({ localRegistry: true });
+      var ds = app.dataSource('ds', { connector: 'memory' });
+      var Score = app.registry.createModel('Score');
+      this.Score = app.model(Score, {
         dataSource: 'ds',
         changeDataSource: false // use only local observers
       });

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -41,7 +41,8 @@ describe('loopback application', function() {
       loopback.ACL.attachTo(db);
       loopback.User.hasMany(loopback.AccessToken, { as: 'accessTokens' });
 
-      var Streamer = app.model('Streamer', { dataSource: 'db' });
+      var Streamer = app.registry.createModel('Streamer');
+      app.model(Streamer, { dataSource: 'db' });
       Streamer.read = function(req, res, cb) {
         var body = new Buffer(0);
         req.on('data', function(chunk) {

--- a/test/registries.test.js
+++ b/test/registries.test.js
@@ -16,15 +16,17 @@ describe('Registry', function() {
       var dsFoo = appFoo.dataSource('dsFoo', {connector: 'memory'});
       var dsBar = appFoo.dataSource('dsBar', {connector: 'memory'});
 
-      var FooModel = appFoo.model(modelName, settings);
-      var FooSubModel = appFoo.model(subModelName, settings);
-      var BarModel = appBar.model(modelName, settings);
-      var BarSubModel = appBar.model(subModelName, settings);
+      var FooModel = appFoo.registry.createModel(modelName, {}, settings);
+      appFoo.model(FooModel, { dataSource: dsFoo });
 
-      FooModel.attachTo(dsFoo);
-      FooSubModel.attachTo(dsFoo);
-      BarModel.attachTo(dsBar);
-      BarSubModel.attachTo(dsBar);
+      var FooSubModel = appFoo.registry.createModel(subModelName, {}, settings);
+      appFoo.model(FooSubModel, { dataSource: dsFoo });
+
+      var BarModel = appBar.registry.createModel(modelName, {}, settings);
+      appBar.model(BarModel, { dataSource: dsBar });
+
+      var BarSubModel = appBar.registry.createModel(subModelName, {}, settings);
+      appBar.model(BarSubModel, { dataSource: dsBar });
 
       FooModel.hasMany(FooSubModel);
       BarModel.hasMany(BarSubModel);

--- a/test/relations.integration.js
+++ b/test/relations.integration.js
@@ -41,24 +41,14 @@ describe('relations - integration', function() {
   describe('polymorphicHasMany', function() {
 
     before(function defineProductAndCategoryModels() {
-      var Team = app.model(
-        'Team',
-        { properties: { name: 'string' },
-          dataSource: 'db'
-        }
-      );
-      var Reader = app.model(
-        'Reader',
-        { properties: { name: 'string' },
-          dataSource: 'db'
-        }
-      );
-      var Picture = app.model(
-        'Picture',
-        { properties: { name: 'string', imageableId: 'number', imageableType: 'string'},
-          dataSource: 'db'
-        }
-      );
+      var Team = app.registry.createModel('Team', { name: 'string' });
+      var Reader = app.registry.createModel('Reader', { name: 'string' });
+      var Picture = app.registry.createModel('Picture',
+        { name: 'string', imageableId: 'number', imageableType: 'string' });
+
+      app.model(Team, { dataSource: 'db' });
+      app.model(Reader, { dataSource: 'db' });
+      app.model(Picture, { dataSource: 'db' });
 
       Reader.hasMany(Picture, { polymorphic: { // alternative syntax
         as: 'imageable', // if not set, default to: reference
@@ -684,15 +674,17 @@ describe('relations - integration', function() {
 
   describe('hasAndBelongsToMany', function() {
     beforeEach(function defineProductAndCategoryModels() {
-      var product = app.model(
-        'product',
-        { properties: { id: 'string', name: 'string' }, dataSource: 'db' }
-
+      var product = app.registry.createModel(
+         'product',
+         { id: 'string', name: 'string' }
       );
-      var category = app.model(
+      var category = app.registry.createModel(
         'category',
-        { properties: { id: 'string', name: 'string' }, dataSource: 'db' }
+        { id: 'string', name: 'string' }
       );
+      app.model(product, { dataSource: 'db' });
+      app.model(category, { dataSource: 'db' });
+
       product.hasAndBelongsToMany(category);
       category.hasAndBelongsToMany(product);
     });
@@ -807,17 +799,18 @@ describe('relations - integration', function() {
   describe('embedsOne', function() {
 
     before(function defineGroupAndPosterModels() {
-      var group = app.model(
-        'group',
-        { properties: { name: 'string' },
-          dataSource: 'db',
-          plural: 'groups'
-        }
+      var group = app.registry.createModel('group',
+        { name: 'string' },
+        { plural: 'groups' }
       );
-      var poster = app.model(
+      app.model(group, { dataSource: 'db' });
+
+      var poster = app.registry.createModel(
         'poster',
-        { properties: { url: 'string' }, dataSource: 'db' }
+        { url: 'string' }
       );
+      app.model(poster, { dataSource: 'db' });
+
       group.embedsOne(poster, { as: 'cover' });
     });
 
@@ -924,17 +917,18 @@ describe('relations - integration', function() {
   describe('embedsMany', function() {
 
     before(function defineProductAndCategoryModels() {
-      var todoList = app.model(
+      var todoList = app.registry.createModel(
         'todoList',
-        { properties: { name: 'string' },
-          dataSource: 'db',
-          plural: 'todo-lists'
-        }
+        { name: 'string' },
+        { plural: 'todo-lists' }
       );
-      var todoItem = app.model(
+      app.model(todoList, { dataSource: 'db' });
+
+      var todoItem = app.registry.createModel(
         'todoItem',
-        { properties: { content: 'string' }, dataSource: 'db' }
+        { content: 'string' }, { forceId: false }
       );
+      app.model(todoItem, { dataSource: 'db' });
       todoList.embedsMany(todoItem, { as: 'items' });
     });
 
@@ -1112,18 +1106,24 @@ describe('relations - integration', function() {
   describe('referencesMany', function() {
 
     before(function defineProductAndCategoryModels() {
-      var recipe = app.model(
+      var recipe = app.registry.createModel(
         'recipe',
-        { properties: { name: 'string' }, dataSource: 'db' }
+        { name: 'string' }
       );
-      var ingredient = app.model(
+      app.model(recipe, { dataSource: 'db' });
+
+      var ingredient = app.registry.createModel(
         'ingredient',
-        { properties: { name: 'string' }, dataSource: 'db' }
+       { name: 'string' }
       );
-      var photo = app.model(
+      app.model(ingredient, { dataSource: 'db' });
+
+      var photo = app.registry.createModel(
         'photo',
-        { properties: { name: 'string' }, dataSource: 'db' }
+        { name: 'string' }
       );
+      app.model(photo, { dataSource: 'db' });
+
       recipe.referencesMany(ingredient);
       // contrived example for test:
       recipe.hasOne(photo, { as: 'picture', options: {
@@ -1460,31 +1460,41 @@ describe('relations - integration', function() {
   describe('nested relations', function() {
 
     before(function defineModels() {
-      var Book = app.model(
+      var Book = app.registry.createModel(
         'Book',
-        { properties: { name: 'string' }, dataSource: 'db',
-        plural: 'books' }
+        { name: 'string' },
+        { plural: 'books' }
       );
-      var Page = app.model(
+      app.model(Book, { dataSource: 'db' });
+
+      var Page = app.registry.createModel(
         'Page',
-        { properties: { name: 'string' }, dataSource: 'db',
-        plural: 'pages' }
+        { name: 'string' },
+        { plural: 'pages' }
       );
-      var Image = app.model(
+      app.model(Page, { dataSource: 'db' });
+
+      var Image = app.registry.createModel(
         'Image',
-        { properties: { name: 'string' }, dataSource: 'db',
-        plural: 'images' }
+        { name: 'string' },
+        { plural: 'images' }
       );
-      var Note = app.model(
+      app.model(Image, { dataSource: 'db' });
+
+      var Note = app.registry.createModel(
         'Note',
-        { properties: { text: 'string' }, dataSource: 'db',
-        plural: 'notes' }
+        { text: 'string' },
+        { plural: 'notes' }
       );
-      var Chapter = app.model(
+      app.model(Note, { dataSource: 'db' });
+
+      var Chapter = app.registry.createModel(
         'Chapter',
-        { properties: { name: 'string' }, dataSource: 'db',
-          plural: 'chapters' }
+        { name: 'string' },
+        { plural: 'chapters' }
       );
+      app.model(Chapter, { dataSource: 'db' });
+
       Book.hasMany(Page);
       Book.hasMany(Chapter);
       Page.hasMany(Note);

--- a/test/remoting-coercion.test.js
+++ b/test/remoting-coercion.test.js
@@ -12,7 +12,12 @@ describe('remoting coercion', function() {
     var app = loopback();
     app.use(loopback.rest());
 
-    var TestModel = app.model('TestModel', {base: 'Model', dataSource: null, public: true});
+    var TestModel = app.registry.createModel('TestModel',
+      {},
+      { base: 'Model' }
+    );
+    app.model(TestModel, { public: true });
+
     TestModel.test = function(inst, cb) {
       called = true;
       assert(inst instanceof TestModel);


### PR DESCRIPTION
Current implementation of `app.model(modelName, settings)`
works as a sugar for model creation. From LB 3.0 onwards, this is
not supported. 
This backporting:
- keeps the sugar method for model creation for backward
compatibility
- updates test cases to use `app.registry.createModel()`
for model creation

Backport of #2401 

Connect to strongloop-internal/scrum-loopback#772