### PR TITLE
propagate resolved roles in remoting context

### DIFF
--- a/lib/access-context.js
+++ b/lib/access-context.js
@@ -12,17 +12,29 @@ var debug = require('debug')('loopback:security:access-context');
  * Access context represents the context for a request to access protected
  * resources
  *
+ * NOTE While the method expects an array of principals in the AccessContext instance/object,
+ * it also accepts a single principal defined with the following properties:
+ * ```js
+ * {
+ *   // AccessContext instance/object
+ *   // ..
+ *   principalType: 'somePrincipalType', // APP, ROLE, USER, or custom user model name
+ *   principalId: 'somePrincipalId',
+ * }
+ * ```
+ *
  * @class
- * @options {Object} context The context object
+ * @options {AccessContext|Object} context An AccessContext instance or an object
  * @property {Principal[]} principals An array of principals
  * @property {Function} model The model class
  * @property {String} modelName The model name
- * @property {String} modelId The model id
+ * @property {*} modelId The model id
  * @property {String} property The model property/method/relation name
  * @property {String} method The model method to be invoked
- * @property {String} accessType The access type
- * @property {AccessToken} accessToken The access token
- *
+ * @property {String} accessType The access type: READ, REPLICATE, WRITE, or EXECUTE.
+ * @property {AccessToken} accessToken The access token resolved for the request
+ * @property {RemotingContext} remotingContext The request's remoting context
+ * @property {Registry} registry The application or global registry
  * @returns {AccessContext}
  * @constructor
  */
@@ -250,16 +262,23 @@ Principal.prototype.equals = function(p) {
 
 /**
  * A request to access protected resources.
- * @param {String} model The model name
- * @param {String} property
+ *
+ * The method can either be called with the following signature or with a single
+ * argument: an AccessRequest instance or an object containing all the required properties.
+ *
+ * @class
+ * @options {String|AccessRequest|Object} model|req The model name,<br>
+ *    or an AccessRequest instance/object.
+ * @param {String} property The property/method/relation name
  * @param {String} accessType The access type
  * @param {String} permission The requested permission
+ * @param {String[]} methodNames The names of involved methods
+ * @param {Registry} registry The application or global registry
  * @returns {AccessRequest}
- * @class
  */
-function AccessRequest(model, property, accessType, permission, methodNames) {
+function AccessRequest(model, property, accessType, permission, methodNames, registry) {
   if (!(this instanceof AccessRequest)) {
-    return new AccessRequest(model, property, accessType);
+    return new AccessRequest(model, property, accessType, permission, methodNames);
   }
   if (arguments.length === 1 && typeof model === 'object') {
     // The argument is an object that contains all required properties
@@ -268,14 +287,19 @@ function AccessRequest(model, property, accessType, permission, methodNames) {
     this.property = obj.property || AccessContext.ALL;
     this.accessType = obj.accessType || AccessContext.ALL;
     this.permission = obj.permission || AccessContext.DEFAULT;
-    this.methodNames = methodNames || [];
+    this.methodNames = obj.methodNames || [];
+    this.registry = obj.registry;
   } else {
     this.model = model || AccessContext.ALL;
     this.property = property || AccessContext.ALL;
     this.accessType = accessType || AccessContext.ALL;
     this.permission = permission || AccessContext.DEFAULT;
     this.methodNames = methodNames || [];
+    this.registry = registry;
   }
+  // do not create AccessRequest without a registry
+  assert(this.registry,
+    'Application registry is mandatory in AccessRequest but missing in provided argument(s)');
 }
 
 /**
@@ -306,6 +330,28 @@ AccessRequest.prototype.exactlyMatches = function(acl) {
   }
 
   return false;
+};
+
+/**
+ * Settle the accessRequest's permission if DEFAULT
+ * In most situations, the default permission can be resolved from the nested model
+ * config. An default permission can also be explicitly provided to override it or
+ * cope with AccessRequest instances without a nested model (e.g. model is '*')
+ *
+ * @param {String} defaultPermission (optional) the default permission to apply
+ */
+
+AccessRequest.prototype.settleDefaultPermission = function(defaultPermission) {
+  if (this.permission !== 'DEFAULT')
+    return;
+
+  var modelName = this.model;
+  if (!defaultPermission) {
+    var modelClass = this.registry.findModel(modelName);
+    defaultPermission = modelClass && modelClass.settings.defaultPermission;
+  }
+
+  this.permission = defaultPermission || 'ALLOW';
 };
 
 /**

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -897,7 +897,7 @@ describe.onServer('Remote Methods', function() {
       request(app).get('/TestModels/saveOptions')
         .expect(204, function(err) {
           if (err) return done(err);
-          expect(actualOptions).to.eql({accessToken: null});
+          expect(actualOptions).to.include({accessToken: null});
           done();
         });
     });


### PR DESCRIPTION
### Description

For some **advanced CRUD access control in remote methods**, it is often required to **get/check roles resolved** (i.e. allowed) for a user against a method with `Role.getRoles(context)` or `Role.isInRole(role, context)`.
In addition to clutter the remote methods / hooks code, it forces the app to run again through all static roles and registered dynamic role resolvers, inducing performance loss and extra calls to db.

Meanwhile, the exact same course of action is performed right when the `Model.checkAccess()` method is called to verify if a principal is allowed to access a protected resource : 

`Model.checkAccess(context)` -> `ACL.checkAccessForContext(context)` -> `acls.forEach(acl, ...)` ->`roleModel.isInRole(acl.principalId, context)` 

This PR proposes to add a new param (`Array`) in remoting context (name proposed: `resolvedRoles`, to be discussed) which is filled during **Model Access Permission Checking** phase with the **roles** for which the user is allowed to run the remote method.

an example of `resolvedRoles` is: `['admin', '$owner']` where admin is a custom role statically mapped to a principal, and $owner is a built-in smart role

`resolvedRoles` param can then be accessed in remote method and remote method hooks as `ctx.req.remotingContext.resolvedRoles`

_To be noted: the `resolvedRoles` param is set in a way that the calling user cannot temper the value to fool the additional access control policies added by user in remote methods_ 

**Reviewers:** please review/discuss the general idea before i provide the required tests  

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] New tests added or existing tests modified to cover all changes
