### PR TITLE
Add sync option to context

### DIFF
--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -1440,7 +1440,11 @@ module.exports = function(registry) {
   }
 
   function applyCreate(Model, id, current, data, change, conflicts, cb) {
-    Model.create(data, function(createErr) {
+    var options = {
+      sync: true
+    };
+
+    Model.create(data, options, function(createErr) {
       if (!createErr) return cb();
 
       // We don't have a reliable way how to detect the situation

--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -1095,6 +1095,10 @@ module.exports = function(registry) {
       since = { source: since, target: since };
     }
 
+    if (options && typeof options === 'function') {
+      options = {};
+    }
+
     options = options || {};
 
     var sourceModel = this;
@@ -1345,9 +1349,6 @@ module.exports = function(registry) {
 
     options = options || {};
 
-    var sourceModel = this;
-    callback = callback || utils.createPromiseCallback();
-
     buildLookupOfAffectedModelData(Model, updates, function(err, currentMap) {
       if (err) return callback(err);
 
@@ -1369,7 +1370,7 @@ module.exports = function(registry) {
             break;
           case Change.DELETE:
             tasks.push(function(cb) {
-              applyDelete(Model, id, current, update.change, options, conflicts, cb);
+              applyDelete(Model, id, current, update.change, conflicts, options, cb);
             });
             break;
         }

--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -1209,7 +1209,7 @@ module.exports = function(registry) {
     function bulkUpdate(_updates, cb) {
       debug('\tstarting bulk update');
       updates = _updates;
-      targetModel.bulkUpdate(updates, function(err) {
+      targetModel.bulkUpdate(updates, options, function(err) {
         var conflicts = err && err.details && err.details.conflicts;
         if (conflicts && err.statusCode == 409) {
           diff.conflicts = conflicts;
@@ -1323,14 +1323,30 @@ module.exports = function(registry) {
    * **Note: this is not atomic**
    *
    * @param  {Array} updates An updates list, usually from [createUpdates()](#persistedmodel-createupdates).
+   * @param  {Object} [options] options get added on the context
    * @param  {Function} callback Callback function.
    */
 
-  PersistedModel.bulkUpdate = function(updates, callback) {
+  PersistedModel.bulkUpdate = function(updates, options, callback) {
     var tasks = [];
     var Model = this;
     var Change = this.getChangeModel();
     var conflicts = [];
+
+    var lastArg = arguments[arguments.length - 1];
+
+    if (typeof lastArg === 'function' && arguments.length > 1) {
+      callback = lastArg;
+    }
+
+    if (options && typeof options === 'function') {
+      options = {};
+    }
+
+    options = options || {};
+
+    var sourceModel = this;
+    callback = callback || utils.createPromiseCallback();
 
     buildLookupOfAffectedModelData(Model, updates, function(err, currentMap) {
       if (err) return callback(err);
@@ -1338,21 +1354,22 @@ module.exports = function(registry) {
       updates.forEach(function(update) {
         var id = update.change.modelId;
         var current = currentMap[id];
+
         switch (update.type) {
           case Change.UPDATE:
             tasks.push(function(cb) {
-              applyUpdate(Model, id, current, update.data, update.change, conflicts, cb);
+              applyUpdate(Model, id, current, update.data, update.change, conflicts, options, cb);
             });
             break;
 
           case Change.CREATE:
             tasks.push(function(cb) {
-              applyCreate(Model, id, current, update.data, update.change, conflicts, cb);
+              applyCreate(Model, id, current, update.data, update.change, conflicts, options, cb);
             });
             break;
           case Change.DELETE:
             tasks.push(function(cb) {
-              applyDelete(Model, id, current, update.change, conflicts, cb);
+              applyDelete(Model, id, current, update.change, options, conflicts, cb);
             });
             break;
         }
@@ -1386,7 +1403,7 @@ module.exports = function(registry) {
     });
   }
 
-  function applyUpdate(Model, id, current, data, change, conflicts, cb) {
+  function applyUpdate(Model, id, current, data, change, conflicts, options, cb) {
     var Change = Model.getChangeModel();
     var rev = current ?  Change.revisionForInst(current) : null;
 
@@ -1404,7 +1421,7 @@ module.exports = function(registry) {
     // but not included in `data`
     // See https://github.com/strongloop/loopback/issues/1215
 
-    Model.updateAll(current.toObject(), data, function(err, result) {
+    Model.updateAll(current.toObject(), data, options, function(err, result) {
       if (err) return cb(err);
 
       var count = result && result.count;
@@ -1439,11 +1456,7 @@ module.exports = function(registry) {
     });
   }
 
-  function applyCreate(Model, id, current, data, change, conflicts, cb) {
-    var options = {
-      sync: true
-    };
-
+  function applyCreate(Model, id, current, data, change, conflicts, options, cb) {
     Model.create(data, options, function(createErr) {
       if (!createErr) return cb();
 
@@ -1472,7 +1485,7 @@ module.exports = function(registry) {
     }
   }
 
-  function applyDelete(Model, id, current, change, conflicts, cb) {
+  function applyDelete(Model, id, current, change, conflicts, options, cb) {
     if (!current) {
       // The instance was either already deleted or not created at all,
       // we are done.
@@ -1490,7 +1503,7 @@ module.exports = function(registry) {
       return Change.rectifyModelChanges(Model.modelName, [id], cb);
     }
 
-    Model.deleteAll(current.toObject(), function(err, result) {
+    Model.deleteAll(current.toObject(), options, function(err, result) {
       if (err) return cb(err);
 
       var count = result && result.count;

--- a/test/replication.test.js
+++ b/test/replication.test.js
@@ -60,65 +60,6 @@ describe('Replication / Change APIs', function() {
     };
   });
 
-  describe('ensure options object is set on context during bulkUpdate', function() {
-    var syncPropertyExists = false;
-    var OptionsSourceModel;
-
-    beforeEach(function() {
-      OptionsSourceModel = PersistedModel.extend(
-        'OptionsSourceModel-' + tid,
-        { id: { id: true, type: String, defaultFn: 'guid' } },
-        { trackChanges: true });
-
-      OptionsSourceModel.attachTo(dataSource);
-
-      OptionsSourceModel.observe('before save', function updateTimestamp(ctx, next) {
-        if (ctx.options.sync) {
-          syncPropertyExists = true;
-        } else {
-          syncPropertyExists = false;
-        }
-
-        next();
-      });
-    });
-
-    it('bulkUpdate should call Model updates with the provided options object', function(done) {
-      var testData = {name: 'Janie', surname: 'Doe'};
-      var updates = [
-        {
-          data: null,
-          change: null,
-          type: 'create'
-        }
-      ];
-
-      var options = {
-        sync: true
-      };
-
-      async.waterfall([
-        function(callback) {
-          TargetModel.create(testData, callback);
-        },
-        function(data, callback) {
-          updates[0].data = data;
-          TargetModel.getChangeModel().find({where: {modelId: data.id}}, callback);
-        },
-        function(data, callback) {
-          updates[0].change = data;
-          OptionsSourceModel.bulkUpdate(updates, options, callback);
-        }
-      ], function(err, result) {
-        if (err) return done(err);
-
-        expect(syncPropertyExists).to.eql(true);
-
-        done();
-      });
-    });
-  });
-
   describe('optimization check rectifyChange Vs rectifyAllChanges', function() {
     beforeEach(function initialData(done) {
       var data = [{name: 'John', surname: 'Doe'}, {name: 'Jane', surname: 'Roe'}];
@@ -1596,6 +1537,95 @@ describe('Replication / Change APIs', function() {
     }
   });
 
+  describe('ensure options object is set on context during bulkUpdate', function() {
+    var syncPropertyExists = false;
+    var OptionsSourceModel;
+
+    beforeEach(function() {
+      OptionsSourceModel = PersistedModel.extend(
+        'OptionsSourceModel-' + tid,
+        { id: { id: true, type: String, defaultFn: 'guid' } },
+        { trackChanges: true });
+
+      OptionsSourceModel.attachTo(dataSource);
+
+      OptionsSourceModel.observe('before save', function updateTimestamp(ctx, next) {
+        if (ctx.options.sync) {
+          syncPropertyExists = true;
+        } else {
+          syncPropertyExists = false;
+        }
+
+        next();
+      });
+    });
+
+    it('bulkUpdate should call Model updates with the provided options object', function(done) {
+      var testData = {name: 'Janie', surname: 'Doe'};
+      var updates = [
+        {
+          data: null,
+          change: null,
+          type: 'create'
+        }
+      ];
+
+      var options = {
+        sync: true
+      };
+
+      async.waterfall([
+        function(callback) {
+          TargetModel.create(testData, callback);
+        },
+        function(data, callback) {
+          updates[0].data = data;
+          TargetModel.getChangeModel().find({where: {modelId: data.id}}, callback);
+        },
+        function(data, callback) {
+          updates[0].change = data;
+          OptionsSourceModel.bulkUpdate(updates, options, callback);
+        }
+      ], function(err, result) {
+        if (err) return done(err);
+
+        expect(syncPropertyExists).to.eql(true);
+
+        done();
+      });
+    });
+  });
+
+  describe('ensure bulkUpdate works with just 2 args', function() {
+    it('bulkUpdate should successfully finish without options', function(done) {
+      var testData = {name: 'Janie', surname: 'Doe'};
+      var updates = [
+        {
+          data: null,
+          change: null,
+          type: 'create'
+        }
+      ];
+
+      async.waterfall([
+        function(callback) {
+          TargetModel.create(testData, callback);
+        },
+        function(data, callback) {
+          updates[0].data = data;
+          TargetModel.getChangeModel().find({where: {modelId: data.id}}, callback);
+        },
+        function(data, callback) {
+          updates[0].change = data;
+          SourceModel.bulkUpdate(updates, callback);
+        }
+      ], function(err, result) {
+        if (err) return done(err);
+        done();
+      });
+    });
+  });
+
   var _since = {};
   function replicate(source, target, since, next) {
     if (typeof since === 'function') {
@@ -1650,14 +1680,14 @@ describe('Replication / Change APIs', function() {
 
   function setupRaceConditionInReplication(fn) {
     var bulkUpdate = TargetModel.bulkUpdate;
-    TargetModel.bulkUpdate = function(data, cb) {
+    TargetModel.bulkUpdate = function(data, options, cb) {
       // simulate the situation when a 3rd party modifies the database
       // while a replication run is in progress
       var self = this;
       fn(function(err) {
         if (err) return cb(err);
 
-        bulkUpdate.call(self, data, cb);
+        bulkUpdate.call(self, data, options, cb);
       });
 
       // apply the 3rd party modification only once


### PR DESCRIPTION
### Description
We are passing options to bulkUpdate, so we can detect saves and updates during sync. Saves during sync can be identified by adding a property on options which gets passed into to replicate. 

e.g.:
When you want to update last modified date column on each save through operation hooks, but not during sync:

```
var options = {
  sync: true,
  ... other options
}

SomeModel.replicate(since, targetModel, options, callback);

SomeModel.observe('before save', function updateLastModDate(ctx, next) {
if (ctx.options.sync) {
  // do not update
} else {
  // update
}

next();
});

```
#### Related issues

- None

### Checklist

- [ ] New tests are added to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
