### PR TITLE
Avoid periodic cleanup/rectification of changes

### DIFF
--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -1597,14 +1597,16 @@ module.exports = function(registry) {
     var idDefn = idProp && idProp.defaultFn;
     if (idType !== String || !(idDefn === 'uuid' || idDefn === 'guid')) {
       deprecated('The model ' + this.modelName + ' is tracking changes, ' +
-        'which requries a string id with GUID/UUID default value.');
+        'which requires a string id with GUID/UUID default value.');
     }
 
     Model.observe('after save', rectifyOnSave);
 
     Model.observe('after delete', rectifyOnDelete);
 
-    if (runtime.isServer) {
+    // Only run if the run time is server
+    // Can switch off cleanup by setting the interval to -1
+    if (runtime.isServer && cleanupInterval > 0) {
       // initial cleanup
       cleanup();
 

--- a/test/replication.test.js
+++ b/test/replication.test.js
@@ -11,6 +11,7 @@ var defineModelTestsWithDataSource = require('./util/model-tests');
 var PersistedModel = loopback.PersistedModel;
 var expect = require('chai').expect;
 var debug = require('debug')('test');
+var runtime = require('./../lib/runtime');
 
 describe('Replication / Change APIs', function() {
   this.timeout(10000);
@@ -58,6 +59,77 @@ describe('Replication / Change APIs', function() {
         SourceModel.replicate(TargetModel, cb);
       });
     };
+  });
+
+  describe('cleanup check for enableChangeTracking', function() {
+    describe('when no changeCleanupInterval set', function() {
+      it('should call rectifyAllChanges if running on server', function(done) {
+        var calls = mockRectifyAllChanges(SourceModel);
+        SourceModel.enableChangeTracking();
+
+        if (runtime.isServer) {
+          expect(calls).to.eql(['rectifyAllChanges']);
+        } else {
+          expect(calls).to.eql([]);
+        }
+
+        done();
+      });
+    });
+
+    describe('when changeCleanupInterval set to -1', function() {
+      var Model;
+      beforeEach(function() {
+        Model = this.Model = PersistedModel.extend(
+          'Model-' + tid,
+          {id: {id: true, type: String, defaultFn: 'guid'}},
+          {trackChanges: true, changeCleanupInterval: -1});
+
+        Model.attachTo(dataSource);
+      });
+
+      it('should not call rectifyAllChanges', function(done) {
+        var calls = mockRectifyAllChanges(Model);
+        Model.enableChangeTracking();
+        expect(calls).to.eql([]);
+        done();
+      });
+    });
+
+    describe('when changeCleanupInterval set to 10000', function() {
+      var Model;
+      beforeEach(function() {
+        Model = this.Model = PersistedModel.extend(
+          'Model-' + tid,
+          {id: {id: true, type: String, defaultFn: 'guid'}},
+          {trackChanges: true, changeCleanupInterval: 10000});
+
+        Model.attachTo(dataSource);
+      });
+
+      it('should call rectifyAllChanges if running on server', function(done) {
+        var calls = mockRectifyAllChanges(Model);
+        Model.enableChangeTracking();
+        if (runtime.isServer) {
+          expect(calls).to.eql(['rectifyAllChanges']);
+        } else {
+          expect(calls).to.eql([]);
+        }
+
+        done();
+      });
+    });
+
+    function mockRectifyAllChanges(Model) {
+      var calls = [];
+
+      Model.rectifyAllChanges = function(cb) {
+        calls.push('rectifyAllChanges');
+        process.nextTick(cb);
+      };
+
+      return calls;
+    }
   });
 
   describe('optimization check rectifyChange Vs rectifyAllChanges', function() {


### PR DESCRIPTION
### Description

Add a value for which cleanup would not run. Running cleanup on a big database is make the machine run out of memory.

#### Related issues

- None

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
