### PR TITLE
Add mutli tenancy to replication

### DIFF
--- a/common/models/change.json
+++ b/common/models/change.json
@@ -20,6 +20,10 @@
     },
     "modelId": {
       "type": "string"
+    },
+    "tenant": {
+      "type": "string",
+      "default": null
     }
   }
 }

--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -865,7 +865,8 @@ module.exports = function(registry) {
         accessType: 'READ',
         accepts: [
           {arg: 'since', type: 'number', description: 'Only return changes since this checkpoint'},
-          {arg: 'filter', type: 'object', description: 'Only include changes that match this filter'}
+          {arg: 'filter', type: 'object', description: 'Only include changes that match this filter'},
+          {arg: 'tenant', type: 'string', description: 'Only include changes that match this tenant'},
         ],
         returns: {arg: 'changes', type: 'array', root: true},
         http: {verb: 'get', path: '/changes'}

--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -865,8 +865,8 @@ module.exports = function(registry) {
         accessType: 'READ',
         accepts: [
           {arg: 'since', type: 'number', description: 'Only return changes since this checkpoint'},
-          {arg: 'filter', type: 'object', description: 'Only include changes that match this filter'},
-          {arg: 'tenant', type: 'string', description: 'Only include changes that match this tenant'},
+          {arg: 'filter', type: 'object', description: 'Only include changes that matches this filter'},
+          {arg: 'tenant', type: 'string', description: 'Only include changes that matches this tenant'},
         ],
         returns: {arg: 'changes', type: 'array', root: true},
         http: {verb: 'get', path: '/changes'}

--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -996,12 +996,13 @@ module.exports = function(registry) {
    * to reduce the number of results returned.
    * @param  {Number}   since    Return only changes since this checkpoint.
    * @param  {Object}   filter   Include only changes that match this filter, the same as for [#persistedmodel-find](find()).
+   * @param  {String}   tenant   Include only changes for this tenant
    * @callback {Function} callback Callback function called with `(err, changes)` arguments.  Required.
    * @param {Error} err Error object; see [Error object](http://docs.strongloop.com/display/LB/Error+object).
    * @param {Array} changes An array of [Change](#change) objects.
    */
 
-  PersistedModel.changes = function(since, filter, callback) {
+  PersistedModel.changes = function(since, filter, tenant, callback) {
     if (typeof since === 'function') {
       filter = {};
       callback = since;
@@ -1012,10 +1013,24 @@ module.exports = function(registry) {
       since = -1;
       filter = {};
     }
+    if (typeof tenant === 'function') {
+      callback = tenant;
+      tenant = null;
+    }
 
     var idName = this.dataSource.idName(this.modelName);
     var Change = this.getChangeModel();
     var model = this;
+    var changeFilter = {
+      where: {
+        checkpoint: {gte: since},
+        modelName: this.modelName
+      }
+    };
+
+    if (tenant) {
+      changeFilter.where.tenant = tenant;
+    }
 
     filter = filter || {};
     filter.fields = {};
@@ -1023,10 +1038,7 @@ module.exports = function(registry) {
     filter.fields[idName] = true;
 
     // TODO(ritch) this whole thing could be optimized a bit more
-    Change.find({ where: {
-      checkpoint: { gte: since },
-      modelName: this.modelName
-    }}, function(err, changes) {
+    Change.find(changeFilter, function(err, changes) {
       if (err) return callback(err);
       if (!Array.isArray(changes) || changes.length === 0) return callback(null, []);
       var ids = changes.map(function(change) {
@@ -1172,7 +1184,7 @@ module.exports = function(registry) {
     async.waterfall(tasks, done);
 
     function getSourceChanges(cb) {
-      sourceModel.changes(since.source, options.filter, debug.enabled ? log : cb);
+      sourceModel.changes(since.source, options.filter, options.tenant, debug.enabled ? log : cb);
 
       function log(err, result) {
         if (err) return cb(err);

--- a/test/replication.test.js
+++ b/test/replication.test.js
@@ -1642,3 +1642,71 @@ describe('Replication / Change APIs', function() {
     return getPropValue(list, 'id');
   }
 });
+
+describe('Replication / Change APIs with multi tenancy', function() {
+  this.timeout(10000);
+  var dataSource, SourceModelWithTenant, TargetModelWithTenant;
+  var useSinceFilter;
+  var tid = 0; // per-test unique id used e.g. to build unique model names
+
+  beforeEach(function() {
+    tid++;
+    useSinceFilter = false;
+    var test = this;
+
+    dataSource = this.dataSource = loopback.createDataSource({
+      connector: loopback.Memory
+    });
+    SourceModelWithTenant = this.SourceModelWithTenant = PersistedModel.extend(
+      'SourceModelWithTenant-' + tid,
+      { id: { id: true, type: String, defaultFn: 'guid' } },
+      { trackChanges: true, tenantProperty: 'tenantId' });
+
+    SourceModelWithTenant.attachTo(dataSource);
+
+    TargetModelWithTenant = this.TargetModelWithTenant = PersistedModel.extend(
+      'TargetModelWithTenant-' + tid,
+      { id: { id: true, type: String, defaultFn: 'guid' } },
+      { trackChanges: true, tenantProperty: 'tenantId' });
+
+    var TargetWithTenantChange = TargetModelWithTenant.Change;
+    TargetWithTenantChange.Checkpoint = loopback.Checkpoint.extend('TargetWithTenantCheckpoint');
+    TargetWithTenantChange.Checkpoint.attachTo(dataSource);
+
+    TargetModelWithTenant.attachTo(dataSource);
+
+    test.startingCheckpoint = -1;
+  });
+
+  describe('Model.changes(since, filter, tenant, callback)', function() {
+    it('Get changes since the given checkpoint for the given tenant', function(done) {
+      var test = this;
+      this.SourceModelWithTenant.create([{name: 'foo', tenantId: '123'}, {name: 'foo', tenantId: '456'}], function(err) {
+        if (err) return done(err);
+
+        setTimeout(function() {
+          test.SourceModelWithTenant.changes(test.startingCheckpoint, {}, '123', function(err, changes) {
+            assert.equal(changes.length, 1);
+
+            done();
+          });
+        }, 1);
+      });
+    });
+
+    it('excludes changes from older checkpoints', function(done) {
+      var FUTURE_CHECKPOINT = 999;
+
+      SourceModelWithTenant.create({ name: 'foo', tenantId: '123' }, function(err) {
+        if (err) return done(err);
+        SourceModelWithTenant.changes(FUTURE_CHECKPOINT, {}, '123', function(err, changes) {
+          if (err) return done(err);
+
+          expect(changes).to.be.empty; //jshint ignore:line
+
+          done();
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Description
Enable replication to scope changes by tenant. This makes querying for changes faster, as we can filter by tenant where it is provided.


#### Related issues

- None

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)

