### PR TITLE
Remove "options.template" from Email payload

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -477,6 +477,10 @@ module.exports = function(User) {
       function setHtmlContentAndSend(html) {
         options.html = html;
 
+        // Remove options.template to prevent rejection by certain
+        // nodemailer transport plugins.
+        delete options.template;
+
         Email.send(options, function(err, email) {
           if (err) {
             fn(err);

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -1668,6 +1668,24 @@ describe('User', function() {
             done();
           });
       });
+
+      it('removes "options.template" from Email payload', function() {
+        var MailerMock = {
+          send: function(options, cb) { cb(null, options); },
+        };
+
+        return User.create({email: 'user@example.com', password: 'pass'})
+          .then(function(user) {
+            return user.verify({
+              type: 'email',
+              from: 'noreply@example.com',
+              mailer: MailerMock,
+            });
+          })
+          .then(function(result) {
+            expect(result.email).to.not.have.property('template');
+          });
+      });
     });
 
     describe('User.confirm(options, fn)', function() {


### PR DESCRIPTION
Fix User.confirm to exclude "options.template" when sending the confirmation email. Certain nodemailer transport plugins are rejecting such requests.

This patch supersedes abandoned #1831.

@loay or @superkhau  please review
cc @sharkinsspatial