### PR TITLE
Role.getRoles() to return only role names

### DIFF
--- a/common/models/role.js
+++ b/common/models/role.js
@@ -368,7 +368,12 @@ module.exports = function(Role) {
    * @param {Error} err Error object.
    * @param {String[]} roles An array of role IDs
    */
-  Role.getRoles = function(context, callback) {
+  Role.getRoles = function(context, options, callback) {
+    if (!callback && typeof options === 'function') {
+      callback = options;
+      options = {};
+    }
+
     if (!(context instanceof AccessContext)) {
       context = new AccessContext(context);
     }
@@ -418,15 +423,24 @@ module.exports = function(Role) {
       if (principalType && principalId) {
         // Please find() treat undefined matches all values
         inRoleTasks.push(function(done) {
-          roleMappingModel.find({where: {principalType: principalType,
-            principalId: principalId}}, function(err, mappings) {
+          var filter = {where: {principalType: principalType, principalId: principalId}};
+          if (options.returnOnlyRoleNames === true) {
+            filter.include = ['role'];
+          }
+          roleMappingModel.find(filter, function(err, mappings) {
             debug('Role mappings found: %s %j', err, mappings);
             if (err) {
               if (done) done(err);
               return;
             }
             mappings.forEach(function(m) {
-              addRole(m.roleId);
+              var role;
+              if (options.returnOnlyRoleNames === true) {
+                role = m.toJSON().role.name;
+              } else {
+                role = m.roleId;
+              }
+              addRole(role);
             });
             if (done) done();
           });

--- a/test/role.test.js
+++ b/test/role.test.js
@@ -254,6 +254,20 @@ describe('role model', function() {
             },
             function(next) {
               Role.getRoles(
+                {principalType: RoleMapping.USER, principalId: user.id},
+                {returnOnlyRoleNames: true},
+                function(err, roles) {
+                  if (err) return next(err);
+                  expect(roles).to.eql([
+                    Role.AUTHENTICATED,
+                    Role.EVERYONE,
+                    role.name,
+                  ]);
+                  next();
+                });
+            },
+            function(next) {
+              Role.getRoles(
                 {principalType: RoleMapping.APP, principalId: user.id},
                 function(err, roles) {
                   if (err) return next(err);


### PR DESCRIPTION
### Description

Currently the return type of `Role.getRoles()` method is inconsistent: role names are returned for  smart roles and role ids are returned for static roles (configured through user-role mapping)

This PR proposes to return only role names in `Role.getRoles()`
Tests have been updated.

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)

@bajtos, @superkhau could you please have a look?