### PR TITLE
Opt-out downstream builds that are unstable

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,11 @@
   },
   "config": {
     "ci": {
-      "debug": "*,-mocha:*,-eslint:*"
+      "debug": "*,-mocha:*,-eslint:*",
+      "downstreamIgnoreList" : [
+        "dashboard-controller",
+        "gateway-director-management-interface"
+      ]
     }
   },
   "license": "MIT"


### PR DESCRIPTION
### Description
opting out of https://cis-jenkins.swg-devops.com/job/ds/job/dashboard-controller~master

#### Related issues
#2980 

repos that are opting out are not a good indicator of stability of
this module, and are failing