### PR TITLE
allow batch create for persisted models

### DIFF
--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -640,7 +640,7 @@ module.exports = function(registry) {
       description: 'Create a new instance of the model and persist it into the data source.',
       accessType: 'WRITE',
       accepts: {
-        arg: 'data', type: 'object', model: typeName,
+        arg: 'data', type: 'object', model: typeName, allowArray: true,
         description: 'Model instance data',
         http: { source: 'body' },
       },

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -124,6 +124,44 @@ describe.onServer('Remote Methods', function() {
     app.use(loopback.rest());
   });
 
+  describe('Model.create(data, callback)', function() {
+    it('creates model', function(done) {
+      var anObject = { first: 'June' };
+      request(app)
+        .post('/users')
+        // sends an object
+        .send(anObject)
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .end(function(err, res) {
+          if (err) return done(err);
+          expect(res.body).to.have.property('id');
+          expect(res.body).to.have.property('first', 'June');
+          done();
+        });
+    });
+    // batch create must be tested with a remote request because there are
+    // coercion being done on strong-remoting side
+    it('creates array of models', function(done) {
+      var arrayOfObjects = [
+        { first: 'John' }, { first: 'Jane' },
+      ];
+      request(app)
+        .post('/users')
+        // sends an array of objects
+        .send(arrayOfObjects)
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .end(function(err, res) {
+          if (err) return done(err);
+          expect(res.body.length).to.eql(2);
+          expect(res.body).to.have.deep.property('[0].first', 'John');
+          expect(res.body).to.have.deep.property('[1].first', 'Jane');
+          done();
+        });
+    });
+  });
+  // destoryAll is not exposed as a remoteMethod by default
   describe('Model.destroyAll(callback)', function() {
     it('Delete all Model instances from data source', function(done) {
       (new TaskEmitter())


### PR DESCRIPTION
connect to strongloop-internal/scrum-loopback#1138

### Description
In strong-remoting 3.x, we have stricken the coercion of inputs
methods that are expecting an Object will nolonger accept an array
as input, to preserve backwards compatibility we have added flag
allowArray in remote arguments, which would accept an array of objects

#### Related issues

- None

### Checklist

- [x] New tests are added to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)

List of other remoteMethods in persistedModel that receives a `data` with `type:object`
i looked at them and dont think they should support batch
- patchOrCreate (data) 
- replaceOrCreate (data)
- upsertWithWhere (where, data)
- replaceById (id, data)
- updateAll (where, data) 
- patchAttributes (data)
- updateLastChange (id, data)

