### PR TITLE
Remove workaround for default value

### DIFF
--- a/common/models/access-token.js
+++ b/common/models/access-token.js
@@ -34,12 +34,6 @@ var DEFAULT_TOKEN_LEN = 64;
  */
 
 module.exports = function(AccessToken) {
-  // Workaround for https://github.com/strongloop/loopback/issues/292
-  AccessToken.definition.rawProperties.created.default =
-  AccessToken.definition.properties.created.default = function() {
-    return new Date();
-  };
-
   /**
    * Anonymous Token
    *

--- a/common/models/access-token.json
+++ b/common/models/access-token.json
@@ -12,7 +12,8 @@
       "description": "time to live in seconds (2 weeks by default)"
     },
     "created": {
-      "type": "Date"
+      "type": "Date",
+      "defaultFn": "now"
     }
   },
   "relations": {


### PR DESCRIPTION
### Description
Remove the work around for issue 292 concerning the default value, as it is not needed anymore since the json file is configured. 
The same fix is implemented for both `application` and `role`. 

#### Related issues

https://github.com/strongloop/loopback/issues/292

### Checklist

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)

