### PR TITLE
Fix PR template to not link all PRs to #49 (#2887)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,14 @@
 ### Description
 
 
-#### Related issues (eg. #49 or strongloop/loopback#49)
+#### Related issues
+
+<!--
+Please use the following link syntaxes:
+
+- #49 (to reference issues in the current repository)
+- strongloop/loopback#49 (to reference issues in another repository)
+-->
 
 - None
 


### PR DESCRIPTION
- Add comment with syntax examples
- Remove direct links to #49 in section header

Backport of #2887 

cc @bajtos 