### PR TITLE
Update Downstream ignore List

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,5 +115,10 @@
       "debug": "*,-mocha:*,-eslint:*"
     }
   },
-  "license": "MIT"
+  "license": "MIT",
+  "ci": {
+    "downstreamIgnoreList": [
+      "loopback-connector-swagger"
+    ]
+  }
 }


### PR DESCRIPTION

Add loopback-connector-swagger to downstream ignore list. 
All servers pass except this one. The cause is not related to a fault in the unit tests. 

