### PR TITLE
Allow password reset request for users in realms

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -546,11 +546,12 @@ module.exports = function(User) {
   };
 
   /**
-   * Create a short lived acess token for temporary login. Allows users
+   * Create a short lived access token for temporary login. Allows users
    * to change passwords if forgotten.
    *
    * @options {Object} options
-   * @prop {String} email The user's email address
+   * @property {String} email The user's email address
+   * @property {String} realm The user's realm (optional)
    * @callback {Function} callback
    * @param {Error} err
    */
@@ -575,7 +576,13 @@ module.exports = function(User) {
     } catch (err) {
       return cb(err);
     }
-    UserModel.findOne({ where: { email: options.email }}, function(err, user) {
+    var where = {
+      email: options.email
+    };
+    if (options.realm) {
+      where.realm = options.realm;
+    }
+    UserModel.findOne({ where: where }, function(err, user) {
       if (err) {
         return cb(err);
       }

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -15,6 +15,7 @@ describe('User', function() {
   var validCredentials = {email: validCredentialsEmail, password: 'bar'};
   var validCredentialsEmailVerified = {email: 'foo1@bar.com', password: 'bar1', emailVerified: true};
   var validCredentialsEmailVerifiedOverREST = {email: 'foo2@bar.com', password: 'bar2', emailVerified: true};
+  var validCredentialsWithRealm = {email: 'foo3@bar.com', password: 'bar', realm: 'foobar'};
   var validCredentialsWithTTL = {email: 'foo@bar.com', password: 'bar', ttl: 3600};
   var validCredentialsWithTTLAndScope = {email: 'foo@bar.com', password: 'bar', ttl: 3600, scope: 'all'};
   var validMixedCaseEmailCredentials = {email: 'Foo@bar.com', password: 'bar'};
@@ -1876,6 +1877,58 @@ describe('User', function() {
 
             done();
           });
+      });
+    });
+
+    describe('User.resetPassword(options, cb) requiring realm', function() {
+      var realmUser;
+
+      beforeEach(function(done) {
+        User.create(validCredentialsWithRealm, function(err, u) {
+          if (err) return done(err);
+
+          realmUser = u;
+          done();
+        });
+      });
+
+      it('Reports when email is not found in realm', function(done) {
+        User.resetPassword({
+          email: realmUser.email,
+          realm: 'unknown'
+        }, function(err) {
+          assert(err);
+          assert.equal(err.code, 'EMAIL_NOT_FOUND');
+          assert.equal(err.statusCode, 404);
+
+          done();
+        });
+      });
+
+      it('Creates a temp accessToken to allow a user in realm to change password', function(done) {
+        var calledBack = false;
+
+        User.resetPassword({
+          email: realmUser.email,
+          realm: realmUser.realm
+        }, function() {
+          calledBack = true;
+        });
+
+        User.once('resetPasswordRequest', function(info) {
+          assert(info.email);
+          assert(info.accessToken);
+          assert(info.accessToken.id);
+          assert.equal(info.accessToken.ttl / 60, 15);
+          assert(calledBack);
+          info.accessToken.user(function(err, user) {
+            if (err) return done(err);
+
+            assert.equal(user.email, realmUser.email);
+
+            done();
+          });
+        });
       });
     });
   });


### PR DESCRIPTION
### Description

Currently the `User.resetPassword` method only accepts an email address as a parameter. 

When you have a LoopBack application that partitions the users in Realms you need to `find` the user based on it's email address + realm, because it allows for 2 users with the same email address.

This PR fixes the issue by adding support for an optional `realm` property, that will enhance the filter used in the `findOne` method.

@bajtos @raymondfeng @superkhau could you please review?   

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- #2866 

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
