### PR TITLE
Support multi-tenancy in change replication - allow apps to extend Change model with extra properties

### DIFF
--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -1052,6 +1052,7 @@ module.exports = function(registry) {
     var idName = this.dataSource.idName(this.modelName);
     var Change = this.getChangeModel();
     var model = this;
+    const changeFilter = this.createChangeFilter(since, filter);
 
     filter = filter || {};
     filter.fields = {};
@@ -1059,10 +1060,7 @@ module.exports = function(registry) {
     filter.fields[idName] = true;
 
     // TODO(ritch) this whole thing could be optimized a bit more
-    Change.find({where: {
-      checkpoint: {gte: since},
-      modelName: this.modelName,
-    }}, function(err, changes) {
+    Change.find(changeFilter, function(err, changes) {
       if (err) return callback(err);
       if (!Array.isArray(changes) || changes.length === 0) return callback(null, []);
       var ids = changes.map(function(change) {
@@ -1759,11 +1757,12 @@ module.exports = function(registry) {
     assert(BaseChangeModel,
       'Change model must be defined before enabling change replication');
 
+    const additionalChangeModelProperties =
+      this.settings.additionalChangeModelProperties || {};
+
     this.Change = BaseChangeModel.extend(this.modelName + '-change',
-      {},
-      {
-        trackModel: this,
-      }
+      additionalChangeModelProperties,
+      {trackModel: this}
     );
 
     if (this.dataSource) {
@@ -1926,6 +1925,77 @@ module.exports = function(registry) {
         next();
       };
     }
+  };
+
+  /**
+   * Get the filter for searching related changes.
+   *
+   * Models should override this function to copy properties
+   * from the model instance filter into the change search filter.
+   *
+   * ```js
+   * module.exports = (TargetModel, config) => {
+   *   TargetModel.createChangeFilter = function(since, modelFilter) {
+   *     const filter = this.base.createChangeFilter.apply(this, arguments);
+   *     if (modelFilter && modelFilter.where && modelFilter.where.tenantId) {
+   *       filter.where.tenantId = modelFilter.where.tenantId;
+   *     }
+   *     return filter;
+   *   };
+   * };
+   * ```
+   *
+   * @param {Number} since Return only changes since this checkpoint.
+   * @param {Object} modelFilter Filter describing which model instances to
+   * include in the list of changes.
+   * @returns {Object} The filter object to pass to `Change.find()`. Default:
+   * ```
+   * {where: {checkpoint: {gte: since}, modelName: this.modelName}}
+   * ```
+   */
+  PersistedModel.createChangeFilter = function(since, modelFilter) {
+    return {
+      where: {
+        checkpoint: {gte: since},
+        modelName: this.modelName,
+      },
+    };
+  };
+
+  /**
+   * Add custom data to the Change instance.
+   *
+   * Models should override this function to duplicate model instance properties
+   * to the Change instance properties, typically to allow the changes() method
+   * to filter the changes using these duplicated properties directly while
+   * querying the Change model.
+   *
+   * ```js
+   * module.exports = (TargetModel, config) => {
+   *   TargetModel.prototype.fillCustomChangeProperties = function(change, cb) {
+   *     var inst = this;
+   *     const base = this.constructor.base;
+   *     base.prototype.fillCustomChangeProperties.call(this, change, err => {
+   *       if (err) return cb(err);
+   *
+   *       if (inst && inst.tenantId) {
+   *         change.tenantId = inst.tenantId;
+   *       } else {
+   *         change.tenantId = null;
+   *       }
+   *
+   *       cb();
+   *     });
+   *   };
+   * };
+   * ```
+   *
+   * @callback {Function} callback
+   * @param {Error} err Error object; see [Error object](http://loopback.io/doc/en/lb3/Error-object.html).
+   */
+  PersistedModel.prototype.fillCustomChangeProperties = function(change, cb) {
+    // no-op by default
+    cb();
   };
 
   PersistedModel.setup();


### PR DESCRIPTION
### Description
Enable replication to scope changes by tenant. This makes querying for changes faster, as we can filter by tenant where it is provided.


#### Related issues

- None

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
