### PR TITLE
fixing use-strict issue with connectors after merge #2632

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -423,7 +423,7 @@ function dataSourcesFromConfig(name, config, connectorRegistry, registry) {
         config.connector = require(connectorPath);
       }
     }
-    if (!config.connector.name)
+    if (config.connector && typeof config.connector === 'object' && !config.connector.name)
       config.connector.name = name;
   }
 


### PR DESCRIPTION
### Description
adding `'use strict'` in lib/application.js on recent code style review broke the support for db connectors here : https://github.com/strongloop/loopback/blob/master/lib/application.js#L427
 
This PR solves this issue by looking at config.connector type before trying to assign config.connector.name property

All tests pass. No need for new tests

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

https://github.com/strongloop/loopback/pull/2632#issuecomment-262482888
https://github.com/strongloop/loopback/issues/2978

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)

