### PR TITLE
Fix context within listByPrincipalType role method [2.x]

### DIFF
--- a/common/models/role.js
+++ b/common/models/role.js
@@ -80,26 +80,27 @@ module.exports = function(Role) {
         };
 
         var model = relsToModels[rel];
-        listByPrincipalType(model, relsToTypes[rel], query, callback);
+        listByPrincipalType(this, model, relsToTypes[rel], query, callback);
       };
     });
 
     /**
      * Fetch all models assigned to this role
      * @private
+     * @param {object} Context role context
      * @param {*} model model type to fetch
      * @param {String} [principalType] principalType used in the rolemapping for model
      * @param {object} [query] query object passed to model find call
      * @param  {Function} [callback] callback function called with `(err, models)` arguments.
      */
-    function listByPrincipalType(model, principalType, query, callback) {
+    function listByPrincipalType(context, model, principalType, query, callback) {
       if (callback === undefined) {
         callback = query;
         query = {};
       }
 
       roleModel.roleMappingModel.find({
-        where: {roleId: this.id, principalType: principalType}
+        where: {roleId: context.id, principalType: principalType},
       }, function(err, mappings) {
         var ids;
         if (err) {


### PR DESCRIPTION
Fix for current implementation that returned all models that had any assigned roles. Context was not carried into `listByPrincipalType`, setting `roleId` as null.

Back-port of #2742

cc @codyolsen 