### PR TITLE
Fix PR template to not link all PRs to #49

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,10 +4,10 @@
 #### Related issues
 
 <!--
-Use on of the following link syntax:
+Please use the following link syntaxes:
 
- - #49
- - strongloop/loopback#49
+- #49 (to reference issues in the current repository)
+- strongloop/loopback#49 (to reference issues in another repository)
 -->
 
 - None

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,14 @@
 ### Description
 
 
-#### Related issues (eg. #49 or strongloop/loopback#49)
+#### Related issues
+
+<!--
+Use on of the following link syntax:
+
+ - #49
+ - strongloop/loopback#49
+-->
 
 - None
 


### PR DESCRIPTION
<!--
Use on of the following link syntax:

 - #49
 - strongloop/loopback#49
-->

The current template links all new pull requests to #49:

<img width="752" alt="screen shot 2016-10-24 at 10 26 34" src="https://cloud.githubusercontent.com/assets/1140553/19638556/d251bb9c-99d4-11e6-88ab-0003226ea5ef.png">

In this patch, I am moving the example links to an HTML comment to prevent auto-linking.

@superkhau PTAL
cc @strongloop/loopback-dev 