### PR TITLE
Re-enable "no-unused-expressions" rule for eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,7 +5,6 @@
       "ignoreComments": true,
       "ignoreUrls": true,
       "ignorePattern": "^\\s*var\\s.+=\\s*(require\\s*\\()|(/)"
-    }],
-  "no-unused-expressions": "off",
+    }]
   }
 }

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "browserify": "^13.1.0",
     "chai": "^3.5.0",
     "cookie-parser": "^1.3.4",
+    "dirty-chai": "^1.2.2",
     "es5-shim": "^4.1.0",
     "eslint-config-loopback": "^5.0.0",
     "express-session": "^1.14.0",

--- a/test/access-control.integration.js
+++ b/test/access-control.integration.js
@@ -159,7 +159,7 @@ describe('access control - integration', function() {
       roleModel.registerResolver('$dynamic-role', function(role, context, callback) {
         if (!(context && context.accessToken && context.accessToken.userId)) {
           return process.nextTick(function() {
-            callback && callback(null, false);
+            if (callback) callback(null, false);
           });
         }
         var accessToken = context.accessToken;
@@ -216,7 +216,7 @@ describe('access control - integration', function() {
           if (context.remotingContext) {
             count++;
           }
-          callback && callback(null, false); // Always true
+          if (callback) callback(null, false); // Always true
         });
       });
     });

--- a/test/access-token.test.js
+++ b/test/access-token.test.js
@@ -5,7 +5,7 @@
 
 'use strict';
 var assert = require('assert');
-var expect = require('chai').expect;
+var expect = require('./helpers/expect');
 var cookieParser = require('cookie-parser');
 var LoopBackContext = require('loopback-context');
 var contextMiddleware = require('loopback-context').perRequest;

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -14,7 +14,7 @@ var loopback = require('../');
 var PersistedModel = loopback.PersistedModel;
 
 var describe = require('./util/describe');
-var expect = require('chai').expect;
+var expect = require('./helpers/expect');
 var it = require('./util/it');
 var request = require('supertest');
 
