### PR TITLE
add setting 'changeModel'

### DIFF
--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -1669,7 +1669,7 @@ module.exports = function(registry) {
     assert(BaseChangeModel,
       'Change model must be defined before enabling change replication');
 
-    this.Change = BaseChangeModel.extend(this.modelName + '-change',
+    this.Change = BaseChangeModel.extend(this.settings.changeModel||(this.modelName + '-change'),
       {},
       {
         trackModel: this,


### PR DESCRIPTION
### Description

Now is not possible define a model to save the changes in [Synchronization](http://loopback.io/doc/en/lb2/Synchronization.html), It is a problem as is used rethinkDB because the table use a verical line symbol (-) and it is not permit. see the next error.

> ```
> Table name `Todo-change` invalid (Use A-Za-z0-9_ only) in:
> ```
