### PR TITLE
Fix registration of operation hooks in User model (part 2)

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -682,15 +682,6 @@ module.exports = function(User) {
       }
     };
 
-    // Access token to normalize email credentials
-    UserModel.observe('access', function normalizeEmailCase(ctx, next) {
-      if (!ctx.Model.settings.caseSensitiveEmail && ctx.query.where &&
-          ctx.query.where.email && typeof(ctx.query.where.email) === 'string') {
-        ctx.query.where.email = ctx.query.where.email.toLowerCase();
-      }
-      next();
-    });
-
     // Make sure emailVerified is not set by creation
     UserModel.beforeRemote('create', function(ctx, user, next) {
       var body = ctx.req.body;
@@ -817,6 +808,15 @@ module.exports = function(User) {
   //
   // Important: Operation hooks are inherited by subclassed models,
   // therefore they must be registered outside of setup() function
+
+  // Access token to normalize email credentials
+  User.observe('access', function normalizeEmailCase(ctx, next) {
+    if (!ctx.Model.settings.caseSensitiveEmail && ctx.query.where &&
+        ctx.query.where.email && typeof(ctx.query.where.email) === 'string') {
+      ctx.query.where.email = ctx.query.where.email.toLowerCase();
+    }
+    next();
+  });
 
   // Delete old sessions once email is updated
   User.observe('before save', function beforeEmailUpdate(ctx, next) {


### PR DESCRIPTION
Follow-up for 4edce47 which moved only two out of three hooks. Sorry for the mess!