### PR TITLE
make test individually runable

### DIFF
--- a/test/access-token.test.js
+++ b/test/access-token.test.js
@@ -16,7 +16,11 @@ Token.attachTo(ds);
 var ACL = loopback.ACL;
 
 describe('loopback.token(options)', function() {
-  beforeEach(createTestingToken);
+  var app;
+  beforeEach(function(done) {
+    app = loopback();
+    createTestingToken.call(this, done);
+  });
 
   it('should populate req.token from the query string', function(done) {
     createTestAppAndRequest(this.token, done)
@@ -428,7 +432,9 @@ describe('AccessToken', function() {
 });
 
 describe('app.enableAuth()', function() {
+  var app;
   beforeEach(function setupAuthWithModels() {
+    app = loopback();
     app.enableAuth({ dataSource: ds });
   });
   beforeEach(createTestingToken);

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -16,11 +16,15 @@ var expect = require('chai').expect;
 var it = require('./util/it');
 
 describe('app', function() {
+  var app;
+  beforeEach(function() {
+    app = loopback();
+  });
+
   describe.onServer('.middleware(phase, handler)', function() {
-    var app, steps;
+    var steps;
 
     beforeEach(function setup() {
-      app = loopback();
       steps = [];
     });
 

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,1 @@
+--require ./test/support.js

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -4,12 +4,16 @@
 // License text available at https://opensource.org/licenses/MIT
 
 var async = require('async');
+var chai = require('chai');
+var describe = require('./util/describe');
 var loopback = require('../');
 var ACL = loopback.ACL;
 var defineModelTestsWithDataSource = require('./util/model-tests');
 var PersistedModel = loopback.PersistedModel;
+var sinonChai = require('sinon-chai');
 
-var describe = require('./util/describe');
+var expect = chai.expect;
+chai.use(sinonChai);
 
 describe('Model / PersistedModel', function() {
   defineModelTestsWithDataSource({

--- a/test/support.js
+++ b/test/support.js
@@ -12,7 +12,6 @@ expect = require('chai').expect;
 loopback = require('../');
 memoryConnector = loopback.Memory;
 GeoPoint = loopback.GeoPoint;
-app = null;
 TaskEmitter = require('strong-task-emitter');
 request = require('supertest');
 var RemoteObjects = require('strong-remoting');
@@ -20,10 +19,6 @@ var RemoteObjects = require('strong-remoting');
 // Speed up the password hashing algorithm
 // for tests using the built-in User model
 loopback.User.settings.saltWorkFactor = 4;
-
-beforeEach(function() {
-  this.app = app = loopback();
-});
 
 assertValidDataSource = function(dataSource) {
   // has methods


### PR DESCRIPTION
### Description

previous when you do command such as `mocha test/model.test.js`
we get errors such as "expect is not a function", "assert is not a function"
this is to organize the test file in a slightly different way, so we can do `mocha test/model.test.js`

not sure if we need to modify [`karma.conf`](https://github.com/strongloop/loopback/blob/c28a1568b31b8fb8d75273b4940b1aa8cabc2828/test/karma.conf.js#L23) too, npm test is locally passing for me
#### Related issues
- None
### Checklist
- [ ] New tests are added to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)


**Update 14/11/16**:
  - Needs re-review from @bajtos or @strongloop/squad-epitome 

**Update 14/11/16**:
  - @pthieu will finish review.