### PR TITLE
Add options to bulk update

### DIFF
--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -67,9 +67,9 @@ module.exports = function(registry) {
   function throwNotAttached(modelName, methodName) {
     throw new Error(
       g.f('Cannot call %s.%s().' +
-      ' The %s method has not been setup.' +
-      ' The {{PersistedModel}} has not been correctly attached to a {{DataSource}}!',
-      modelName, methodName, methodName)
+        ' The %s method has not been setup.' +
+        ' The {{PersistedModel}} has not been correctly attached to a {{DataSource}}!',
+        modelName, methodName, methodName)
     );
   }
 
@@ -114,9 +114,9 @@ module.exports = function(registry) {
    */
 
   PersistedModel.upsert = PersistedModel.updateOrCreate = PersistedModel.patchOrCreate =
-  function upsert(data, callback) {
-    throwNotAttached(this.modelName, 'upsert');
-  };
+    function upsert(data, callback) {
+      throwNotAttached(this.modelName, 'upsert');
+    };
 
   /**
    * Update or insert a model instance based on the search criteria.
@@ -136,9 +136,9 @@ module.exports = function(registry) {
    */
 
   PersistedModel.upsertWithWhere =
-  PersistedModel.patchOrCreateWithWhere = function upsertWithWhere(where, data, callback) {
-    throwNotAttached(this.modelName, 'upsertWithWhere');
-  };
+    PersistedModel.patchOrCreateWithWhere = function upsertWithWhere(where, data, callback) {
+      throwNotAttached(this.modelName, 'upsertWithWhere');
+    };
 
   /**
    * Replace or insert a model instance; replace existing record if one is found,
@@ -408,7 +408,7 @@ module.exports = function(registry) {
     }
 
     callback = callback || function() {
-    };
+      };
     options = options || {};
 
     if (!('validate' in options)) {
@@ -520,9 +520,9 @@ module.exports = function(registry) {
    */
 
   PersistedModel.prototype.updateAttributes = PersistedModel.prototype.patchAttributes =
-  function updateAttributes(data, cb) {
-    throwNotAttached(this.modelName, 'updateAttributes');
-  };
+    function updateAttributes(data, cb) {
+      throwNotAttached(this.modelName, 'updateAttributes');
+    };
 
   /**
    * Replace attributes for a model instance and persist it into the datasource.
@@ -677,7 +677,7 @@ module.exports = function(registry) {
     setRemoting(PersistedModel, 'upsertWithWhere', {
       aliases: ['patchOrCreateWithWhere'],
       description: 'Update an existing model instance or insert a new one into ' +
-        'the data source based on the where criteria.',
+      'the data source based on the where criteria.',
       accessType: 'WRITE',
       accepts: [
         { arg: 'where', type: 'object', http: { source: 'query' },
@@ -740,8 +740,8 @@ module.exports = function(registry) {
       accepts: [
         { arg: 'id', type: 'any', description: 'Model id', required: true,
           http: { source: 'path' }},
-          { arg: 'data', type: 'object', model: typeName, http: { source: 'body' }, description:
-        'Model instance data' },
+        { arg: 'data', type: 'object', model: typeName, http: { source: 'body' }, description:
+          'Model instance data' },
       ],
       returns: { arg: 'data', type: typeName, root: true },
       http: [{ verb: 'post', path: '/:id/replace' }],
@@ -808,7 +808,7 @@ module.exports = function(registry) {
       description: 'Delete a model instance by {{id}} from the data source.',
       accessType: 'WRITE',
       accepts: {arg: 'id', type: 'any', description: 'Model id', required: true,
-                http: {source: 'path'}},
+        http: {source: 'path'}},
       http: {verb: 'del', path: '/:id'},
       returns: {arg: 'count', type: 'object', root: true}
     });
@@ -856,7 +856,7 @@ module.exports = function(registry) {
 
       setRemoting(PersistedModel, 'changes', {
         description: 'Get the changes to a model since a given checkpoint.' +
-          'Provide a filter object to reduce the number of results returned.',
+        'Provide a filter object to reduce the number of results returned.',
         accessType: 'READ',
         accepts: [
           {arg: 'since', type: 'number', description: 'Only return changes since this checkpoint'},
@@ -915,8 +915,8 @@ module.exports = function(registry) {
 
       setRemoting(PersistedModel, 'updateLastChange', {
         description:
-          'Update the properties of the most recent change record ' +
-          'kept for this instance.',
+        'Update the properties of the most recent change record ' +
+        'kept for this instance.',
         accessType: 'WRITE',
         accepts: [
           {
@@ -1095,6 +1095,10 @@ module.exports = function(registry) {
       since = { source: since, target: since };
     }
 
+    if (options && typeof options === 'function') {
+      options = {};
+    }
+
     options = options || {};
 
     var sourceModel = this;
@@ -1209,15 +1213,15 @@ module.exports = function(registry) {
     function bulkUpdate(_updates, cb) {
       debug('\tstarting bulk update');
       updates = _updates;
-      targetModel.bulkUpdate(updates, function(err) {
+      targetModel.bulkUpdate(updates, options, function(err) {
         var conflicts = err && err.details && err.details.conflicts;
         if (conflicts && err.statusCode == 409) {
           diff.conflicts = conflicts;
           // filter out updates that were not applied
           updates = updates.filter(function(u) {
             return conflicts
-              .filter(function(d) { return d.modelId === u.change.modelId; })
-              .length === 0;
+                .filter(function(d) { return d.modelId === u.change.modelId; })
+                .length === 0;
           });
           return cb();
         }
@@ -1323,14 +1327,27 @@ module.exports = function(registry) {
    * **Note: this is not atomic**
    *
    * @param  {Array} updates An updates list, usually from [createUpdates()](#persistedmodel-createupdates).
+   * @param  {Object} [options] options get added on the context
    * @param  {Function} callback Callback function.
    */
 
-  PersistedModel.bulkUpdate = function(updates, callback) {
+  PersistedModel.bulkUpdate = function(updates, options, callback) {
     var tasks = [];
     var Model = this;
     var Change = this.getChangeModel();
     var conflicts = [];
+
+    var lastArg = arguments[arguments.length - 1];
+
+    if (typeof lastArg === 'function' && arguments.length > 1) {
+      callback = lastArg;
+    }
+
+    if (options && typeof options === 'function') {
+      options = {};
+    }
+
+    options = options || {};
 
     buildLookupOfAffectedModelData(Model, updates, function(err, currentMap) {
       if (err) return callback(err);
@@ -1338,21 +1355,22 @@ module.exports = function(registry) {
       updates.forEach(function(update) {
         var id = update.change.modelId;
         var current = currentMap[id];
+
         switch (update.type) {
           case Change.UPDATE:
             tasks.push(function(cb) {
-              applyUpdate(Model, id, current, update.data, update.change, conflicts, cb);
+              applyUpdate(Model, id, current, update.data, update.change, conflicts, options, cb);
             });
             break;
 
           case Change.CREATE:
             tasks.push(function(cb) {
-              applyCreate(Model, id, current, update.data, update.change, conflicts, cb);
+              applyCreate(Model, id, current, update.data, update.change, conflicts, options, cb);
             });
             break;
           case Change.DELETE:
             tasks.push(function(cb) {
-              applyDelete(Model, id, current, update.change, conflicts, cb);
+              applyDelete(Model, id, current, update.change, conflicts, options, cb);
             });
             break;
         }
@@ -1386,7 +1404,7 @@ module.exports = function(registry) {
     });
   }
 
-  function applyUpdate(Model, id, current, data, change, conflicts, cb) {
+  function applyUpdate(Model, id, current, data, change, conflicts, options, cb) {
     var Change = Model.getChangeModel();
     var rev = current ?  Change.revisionForInst(current) : null;
 
@@ -1404,7 +1422,7 @@ module.exports = function(registry) {
     // but not included in `data`
     // See https://github.com/strongloop/loopback/issues/1215
 
-    Model.updateAll(current.toObject(), data, function(err, result) {
+    Model.updateAll(current.toObject(), data, options, function(err, result) {
       if (err) return cb(err);
 
       var count = result && result.count;
@@ -1426,21 +1444,21 @@ module.exports = function(registry) {
         case null:
           return cb(new Error(
             g.f('Cannot apply bulk updates, ' +
-            'the connector does not correctly report ' +
-            'the number of updated records.')));
+              'the connector does not correctly report ' +
+              'the number of updated records.')));
 
         default:
           debug('%s.updateAll modified unexpected number of instances: %j',
             Model.modelName, count);
           return cb(new Error(
             g.f('Bulk update failed, the connector has modified unexpected ' +
-            'number of records: %s', JSON.stringify(count))));
+              'number of records: %s', JSON.stringify(count))));
       }
     });
   }
 
-  function applyCreate(Model, id, current, data, change, conflicts, cb) {
-    Model.create(data, function(createErr) {
+  function applyCreate(Model, id, current, data, change, conflicts, options, cb) {
+    Model.create(data, options, function(createErr) {
       if (!createErr) return cb();
 
       // We don't have a reliable way how to detect the situation
@@ -1468,7 +1486,7 @@ module.exports = function(registry) {
     }
   }
 
-  function applyDelete(Model, id, current, change, conflicts, cb) {
+  function applyDelete(Model, id, current, change, conflicts, options, cb) {
     if (!current) {
       // The instance was either already deleted or not created at all,
       // we are done.
@@ -1486,7 +1504,7 @@ module.exports = function(registry) {
       return Change.rectifyModelChanges(Model.modelName, [id], cb);
     }
 
-    Model.deleteAll(current.toObject(), function(err, result) {
+    Model.deleteAll(current.toObject(), options, function(err, result) {
       if (err) return cb(err);
 
       var count = result && result.count;
@@ -1508,15 +1526,15 @@ module.exports = function(registry) {
         case null:
           return cb(new Error(
             g.f('Cannot apply bulk updates, ' +
-            'the connector does not correctly report ' +
-            'the number of deleted records.')));
+              'the connector does not correctly report ' +
+              'the number of deleted records.')));
 
         default:
           debug('%s.deleteAll modified unexpected number of instances: %j',
             Model.modelName, count);
           return cb(new Error(
             g.f('Bulk update failed, the connector has deleted unexpected ' +
-            'number of records: %s', JSON.stringify(count))));
+              'number of records: %s', JSON.stringify(count))));
       }
     });
   }

--- a/test/replication.test.js
+++ b/test/replication.test.js
@@ -224,7 +224,7 @@ describe('Replication / Change APIs', function() {
   describe('Model.replicate(since, targetModel, options, callback)', function() {
 
     function assertTargetModelEqualsSourceModel(conflicts, sourceModel,
-      targetModel, done) {
+                                                targetModel, done) {
       var sourceData;
       var targetData;
 
@@ -263,12 +263,12 @@ describe('Replication / Change APIs', function() {
         if (err) return done(err);
 
         test.SourceModel.replicate(test.startingCheckpoint, test.TargetModel,
-        options, function(err, conflicts) {
-          if (err) return done(err);
+          options, function(err, conflicts) {
+            if (err) return done(err);
 
-          assertTargetModelEqualsSourceModel(conflicts, test.SourceModel,
-            test.TargetModel, done);
-        });
+            assertTargetModelEqualsSourceModel(conflicts, test.SourceModel,
+              test.TargetModel, done);
+          });
       });
     });
 
@@ -280,7 +280,7 @@ describe('Replication / Change APIs', function() {
         if (err) return done(err);
 
         test.SourceModel.replicate(test.startingCheckpoint, test.TargetModel,
-        options)
+          options)
           .then(function(conflicts) {
             assertTargetModelEqualsSourceModel(conflicts, test.SourceModel,
               test.TargetModel, done);
@@ -1537,6 +1537,95 @@ describe('Replication / Change APIs', function() {
     }
   });
 
+  describe('ensure options object is set on context during bulkUpdate', function() {
+    var syncPropertyExists = false;
+    var OptionsSourceModel;
+
+    beforeEach(function() {
+      OptionsSourceModel = PersistedModel.extend(
+        'OptionsSourceModel-' + tid,
+        { id: { id: true, type: String, defaultFn: 'guid' } },
+        { trackChanges: true });
+
+      OptionsSourceModel.attachTo(dataSource);
+
+      OptionsSourceModel.observe('before save', function updateTimestamp(ctx, next) {
+        if (ctx.options.sync) {
+          syncPropertyExists = true;
+        } else {
+          syncPropertyExists = false;
+        }
+
+        next();
+      });
+    });
+
+    it('bulkUpdate should call Model updates with the provided options object', function(done) {
+      var testData = {name: 'Janie', surname: 'Doe'};
+      var updates = [
+        {
+          data: null,
+          change: null,
+          type: 'create'
+        }
+      ];
+
+      var options = {
+        sync: true
+      };
+
+      async.waterfall([
+        function(callback) {
+          TargetModel.create(testData, callback);
+        },
+        function(data, callback) {
+          updates[0].data = data;
+          TargetModel.getChangeModel().find({where: {modelId: data.id}}, callback);
+        },
+        function(data, callback) {
+          updates[0].change = data;
+          OptionsSourceModel.bulkUpdate(updates, options, callback);
+        }
+      ], function(err, result) {
+        if (err) return done(err);
+
+        expect(syncPropertyExists).to.eql(true);
+
+        done();
+      });
+    });
+  });
+
+  describe('ensure bulkUpdate works with just 2 args', function() {
+    it('bulkUpdate should successfully finish without options', function(done) {
+      var testData = {name: 'Janie', surname: 'Doe'};
+      var updates = [
+        {
+          data: null,
+          change: null,
+          type: 'create'
+        }
+      ];
+
+      async.waterfall([
+        function(callback) {
+          TargetModel.create(testData, callback);
+        },
+        function(data, callback) {
+          updates[0].data = data;
+          TargetModel.getChangeModel().find({where: {modelId: data.id}}, callback);
+        },
+        function(data, callback) {
+          updates[0].change = data;
+          SourceModel.bulkUpdate(updates, callback);
+        }
+      ], function(err, result) {
+        if (err) return done(err);
+        done();
+      });
+    });
+  });
+
   var _since = {};
   function replicate(source, target, since, next) {
     if (typeof since === 'function') {
@@ -1547,7 +1636,7 @@ describe('Replication / Change APIs', function() {
     var sinceIx = source.modelName + ':to:' + target.modelName;
     if (since === undefined) {
       since = useSinceFilter ?
-        _since[sinceIx] || -1 :
+      _since[sinceIx] || -1 :
         -1;
     }
 
@@ -1591,14 +1680,14 @@ describe('Replication / Change APIs', function() {
 
   function setupRaceConditionInReplication(fn) {
     var bulkUpdate = TargetModel.bulkUpdate;
-    TargetModel.bulkUpdate = function(data, cb) {
+    TargetModel.bulkUpdate = function(data, options, cb) {
       // simulate the situation when a 3rd party modifies the database
       // while a replication run is in progress
       var self = this;
       fn(function(err) {
         if (err) return cb(err);
 
-        bulkUpdate.call(self, data, cb);
+        bulkUpdate.call(self, data, options, cb);
       });
 
       // apply the 3rd party modification only once


### PR DESCRIPTION
### Description

Passing options to bulkUpdate, so we can detect saves and updates during sync. Saves during sync can be identified by adding a property on options which gets passed into to replicate.

e.g.:
When you want to update last modified date column on each save through operation hooks, but not during sync:

```
var options = {
  sync: true,
  ... other options
}

SomeModel.replicate(since, targetModel, options, callback);

SomeModel.observe('before save', function updateLastModDate(ctx, next) {
if (ctx.options.sync) {
  // do not update
} else {
  // update
}

next();
});
```

#### Related issues

- None

### Checklist

- [ ] New tests are added to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