@@ -91,7 +91,7 @@ describe('app', function() {
       app.middleware('routes:before',
         myHandler = handlerThatAddsHandler('my-handler'));
       var found = app._findLayerByHandler(myHandler);
-      expect(found).to.be.object;
+      expect(found).to.be.an('object');
       expect(myHandler).to.equal(found.handle);
       expect(found).have.property('phase', 'routes:before');
       executeMiddlewareHandlers(app, function(err) {
@@ -112,7 +112,7 @@ describe('app', function() {
         wrappedHandler['__NR_handler'] = myHandler;
         app.middleware('routes:before', wrappedHandler);
         var found = app._findLayerByHandler(myHandler);
-        expect(found).to.be.object;
+        expect(found).to.be.an('object');
         expect(found).have.property('phase', 'routes:before');
         executeMiddlewareHandlers(app, function(err) {
           if (err) return done(err);
@@ -132,7 +132,7 @@ describe('app', function() {
         wrappedHandler['__handler'] = myHandler;
         app.middleware('routes:before', wrappedHandler);
         var found = app._findLayerByHandler(myHandler);
-        expect(found).to.be.object;
+        expect(found).to.be.an('object');
         expect(found).have.property('phase', 'routes:before');
         executeMiddlewareHandlers(app, function(err) {
           if (err) return done(err);
@@ -380,7 +380,7 @@ describe('app', function() {
       executeMiddlewareHandlers(app, '/mountpath/test', function(err) {
         if (err) return done(err);
 
-        expect(mountWasEmitted, 'mountWasEmitted').to.be.true;
+        expect(mountWasEmitted, 'mountWasEmitted').to.be.true();
         expect(data).to.eql({
           mountpath: '/mountpath',
           parent: app,
@@ -666,7 +666,7 @@ describe('app', function() {
         remotedClass = sharedClass;
       });
       app.model(Color);
-      expect(remotedClass).to.exist;
+      expect(remotedClass).to.exist();
       expect(remotedClass).to.eql(Color.sharedClass);
     });
 
@@ -680,9 +680,9 @@ describe('app', function() {
       });
       app.model(Color);
       app.models.Color.disableRemoteMethodByName('findOne');
-      expect(remoteMethodDisabledClass).to.exist;
+      expect(remoteMethodDisabledClass).to.exist();
       expect(remoteMethodDisabledClass).to.eql(Color.sharedClass);
-      expect(disabledRemoteMethod).to.exist;
+      expect(disabledRemoteMethod).to.exist();
       expect(disabledRemoteMethod).to.eql('findOne');
     });
 

--- a/test/change-stream.test.js
+++ b/test/change-stream.test.js
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 'use strict';
-var expect = require('chai').expect;
+var expect = require('./helpers/expect');
 var loopback = require('../');
 
 describe('PersistedModel.createChangeStream()', function() {

--- a/test/change.test.js
+++ b/test/change.test.js
@@ -6,7 +6,7 @@
 'use strict';
 var assert = require('assert');
 var async = require('async');
-var expect = require('chai').expect;
+var expect = require('./helpers/expect');
 var loopback = require('../');
 
 var Change, TestModel;

--- a/test/checkpoint.test.js
+++ b/test/checkpoint.test.js
@@ -6,7 +6,7 @@
 'use strict';
 var async = require('async');
 var loopback = require('../');
-var expect = require('chai').expect;
+var expect = require('./helpers/expect');
 
 var Checkpoint = loopback.Checkpoint.extend('TestCheckpoint');
 

--- a/test/error-handler.test.js
+++ b/test/error-handler.test.js
@@ -8,7 +8,7 @@ var loopback = require('../');
 var app;
 var assert = require('assert');
 var request = require('supertest');
-var expect = require('chai').expect;
+var expect = require('./helpers/expect');
 
 describe('loopback.errorHandler(options)', function() {
   it('should throw a descriptive error', function() {

--- a/test/helpers/expect.js
+++ b/test/helpers/expect.js
@@ -1,0 +1,12 @@
+// Copyright IBM Corp. 2013,2016. All Rights Reserved.
+// Node module: loopback
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+var chai = require('chai');
+chai.use(require('dirty-chai'));
+chai.use(require('sinon-chai'));
+
+module.exports = chai.expect;

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 'use strict';
-var expect = require('chai').expect;
+var expect = require('./helpers/expect');
 var loopback = require('../');
 var net = require('net');
 

--- a/test/key-value-model.test.js
+++ b/test/key-value-model.test.js
@@ -1,5 +1,5 @@
 'use strict';
-var expect = require('chai').expect;
+var expect = require('./helpers/expect');
 var http = require('http');
 var loopback = require('..');
 var supertest = require('supertest');
@@ -89,7 +89,7 @@ describe('KeyValueModel', function() {
           request.get('/CacheItems/ttl-key/ttl')
             .end(function(err, res) {
               if (err) return done(err);
-              expect(res.body).to.be.number;
+              expect(res.body).to.be.a('number');
               done();
             });
         });

--- a/test/loopback.test.js
+++ b/test/loopback.test.js
@@ -9,7 +9,7 @@ var describe = require('./util/describe');
 var Domain = require('domain');
 var EventEmitter = require('events').EventEmitter;
 var loopback = require('../');
-var expect = require('chai').expect;
+var expect = require('./helpers/expect');
 var assert = require('assert');
 
 describe('loopback', function() {

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -6,19 +6,16 @@
 'use strict';
 var assert = require('assert');
 var async = require('async');
-var chai = require('chai');
 var describe = require('./util/describe');
 var loopback = require('../');
 var ACL = loopback.ACL;
 var defineModelTestsWithDataSource = require('./util/model-tests');
 var PersistedModel = loopback.PersistedModel;
-var sinonChai = require('sinon-chai');
 var Promise = require('bluebird');
 var TaskEmitter = require('strong-task-emitter');
 var request = require('supertest');
 
-var expect = chai.expect;
-chai.use(sinonChai);
+var expect = require('./helpers/expect');
 
 describe('Model / PersistedModel', function() {
   defineModelTestsWithDataSource({

--- a/test/registries.test.js
+++ b/test/registries.test.js
@@ -5,7 +5,7 @@
 
 'use strict';
 var assert = require('assert');
-var expect = require('chai').expect;
+var expect = require('./helpers/expect');
 var loopback = require('../');
 
 describe('Registry', function() {

--- a/test/relations.integration.js
+++ b/test/relations.integration.js
@@ -10,7 +10,7 @@ var path = require('path');
 var SIMPLE_APP = path.join(__dirname, 'fixtures', 'simple-integration-app');
 var app = require(path.join(SIMPLE_APP, 'server/server.js'));
 var assert = require('assert');
-var expect = require('chai').expect;
+var expect = require('./helpers/expect');
 var debug = require('debug')('loopback:test:relations.integration');
 var async = require('async');
 
@@ -138,7 +138,7 @@ describe('relations - integration', function() {
         .expect(200, function(err, res) {
           if (err) return done(err);
 
-          expect(res.body).to.be.array;
+          expect(res.body).to.be.an('array');
 
           done();
         });
@@ -1410,7 +1410,7 @@ describe('relations - integration', function() {
         .expect(200, function(err, res) {
           if (err) return done(err);
 
-          expect(err).to.not.exist;
+          expect(err).to.not.exist();
           expect(res.body.name).to.equal('Photo 1');
 
           done();
@@ -1492,8 +1492,8 @@ describe('relations - integration', function() {
       Book.nestRemoting('chapters');
       Image.nestRemoting('book');
 
-      expect(Book.prototype['__findById__pages__notes']).to.be.a.function;
-      expect(Image.prototype['__findById__book__pages']).to.be.a.function;
+      expect(Book.prototype['__findById__pages']).to.be.a('function');
+      expect(Image.prototype['__get__book']).to.be.a('function');
 
       Page.beforeRemote('prototype.__findById__notes', function(ctx, result, next) {
         ctx.res.set('x-before', 'before');
@@ -1563,7 +1563,7 @@ describe('relations - integration', function() {
         .expect(200, function(err, res) {
           if (err) return done(err);
 
-          expect(res.body).to.be.an.array;
+          expect(res.body).to.be.an('array');
           expect(res.body).to.have.length(1);
           expect(res.body[0].name).to.equal('Page 1');
 
@@ -1579,7 +1579,7 @@ describe('relations - integration', function() {
 
           expect(res.headers['x-before']).to.equal('before');
           expect(res.headers['x-after']).to.equal('after');
-          expect(res.body).to.be.an.object;
+          expect(res.body).to.be.an('object');
           expect(res.body.text).to.equal('Page Note 1');
 
           done();
@@ -1592,7 +1592,7 @@ describe('relations - integration', function() {
         .expect(404, function(err, res) {
           if (err) return done(err);
 
-          expect(res.body.error).to.be.an.object;
+          expect(res.body.error).to.be.an('object');
           var expected = 'could not find a model with id unknown';
           expect(res.body.error.message).to.equal(expected);
           expect(res.body.error.code).to.be.equal('MODEL_NOT_FOUND');
@@ -1607,7 +1607,7 @@ describe('relations - integration', function() {
         .end(function(err, res) {
           if (err) return done(err);
 
-          expect(res.body).to.be.an.array;
+          expect(res.body).to.be.an('array');
           expect(res.body).to.have.length(1);
           expect(res.body[0].name).to.equal('Page 1');
 
@@ -1621,7 +1621,7 @@ describe('relations - integration', function() {
         .end(function(err, res) {
           if (err) return done(err);
 
-          expect(res.body).to.be.an.object;
+          expect(res.body).to.be.an('object');
           expect(res.body.name).to.equal('Page 1');
 
           done();
@@ -1634,7 +1634,7 @@ describe('relations - integration', function() {
         .expect(200, function(err, res) {
           if (err) return done(err);
 
-          expect(res.body).to.be.an.array;
+          expect(res.body).to.be.an('array');
           expect(res.body).to.have.length(1);
           expect(res.body[0].text).to.equal('Page Note 1');
 
@@ -1650,7 +1650,7 @@ describe('relations - integration', function() {
 
           expect(res.headers['x-before']).to.equal('before');
           expect(res.headers['x-after']).to.equal('after');
-          expect(res.body).to.be.an.object;
+          expect(res.body).to.be.an('object');
           expect(res.body.text).to.equal('Page Note 1');
 
           done();
@@ -1663,8 +1663,8 @@ describe('relations - integration', function() {
         .expect(200, function(err, res) {
           if (err) return done(err);
 
-          expect(res.headers['x-before']).to.empty;
-          expect(res.headers['x-after']).to.empty;
+          expect(res.headers['x-before']).to.empty();
+          expect(res.headers['x-after']).to.empty();
 
           done();
         });

--- a/test/remoting.integration.js
+++ b/test/remoting.integration.js
@@ -10,7 +10,7 @@ var path = require('path');
 var SIMPLE_APP = path.join(__dirname, 'fixtures', 'simple-integration-app');
 var app = require(path.join(SIMPLE_APP, 'server/server.js'));
 var assert = require('assert');
-var expect = require('chai').expect;
+var expect = require('./helpers/expect');
 
 describe('remoting - integration', function() {
   lt.beforeEach.withApp(app);

--- a/test/replication.rest.test.js
+++ b/test/replication.rest.test.js
@@ -8,7 +8,7 @@ var async = require('async');
 var debug = require('debug')('test');
 var extend = require('util')._extend;
 var loopback = require('../');
-var expect = require('chai').expect;
+var expect = require('./helpers/expect');
 var supertest = require('supertest');
 
 describe('Replication over REST', function() {

--- a/test/replication.test.js
+++ b/test/replication.test.js
@@ -10,7 +10,7 @@ var loopback = require('../');
 var Change = loopback.Change;
 var defineModelTestsWithDataSource = require('./util/model-tests');
 var PersistedModel = loopback.PersistedModel;
-var expect = require('chai').expect;
+var expect = require('./helpers/expect');
 var debug = require('debug')('test');
 
 describe('Replication / Change APIs', function() {
@@ -216,7 +216,7 @@ describe('Replication / Change APIs', function() {
         SourceModel.changes(FUTURE_CHECKPOINT, {}, function(err, changes) {
           if (err) return done(err);
 
-          expect(changes).to.be.empty;
+          expect(changes).to.be.empty();
 
           done();
         });

--- a/test/rest.middleware.test.js
+++ b/test/rest.middleware.test.js
@@ -5,7 +5,7 @@
 
 'use strict';
 var assert = require('assert');
-var expect = require('chai').expect;
+var expect = require('./helpers/expect');
 var loopback = require('../');
 var path = require('path');
 var request = require('supertest');
@@ -207,7 +207,7 @@ describe('loopback.rest', function() {
     app.model(AccessToken, {dataSource: 'db'});
     var User = app.registry.getModel('User');
     // Speed up the password hashing algorithm for tests
-    User.settings.saltWorkFactor = 4,
+    User.settings.saltWorkFactor = 4;
     app.model(User, {dataSource: 'db'});
 
     // NOTE(bajtos) This is puzzling to me. The built-in User & AccessToken

--- a/test/role.test.js
+++ b/test/role.test.js
@@ -8,7 +8,7 @@ var assert = require('assert');
 var sinon = require('sinon');
 var loopback = require('../index');
 var async = require('async');
-var expect = require('chai').expect;
+var expect = require('./helpers/expect');
 var Promise = require('bluebird');
 
 function checkResult(err, result) {
@@ -144,7 +144,7 @@ describe('role model', function() {
       if (err) return done(err);
 
       Role.create({name: 'userRole'}, function(err, role) {
-        expect(err).to.exist;
+        expect(err).to.exist();
         expect(err).to.have.property('name', 'ValidationError');
         expect(err).to.have.deep.property('details.codes.name');
         expect(err.details.codes.name).to.contain('uniqueness');

--- a/test/user.integration.js
+++ b/test/user.integration.js
@@ -9,7 +9,7 @@ var lt = require('./helpers/loopback-testing-helper');
 var path = require('path');
 var SIMPLE_APP = path.join(__dirname, 'fixtures', 'user-integration-app');
 var app = require(path.join(SIMPLE_APP, 'server/server.js'));
-var expect = require('chai').expect;
+var expect = require('./helpers/expect');
 
 describe('users - integration', function() {
   lt.beforeEach.withApp(app);
@@ -39,7 +39,7 @@ describe('users - integration', function() {
         .expect(200, function(err, res) {
           if (err) return done(err);
 
-          expect(res.body.id).to.exist;
+          expect(res.body.id).to.exist();
           userId = res.body.id;
 
           done();
@@ -54,7 +54,7 @@ describe('users - integration', function() {
         .expect(200, function(err, res) {
           if (err) return done(err);
 
-          expect(res.body.id).to.exist;
+          expect(res.body.id).to.exist();
           accessToken = res.body.id;
 
           done();
@@ -105,7 +105,7 @@ describe('users - integration', function() {
         .expect(200, function(err, res) {
           if (err) return done(err);
 
-          expect(res.body.id).to.exist;
+          expect(res.body.id).to.exist();
           userId = res.body.id;
 
           done();
@@ -120,7 +120,7 @@ describe('users - integration', function() {
         .expect(200, function(err, res) {
           if (err) return done(err);
 
-          expect(res.body.id).to.exist;
+          expect(res.body.id).to.exist();
           accessToken = res.body.id;
 
           done();

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -5,7 +5,7 @@
 
 'use strict';
 var assert = require('assert');
-var expect = require('chai').expect;
+var expect = require('./helpers/expect');
 var request = require('supertest');
 var loopback = require('../');
 var User, AccessToken;


### PR DESCRIPTION
As a follow-up to #2632, I am cleaning up the use of property-based assertions (see [Beware of libraries that assert on property access](https://github.com/moll/js-must#asserting-on-property-access)). The patch adds "dirty-chai" to modify chai's property checkers.

@superkhau please review
cc @loay 