### PR TITLE
Throw error when model relation name is trigger

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -118,6 +118,12 @@ Registry.prototype.createModel = function(name, properties, options) {
     }
   }
 
+  var invalidRelationName = checkRelationName(options);
+
+  if (invalidRelationName.length > 0) {
+    throw new Error(g.f('Invalid relation name `%s` for model `%s`.', invalidRelationName,  name));
+  }
+
   BaseModel = BaseModel || this.getModel('PersistedModel');
   var model = BaseModel.extend(name, properties, options);
   model.registry = this;
@@ -144,6 +150,30 @@ function buildModelOptionsFromConfig(config) {
     options[key] = config[key];
   }
   return options;
+}
+
+/*
+ * Check the name of a model relation name against a list of reserved names.
+ * @param {Object[]} options
+ * @return {string} The name of the reserved relation name.
+ */
+function checkRelationName(options) {
+  var reservedNames = ['trigger'];
+  var invalidRelationName = '';
+
+  if (options.hasOwnProperty('relations')) {
+    Object.keys(options['relations']).forEach(function(relationName) {
+      var isReserved = reservedNames.some(function(reservedName) {
+        return relationName === reservedName;
+      });
+
+      if (isReserved) {
+        invalidRelationName = relationName;
+      }
+    });
+  }
+
+  return invalidRelationName;
 }
 
 /*

--- a/test/registries.test.js
+++ b/test/registries.test.js
@@ -17,6 +17,27 @@ describe('Registry', function() {
       expect(function() { app.registry.createModel('aModel', props, opts); })
         .to.throw(/model\s`aModel`(.*)unknown\smodel\s`nonexistent`/);
     });
+
+    it('should throw error upon reserved relation name `trigger`', function() {
+      var app = loopback();
+      var fooModel = {
+        name: 'Foo',
+        properties: {
+          name: 'string',
+        },
+        options: {
+          relations: {
+            trigger: {
+              model: 'Bar',
+              type: 'hasMany',
+            },
+          },
+        },
+      };
+
+      expect(function() { app.registry.createModel(fooModel); })
+        .to.throw('Invalid relation name `trigger` for model `Foo`.');
+    });
   });
 
   describe('one per app', function() {


### PR DESCRIPTION
### Description
Defining a model relation with the name "trigger" causes the model not able to insert records. No error is thrown when a model relation with then name "trigger" is defined. Adding a check for the model relation name "trigger" will now throw an error.

@bajtos @raymondfeng  Could you review please?


#### Related issues
- #2396

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)