### PR TITLE
Fix expire in API explorer for KV connectors

### DIFF
--- a/common/models/key-value-model.js
+++ b/common/models/key-value-model.js
@@ -188,8 +188,8 @@ module.exports = function(KeyValueModel) {
       accepts: [
         { arg: 'key', type: 'string', required: true,
           http: { source: 'path' }},
-        { arg: 'ttl', type: 'number', required: true,
-          http: { source: 'form' }},
+        { arg: 'ttl', type: 'object', required: true,
+          http: { source: 'body' }},
       ],
       http: { path: '/:key/expire', verb: 'put' },
     });


### PR DESCRIPTION
**Depends on https://github.com/strongloop/loopback-datasource-juggler/pull/1122 to pass tests**

Expire feature wasn't sending data as part of it's request in API
explorer. Tested manually through clicking API explorer.

More info for why at https://github.com/strongloop/loopback/issues/2770#issuecomment-250597461

Connect to #2770 

@bajtos PTAL