### PR TITLE
Remove redundant items in PR template (#2877)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,12 @@
 ### Description
 
 
-#### Related issues (eg. strongloop/loopback#49)
+#### Related issues (eg. #49 or strongloop/loopback#49)
 
 - None
 
 ### Checklist
 
-- [ ] CLA signed
 - [ ] New tests are added to cover all changes
 - [ ] Code conforms with the [style
   guide](http://loopback.io/doc/en/contrib/style-guide.html)
-- [ ] All CI builds are passing


### PR DESCRIPTION
- Remove sign CLA since CI already shows unsigned CLAs
- Remove all tests must pass CI since we have to check each on a case by
  case basis anyways
- Update example to include linking to the current repo using number
  sign (ie. #49 in addition to org/repo#49)

Backport of #2877