### PR TITLE
fix(user): Use User.createAccessToken in User.resetPassword

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -608,7 +608,7 @@ module.exports = function(User) {
         return cb(err);
       }
 
-      user.accessTokens.create({ttl: ttl}, function(err, accessToken) {
+      user.createAccessToken(ttl, function(err, accessToken) {
         if (err) {
           return cb(err);
         }


### PR DESCRIPTION
### Description

This makes it possible to use an overwritten User.createAccessToken function.

#### Related issues

- None

### Checklist

- [no need] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)