### PR TITLE
Add "returnOnlyRoleNames" option to Role.getRoles

### DIFF
--- a/test/role.test.js
+++ b/test/role.test.js
@@ -251,6 +251,20 @@ describe('role model', function() {
             },
             function(next) {
               Role.getRoles(
+                { principalType: RoleMapping.USER, principalId: user.id },
+                { returnOnlyRoleNames: true },
+                function(err, roles) {
+                  if (err) return next(err);
+                  expect(roles).to.eql([
+                    Role.AUTHENTICATED,
+                    Role.EVERYONE,
+                    role.name,
+                  ]);
+                  next();
+                });
+            },
+            function(next) {
+              Role.getRoles(
                 { principalType: RoleMapping.APP, principalId: user.id },
                 function(err, roles) {
                   if (err) return next(err);


### PR DESCRIPTION
Currently the return type of Role.getRoles() method is inconsistent: role names are returned for smart roles and role ids are returned for static roles (configured through user-role mapping).

This commit adds a new option to Role.getRoles() allowing the caller to request role names to be returned for all types of roles.

Backport #2975

cc @ebarault 