### PR TITLE
Fix support for remote hooks returning a Promise

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -197,7 +197,7 @@ module.exports = function(registry) {
       this._runWhenAttachedToApp(function(app) {
         var remotes = app.remotes();
         remotes.before(className + '.' + name, function(ctx, next) {
-          fn(ctx, ctx.result, next);
+          return fn(ctx, ctx.result, next);
         });
       });
     };
@@ -208,7 +208,7 @@ module.exports = function(registry) {
       this._runWhenAttachedToApp(function(app) {
         var remotes = app.remotes();
         remotes.after(className + '.' + name, function(ctx, next) {
-          fn(ctx, ctx.result, next);
+          return fn(ctx, ctx.result, next);
         });
       });
     };


### PR DESCRIPTION
Fix beforeRemote/afterRemote to correctly return promises returned by the user-provided hook callback.

Connect to #2747
Supersede #2751

cc @tvdstaaij