### PR TITLE
Allow password reset request for users in realms (v3.x)

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -559,11 +559,12 @@ module.exports = function(User) {
   };
 
   /**
-   * Create a short lived acess token for temporary login. Allows users
+   * Create a short lived access token for temporary login. Allows users
    * to change passwords if forgotten.
    *
    * @options {Object} options
    * @prop {String} email The user's email address
+   * @property {String} realm The user's realm (optional)
    * @callback {Function} callback
    * @param {Error} err
    * @promise
@@ -589,7 +590,13 @@ module.exports = function(User) {
     } catch (err) {
       return cb(err);
     }
-    UserModel.findOne({where: {email: options.email}}, function(err, user) {
+    var where = {
+      email: options.email,
+    };
+    if (options.realm) {
+      where.realm = options.realm;
+    }
+    UserModel.findOne({where: where}, function(err, user) {
       if (err) {
         return cb(err);
       }


### PR DESCRIPTION
### Description

Currently the User.resetPassword method only accepts an email address as a parameter.

When you have a LoopBack application that partitions the users in Realms you need to find the user based on it's email address + realm, because it allows for 2 users with the same email address.

This PR fixes the issue by adding support for an optional realm property, that will enhance the filter used in the findOne method.

#### Related issues

The issue fixed in this PR
#2866 

PR for v2.x:
#2980 

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)

