### PR TITLE
add allowArray to relations' 'create' remoteMethod

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -668,7 +668,13 @@ module.exports = function(registry) {
     define('__create__' + scopeName, {
       isStatic: isStatic,
       http: {verb: 'post', path: '/' + pathName},
-      accepts: {arg: 'data', type: 'object', model: toModelName, http: {source: 'body'}},
+      accepts: {
+        arg: 'data',
+        type: 'object',
+        allowArray: true,
+        model: toModelName,
+        http: {source: 'body'},
+      },
       description: format('Creates a new instance in %s of this model.', scopeName),
       accessType: 'WRITE',
       returns: {arg: 'data', type: toModelName, root: true},


### PR DESCRIPTION
connected to #2928 

### Description


this is a problem where relation's model's remoteMethods are rebuilt (not inherited).
Eg lets say 

- **Author.hasMany(Book)**
- `POST /book` (book.create) has flag allowArray
- `POST /Author/id/Book` will rebuild `remoteMethod` per relation type


#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)

this is needed because we added allowArray flag to persisted model's
remoteMethod, but when relations try to rebuild such methods, it does
not carry over such flags


**Update 16/11/16**:
  - Just started.

**Update 17/11/16**:
  - Code is in, could use pre-review