### PR TITLE
Fix description of updateAll response

### DIFF
--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -808,9 +808,14 @@ module.exports = function(registry) {
           description: 'An object of model property name/value pairs' },
       ],
       returns: {
-        arg: 'count',
-        description: 'The number of instances updated',
-        type: 'object',
+        arg: 'info',
+        description: 'Information related to the outcome of the operation',
+        type: {
+          count: {
+            type: 'number',
+            description: 'The number of instances updated',
+          },
+        },
         root: true,
       },
       http: { verb: 'post', path: '/update' },

--- a/test/remoting.integration.js
+++ b/test/remoting.integration.js
@@ -262,6 +262,12 @@ function formatReturns(m) {
     return '';
   }
   var type = returns[0].type;
+
+  // handle anonymous type definitions, e.g
+  // { arg: 'info', type: { count: 'number' } }
+  if (typeof type === 'object' && !Array.isArray(type))
+    type = 'object';
+
   return type ? ':' + type : '';
 }
 


### PR DESCRIPTION
Correctly describe the first non-error callback arg as an `info` object containing a `count` property.

Supersedes #2535
Connect to #2104

@superkhau please review