### PR TITLE
Emit resetPasswordRequest event with options

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -617,6 +617,7 @@ module.exports = function(User) {
           email: options.email,
           accessToken: accessToken,
           user: user,
+          options: options,
         });
       });
     });

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -1815,7 +1815,10 @@ describe('User', function() {
 
   describe('Password Reset', function() {
     describe('User.resetPassword(options, cb)', function() {
-      var email = 'foo@bar.com';
+      var options = {
+        email: 'foo@bar.com',
+        redirect: 'http://foobar.com/reset-password',
+      };
 
       it('Requires email address to reset password', function(done) {
         User.resetPassword({ }, function(err) {
@@ -1849,11 +1852,27 @@ describe('User', function() {
         });
       });
 
+      it('Checks that options exist', function(done) {
+        var calledBack = false;
+
+        User.resetPassword(options, function() {
+          calledBack = true;
+        });
+
+        User.once('resetPasswordRequest', function(info) {
+          assert(info.options);
+          assert.equal(info.options, options);
+          assert(calledBack);
+
+          done();
+        });
+      });
+
       it('Creates a temp accessToken to allow a user to change password', function(done) {
         var calledBack = false;
 
         User.resetPassword({
-          email: email,
+          email: options.email,
         }, function() {
           calledBack = true;
         });
@@ -1867,7 +1886,7 @@ describe('User', function() {
           info.accessToken.user(function(err, user) {
             if (err) return done(err);
 
-            assert.equal(user.email, email);
+            assert.equal(user.email, options.email);
 
             done();
           });
@@ -1896,7 +1915,7 @@ describe('User', function() {
           .post('/test-users/reset')
           .expect('Content-Type', /json/)
           .expect(204)
-          .send({email: email})
+          .send({email: options.email})
           .end(function(err, res) {
             if (err) return done(err);
 


### PR DESCRIPTION
### Description

Currently the 'resetPasswordRequest' event only sends an email address  from all options object. I propose to send all options object, because e.g. I have needed all options more than one time.

@bajtos @raymondfeng @superkhau does it make sense?  

#### Related issues

- None

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [styleguide](http://loopback.io/doc/en/contrib/style-guide.html)

