### PR TITLE
Inject remoting context to options arg

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -424,8 +424,38 @@ module.exports = function(registry) {
       options.isStatic = !m;
       name = options.isStatic ? name : m[1];
     }
+
+    if (options.accepts) {
+      options = extend({}, options);
+      options.accepts = setupOptionsArgs(options.accepts);
+    }
+
     this.sharedClass.defineMethod(name, options);
   };
+
+  function setupOptionsArgs(accepts) {
+    if (!Array.isArray(accepts))
+      accepts = [accepts];
+
+    return accepts.map(function(arg) {
+      if (arg.http && arg.http === 'optionsFromRequest') {
+        // deep clone to preserve the input value
+        arg = extend({}, arg);
+        arg.http = createOptionsViaModelMethod;
+      }
+      return arg;
+    });
+  }
+
+  function createOptionsViaModelMethod(ctx) {
+    var EMPTY_OPTIONS = {};
+    var ModelCtor = ctx.method && ctx.method.ctor;
+    if (!ModelCtor)
+      return EMPTY_OPTIONS;
+    if (typeof ModelCtor.createOptionsFromRemotingContext !== 'function')
+      return EMPTY_OPTIONS;
+    return ModelCtor.createOptionsFromRemotingContext(ctx);
+  }
 
   /**
    * Disable remote invocation for the method with the given name.
@@ -872,6 +902,46 @@ module.exports = function(registry) {
   };
 
   Model.ValidationError = require('loopback-datasource-juggler').ValidationError;
+
+  /**
+   * Create "options" value to use when invoking model methods
+   * via strong-remoting (e.g. REST).
+   *
+   * Example
+   *
+   * ```js
+   * MyModel.myMethod = function(options, cb) {
+   *   // by default, options contains only one property "accessToken"
+   *   var accessToken = options && options.accessToken;
+   *   var userId = accessToken && accessToken.userId;
+   *   var message = 'Hello ' + (userId ? 'user #' + userId : 'anonymous');
+   *   cb(null, message);
+   * });
+   *
+   * MyModel.remoteMethod('myMethod', {
+   *   accepts: {
+   *     arg: 'options',
+   *     type: 'object',
+   *     // "optionsFromRequest" is a loopback-specific HTTP mapping that
+   *     // calls Model's createOptionsFromRemotingContext
+   *     // to build the argument value
+   *     http: 'optionsFromRequest'
+   *    },
+   *    returns: {
+   *      arg: 'message',
+   *      type: 'string'
+   *    }
+   * });
+   * ```
+   *
+   * @param {Object} ctx A strong-remoting Context instance
+   * @returns {Object} The value to pass to "options" argument.
+   */
+  Model.createOptionsFromRemotingContext = function(ctx) {
+    return {
+      accessToken: ctx.req.accessToken,
+    };
+  };
 
   // setup the initial model
   Model.setup();

--- a/lib/model.js
+++ b/lib/model.js
@@ -9,6 +9,7 @@
 'use strict';
 var g = require('./globalize');
 var assert = require('assert');
+var debug = require('debug')('loopback:model');
 var RemoteObjects = require('strong-remoting');
 var SharedClass = require('strong-remoting').SharedClass;
 var extend = require('util')._extend;
@@ -136,15 +137,29 @@ module.exports = function(registry) {
     );
 
     // support remoting prototype methods
-    ModelCtor.sharedCtor = function(data, id, fn) {
+    ModelCtor.sharedCtor = function(data, id, options, fn) {
       var ModelCtor = this;
 
-      if (typeof data === 'function') {
+      var isRemoteInvocationWithOptions = typeof data !== 'object' &&
+        typeof id === 'object' &&
+        typeof options === 'function';
+      if (isRemoteInvocationWithOptions) {
+        // sharedCtor(id, options, fn)
+        fn = options;
+        options = id;
+        id = data;
+        data = null;
+      } else if (typeof data === 'function') {
+        // sharedCtor(fn)
         fn = data;
         data = null;
         id = null;
+        options = null;
       } else if (typeof id === 'function') {
+        // sharedCtor(data, fn)
+        // sharedCtor(id, fn)
         fn = id;
+        options = null;
 
         if (typeof data !== 'object') {
           id = data;
@@ -161,7 +176,8 @@ module.exports = function(registry) {
       } else if (data) {
         fn(null, new ModelCtor(data));
       } else if (id) {
-        ModelCtor.findById(id, function(err, model) {
+        var filter = {};
+        ModelCtor.findById(id, filter, options, function(err, model) {
           if (err) {
             fn(err);
           } else if (model) {
@@ -183,6 +199,7 @@ module.exports = function(registry) {
       {arg: 'id', type: 'any', required: true, http: {source: 'path'},
         description: idDesc},
       // {arg: 'instance', type: 'object', http: {source: 'body'}}
+      {arg: 'options', type: 'object', http: createOptionsViaModelMethod},
     ];
 
     ModelCtor.sharedCtor.http = [
@@ -232,6 +249,14 @@ module.exports = function(registry) {
     // resolve relation functions
     sharedClass.resolve(function resolver(define) {
       var relations = ModelCtor.relations || {};
+      var defineRaw = define;
+      define = function(name, options, fn) {
+        if (options.accepts) {
+          options = extend({}, options);
+          options.accepts = setupOptionsArgs(options.accepts);
+        }
+        defineRaw(name, options, fn);
+      };
 
       // get the relations
       for (var relationName in relations) {
@@ -439,7 +464,7 @@ module.exports = function(registry) {
 
     return accepts.map(function(arg) {
       if (arg.http && arg.http === 'optionsFromRequest') {
-        // deep clone to preserve the input value
+        // clone to preserve the input value
         arg = extend({}, arg);
         arg.http = createOptionsViaModelMethod;
       }
@@ -454,6 +479,7 @@ module.exports = function(registry) {
       return EMPTY_OPTIONS;
     if (typeof ModelCtor.createOptionsFromRemotingContext !== 'function')
       return EMPTY_OPTIONS;
+    debug('createOptionsFromRemotingContext for %s', ctx.method.stringName);
     return ModelCtor.createOptionsFromRemotingContext(ctx);
   }
 
@@ -494,7 +520,10 @@ module.exports = function(registry) {
     define('__get__' + relationName, {
       isStatic: false,
       http: {verb: 'get', path: '/' + pathName},
-      accepts: {arg: 'refresh', type: 'boolean', http: {source: 'query'}},
+      accepts: [
+        {arg: 'refresh', type: 'boolean', http: {source: 'query'}},
+        {arg: 'options', type: 'object', http: 'optionsFromRequest'},
+      ],
       accessType: 'READ',
       description: format('Fetches belongsTo relation %s.', relationName),
       returns: {arg: relationName, type: modelName, root: true},
@@ -519,7 +548,10 @@ module.exports = function(registry) {
     define('__get__' + relationName, {
       isStatic: false,
       http: {verb: 'get', path: '/' + pathName},
-      accepts: {arg: 'refresh', type: 'boolean', http: {source: 'query'}},
+      accepts: [
+        {arg: 'refresh', type: 'boolean', http: {source: 'query'}},
+        {arg: 'options', type: 'object', http: 'optionsFromRequest'},
+      ],
       description: format('Fetches hasOne relation %s.', relationName),
       accessType: 'READ',
       returns: {arg: relationName, type: relation.modelTo.modelName, root: true},
@@ -529,7 +561,13 @@ module.exports = function(registry) {
     define('__create__' + relationName, {
       isStatic: false,
       http: {verb: 'post', path: '/' + pathName},
-      accepts: {arg: 'data', type: 'object', model: toModelName, http: {source: 'body'}},
+      accepts: [
+        {
+          arg: 'data', type: 'object', model: toModelName,
+          http: {source: 'body'},
+        },
+        {arg: 'options', type: 'object', http: 'optionsFromRequest'},
+      ],
       description: format('Creates a new instance in %s of this model.', relationName),
       accessType: 'WRITE',
       returns: {arg: 'data', type: toModelName, root: true},
@@ -538,7 +576,13 @@ module.exports = function(registry) {
     define('__update__' + relationName, {
       isStatic: false,
       http: {verb: 'put', path: '/' + pathName},
-      accepts: {arg: 'data', type: 'object', model: toModelName, http: {source: 'body'}},
+      accepts: [
+        {
+          arg: 'data', type: 'object', model: toModelName,
+          http: {source: 'body'},
+        },
+        {arg: 'options', type: 'object', http: 'optionsFromRequest'},
+      ],
       description: format('Update %s of this model.', relationName),
       accessType: 'WRITE',
       returns: {arg: 'data', type: toModelName, root: true},
@@ -547,6 +591,9 @@ module.exports = function(registry) {
     define('__destroy__' + relationName, {
       isStatic: false,
       http: {verb: 'delete', path: '/' + pathName},
+      accepts: [
+        {arg: 'options', type: 'object', http: 'optionsFromRequest'},
+      ],
       description: format('Deletes %s of this model.', relationName),
       accessType: 'WRITE',
     });
@@ -560,10 +607,15 @@ module.exports = function(registry) {
     define('__findById__' + relationName, {
       isStatic: false,
       http: {verb: 'get', path: '/' + pathName + '/:fk'},
-      accepts: {arg: 'fk', type: 'any',
-        description: format('Foreign key for %s', relationName),
-        required: true,
-        http: {source: 'path'}},
+      accepts: [
+        {
+          arg: 'fk', type: 'any',
+          description: format('Foreign key for %s', relationName),
+          required: true,
+          http: {source: 'path'},
+        },
+        {arg: 'options', type: 'object', http: 'optionsFromRequest'},
+      ],
       description: format('Find a related item by id for %s.', relationName),
       accessType: 'READ',
       returns: {arg: 'result', type: toModelName, root: true},
@@ -574,10 +626,15 @@ module.exports = function(registry) {
     define('__destroyById__' + relationName, {
       isStatic: false,
       http: {verb: 'delete', path: '/' + pathName + '/:fk'},
-      accepts: {arg: 'fk', type: 'any',
-        description: format('Foreign key for %s', relationName),
-        required: true,
-        http: {source: 'path'}},
+      accepts: [
+        {
+          arg: 'fk', type: 'any',
+          description: format('Foreign key for %s', relationName),
+          required: true,
+          http: {source: 'path'},
+        },
+        {arg: 'options', type: 'object', http: 'optionsFromRequest'},
+      ],
       description: format('Delete a related item by id for %s.', relationName),
       accessType: 'WRITE',
       returns: [],
@@ -593,6 +650,7 @@ module.exports = function(registry) {
           required: true,
           http: {source: 'path'}},
         {arg: 'data', type: 'object', model: toModelName, http: {source: 'body'}},
+        {arg: 'options', type: 'object', http: 'optionsFromRequest'},
       ],
       description: format('Update a related item by id for %s.', relationName),
       accessType: 'WRITE',
@@ -618,7 +676,10 @@ module.exports = function(registry) {
         accepts: [{arg: 'fk', type: 'any',
           description: format('Foreign key for %s', relationName),
           required: true,
-          http: {source: 'path'}}].concat(accepts),
+          http: {source: 'path'}},
+        ].concat(accepts).concat([
+          {arg: 'options', type: 'object', http: 'optionsFromRequest'},
+        ]),
         description: format('Add a related item by id for %s.', relationName),
         accessType: 'WRITE',
         returns: {arg: relationName, type: modelThrough.modelName, root: true},
@@ -628,10 +689,15 @@ module.exports = function(registry) {
       define('__unlink__' + relationName, {
         isStatic: false,
         http: {verb: 'delete', path: '/' + pathName + '/rel/:fk'},
-        accepts: {arg: 'fk', type: 'any',
-          description: format('Foreign key for %s', relationName),
-          required: true,
-          http: {source: 'path'}},
+        accepts: [
+          {
+            arg: 'fk', type: 'any',
+            description: format('Foreign key for %s', relationName),
+            required: true,
+            http: {source: 'path'},
+          },
+          {arg: 'options', type: 'object', http: 'optionsFromRequest'},
+        ],
         description: format('Remove the %s relation to an item by id.', relationName),
         accessType: 'WRITE',
         returns: [],
@@ -643,10 +709,15 @@ module.exports = function(registry) {
       define('__exists__' + relationName, {
         isStatic: false,
         http: {verb: 'head', path: '/' + pathName + '/rel/:fk'},
-        accepts: {arg: 'fk', type: 'any',
-          description: format('Foreign key for %s', relationName),
-          required: true,
-          http: {source: 'path'}},
+        accepts: [
+          {
+            arg: 'fk', type: 'any',
+            description: format('Foreign key for %s', relationName),
+            required: true,
+            http: {source: 'path'},
+          },
+          {arg: 'options', type: 'object', http: 'optionsFromRequest'},
+        ],
         description: format('Check the existence of %s relation to an item by id.', relationName),
         accessType: 'READ',
         returns: {arg: 'exists', type: 'boolean', root: true},
@@ -689,7 +760,10 @@ module.exports = function(registry) {
     define('__get__' + scopeName, {
       isStatic: isStatic,
       http: {verb: 'get', path: '/' + pathName},
-      accepts: {arg: 'filter', type: 'object'},
+      accepts: [
+        {arg: 'filter', type: 'object'},
+        {arg: 'options', type: 'object', http: 'optionsFromRequest'},
+      ],
       description: format('Queries %s of %s.', scopeName, this.modelName),
       accessType: 'READ',
       returns: {arg: scopeName, type: [toModelName], root: true},
@@ -698,13 +772,16 @@ module.exports = function(registry) {
     define('__create__' + scopeName, {
       isStatic: isStatic,
       http: {verb: 'post', path: '/' + pathName},
-      accepts: {
-        arg: 'data',
-        type: 'object',
-        allowArray: true,
-        model: toModelName,
-        http: {source: 'body'},
-      },
+      accepts: [
+        {
+          arg: 'data',
+          type: 'object',
+          allowArray: true,
+          model: toModelName,
+          http: {source: 'body'},
+        },
+        {arg: 'options', type: 'object', http: 'optionsFromRequest'},
+      ],
       description: format('Creates a new instance in %s of this model.', scopeName),
       accessType: 'WRITE',
       returns: {arg: 'data', type: toModelName, root: true},
@@ -713,6 +790,16 @@ module.exports = function(registry) {
     define('__delete__' + scopeName, {
       isStatic: isStatic,
       http: {verb: 'delete', path: '/' + pathName},
+      accepts: [
+        {
+          arg: 'where', type: 'object',
+          // The "where" argument is not exposed in the REST API
+          // but we need to provide a value so that we can pass "options"
+          // as the third argument.
+          http: function(ctx) { return undefined; },
+        },
+        {arg: 'options', type: 'object', http: 'optionsFromRequest'},
+      ],
       description: format('Deletes all %s of this model.', scopeName),
       accessType: 'WRITE',
     });
@@ -720,8 +807,13 @@ module.exports = function(registry) {
     define('__count__' + scopeName, {
       isStatic: isStatic,
       http: {verb: 'get', path: '/' + pathName + '/count'},
-      accepts: {arg: 'where', type: 'object',
-        description: 'Criteria to match model instances'},
+      accepts: [
+        {
+          arg: 'where', type: 'object',
+          description: 'Criteria to match model instances',
+        },
+        {arg: 'options', type: 'object', http: 'optionsFromRequest'},
+      ],
       description: format('Counts %s of %s.', scopeName, this.modelName),
       accessType: 'READ',
       returns: {arg: 'count',  type: 'number'},

--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -639,11 +639,14 @@ module.exports = function(registry) {
     setRemoting(PersistedModel, 'create', {
       description: 'Create a new instance of the model and persist it into the data source.',
       accessType: 'WRITE',
-      accepts: {
-        arg: 'data', type: 'object', model: typeName, allowArray: true,
-        description: 'Model instance data',
-        http: {source: 'body'},
-      },
+      accepts: [
+        {
+          arg: 'data', type: 'object', model: typeName, allowArray: true,
+          description: 'Model instance data',
+          http: {source: 'body'},
+        },
+        {arg: 'options', type: 'object', http: 'optionsFromRequest'},
+      ],
       returns: {arg: 'data', type: typeName, root: true},
       http: {verb: 'post', path: '/'},
     });
@@ -653,10 +656,13 @@ module.exports = function(registry) {
       description: 'Patch an existing model instance or insert a new one ' +
         'into the data source.',
       accessType: 'WRITE',
-      accepts: {
-        arg: 'data', type: 'object', model: typeName, http: {source: 'body'},
-        description: 'Model instance data',
-      },
+      accepts: [
+        {
+          arg: 'data', type: 'object', model: typeName, http: {source: 'body'},
+          description: 'Model instance data',
+        },
+        {arg: 'options', type: 'object', http: 'optionsFromRequest'},
+      ],
       returns: {arg: 'data', type: typeName, root: true},
       http: [{verb: 'patch', path: '/'}],
     };
@@ -669,11 +675,14 @@ module.exports = function(registry) {
     var replaceOrCreateOptions = {
       description: 'Replace an existing model instance or insert a new one into the data source.',
       accessType: 'WRITE',
-      accepts: {
-        arg: 'data', type: 'object', model: typeName,
-        http: {source: 'body'},
-        description: 'Model instance data',
-      },
+      accepts: [
+        {
+          arg: 'data', type: 'object', model: typeName,
+          http: {source: 'body'},
+          description: 'Model instance data',
+        },
+        {arg: 'options', type: 'object', http: 'optionsFromRequest'},
+      ],
       returns: {arg: 'data', type: typeName, root: true},
       http: [{verb: 'post', path: '/replaceOrCreate'}],
     };
@@ -694,6 +703,7 @@ module.exports = function(registry) {
           description: 'Criteria to match model instances'},
         {arg: 'data', type: 'object', model: typeName, http: {source: 'body'},
           description: 'An object of model property name/value pairs'},
+        {arg: 'options', type: 'object', http: 'optionsFromRequest'},
       ],
       returns: {arg: 'data', type: typeName, root: true},
       http: {verb: 'post', path: '/upsertWithWhere'},
@@ -702,7 +712,10 @@ module.exports = function(registry) {
     setRemoting(PersistedModel, 'exists', {
       description: 'Check whether a model instance exists in the data source.',
       accessType: 'READ',
-      accepts: {arg: 'id', type: 'any', description: 'Model id', required: true},
+      accepts: [
+        {arg: 'id', type: 'any', description: 'Model id', required: true},
+        {arg: 'options', type: 'object', http: 'optionsFromRequest'},
+      ],
       returns: {arg: 'exists', type: 'boolean'},
       http: [
         {verb: 'get', path: '/:id/exists'},
@@ -738,6 +751,7 @@ module.exports = function(registry) {
           http: {source: 'path'}},
         {arg: 'filter', type: 'object',
           description: 'Filter defining fields and include'},
+        {arg: 'options', type: 'object', http: 'optionsFromRequest'},
       ],
       returns: {arg: 'data', type: typeName, root: true},
       http: {verb: 'get', path: '/:id'},
@@ -751,7 +765,8 @@ module.exports = function(registry) {
         {arg: 'id', type: 'any', description: 'Model id', required: true,
           http: {source: 'path'}},
         {arg: 'data', type: 'object', model: typeName, http: {source: 'body'}, description:
-        'Model instance data'},
+          'Model instance data'},
+        {arg: 'options', type: 'object', http: 'optionsFromRequest'},
       ],
       returns: {arg: 'data', type: typeName, root: true},
       http: [{verb: 'post', path: '/:id/replace'}],
@@ -766,8 +781,11 @@ module.exports = function(registry) {
     setRemoting(PersistedModel, 'find', {
       description: 'Find all instances of the model matched by filter from the data source.',
       accessType: 'READ',
-      accepts: {arg: 'filter', type: 'object', description:
-        'Filter defining fields, where, include, order, offset, and limit'},
+      accepts: [
+        {arg: 'filter', type: 'object', description:
+          'Filter defining fields, where, include, order, offset, and limit'},
+        {arg: 'options', type: 'object', http: 'optionsFromRequest'},
+      ],
       returns: {arg: 'data', type: [typeName], root: true},
       http: {verb: 'get', path: '/'},
     });
@@ -775,8 +793,11 @@ module.exports = function(registry) {
     setRemoting(PersistedModel, 'findOne', {
       description: 'Find first instance of the model matched by filter from the data source.',
       accessType: 'READ',
-      accepts: {arg: 'filter', type: 'object', description:
-        'Filter defining fields, where, include, order, offset, and limit'},
+      accepts: [
+        {arg: 'filter', type: 'object', description:
+          'Filter defining fields, where, include, order, offset, and limit'},
+        {arg: 'options', type: 'object', http: 'optionsFromRequest'},
+      ],
       returns: {arg: 'data', type: typeName, root: true},
       http: {verb: 'get', path: '/findOne'},
       rest: {after: convertNullToNotFoundError},
@@ -785,7 +806,10 @@ module.exports = function(registry) {
     setRemoting(PersistedModel, 'destroyAll', {
       description: 'Delete all matching records.',
       accessType: 'WRITE',
-      accepts: {arg: 'where', type: 'object', description: 'filter.where object'},
+      accepts: [
+        {arg: 'where', type: 'object', description: 'filter.where object'},
+        {arg: 'options', type: 'object', http: 'optionsFromRequest'},
+      ],
       returns: {
         arg: 'count',
         type: 'object',
@@ -805,6 +829,7 @@ module.exports = function(registry) {
           description: 'Criteria to match model instances'},
         {arg: 'data', type: 'object', model: typeName, http: {source: 'body'},
           description: 'An object of model property name/value pairs'},
+        {arg: 'options', type: 'object', http: 'optionsFromRequest'},
       ],
       returns: {
         arg: 'info',
@@ -824,8 +849,11 @@ module.exports = function(registry) {
       aliases: ['destroyById', 'removeById'],
       description: 'Delete a model instance by {{id}} from the data source.',
       accessType: 'WRITE',
-      accepts: {arg: 'id', type: 'any', description: 'Model id', required: true,
-        http: {source: 'path'}},
+      accepts: [
+        {arg: 'id', type: 'any', description: 'Model id', required: true,
+          http: {source: 'path'}},
+        {arg: 'options', type: 'object', http: 'optionsFromRequest'},
+      ],
       http: {verb: 'del', path: '/:id'},
       returns: {arg: 'count', type: 'object', root: true},
     });
@@ -833,7 +861,10 @@ module.exports = function(registry) {
     setRemoting(PersistedModel, 'count', {
       description: 'Count instances of the model matched by where from the data source.',
       accessType: 'READ',
-      accepts: {arg: 'where', type: 'object', description: 'Criteria to match model instances'},
+      accepts: [
+        {arg: 'where', type: 'object', description: 'Criteria to match model instances'},
+        {arg: 'options', type: 'object', http: 'optionsFromRequest'},
+      ],
       returns: {arg: 'count', type: 'number'},
       http: {verb: 'get', path: '/count'},
     });
@@ -843,11 +874,14 @@ module.exports = function(registry) {
       description: 'Patch attributes for a model instance and persist it into ' +
         'the data source.',
       accessType: 'WRITE',
-      accepts: {
-        arg: 'data', type: 'object', model: typeName,
-        http: {source: 'body'},
-        description: 'An object of model property name/value pairs',
-      },
+      accepts: [
+        {
+          arg: 'data', type: 'object', model: typeName,
+          http: {source: 'body'},
+          description: 'An object of model property name/value pairs',
+        },
+        {arg: 'options', type: 'object', http: 'optionsFromRequest'},
+      ],
       returns: {arg: 'data', type: typeName, root: true},
       http: [{verb: 'patch', path: '/'}],
     };

--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
     "sinon-chai": "^2.8.0",
     "strong-error-handler": "^1.0.1",
     "strong-task-emitter": "^0.0.6",
-    "supertest": "^2.0.0"
+    "supertest": "^2.0.0",
+    "supertest-as-promised": "^4.0.2"
   },
   "repository": {
     "type": "git",

--- a/test/context-options.test.js
+++ b/test/context-options.test.js
@@ -1,0 +1,411 @@
+// Copyright IBM Corp. 2013,2016. All Rights Reserved.
+// Node module: loopback
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+var expect = require('chai').expect;
+var loopback = require('..');
+var supertest = require('supertest-as-promised')(require('bluebird'));
+
+describe('OptionsFromRemotingContext', function() {
+  var app, request, accessToken, userId, Product, actualOptions;
+
+  beforeEach(setupAppAndRequest);
+  beforeEach(resetActualOptions);
+
+  context('when making updates via REST', function() {
+    beforeEach(observeOptionsBeforeSave);
+
+    it('injects options to create()', function() {
+      return request.post('/products')
+        .send({name: 'Pen'})
+        .expect(200)
+        .then(expectInjectedOptions);
+    });
+
+    it('injects options to patchOrCreate()', function() {
+      return request.patch('/products')
+        .send({id: 1, name: 'Pen'})
+        .expect(200)
+        .then(expectInjectedOptions);
+    });
+
+    it('injects options to replaceOrCreate()', function() {
+      return request.put('/products')
+        .send({id: 1, name: 'Pen'})
+        .expect(200)
+        .then(expectInjectedOptions);
+    });
+
+    it('injects options to patchOrCreateWithWhere()', function() {
+      return request.post('/products/upsertWithWhere?where[name]=Pen')
+        .send({name: 'Pencil'})
+        .expect(200)
+        .then(expectInjectedOptions);
+    });
+
+    it('injects options to replaceById()', function() {
+      return Product.create({id: 1, name: 'Pen'})
+        .then(function(p) {
+          return request.put('/products/1')
+            .send({name: 'Pencil'})
+            .expect(200);
+        })
+        .then(expectInjectedOptions);
+    });
+
+    it('injects options to prototype.patchAttributes()', function() {
+      return Product.create({id: 1, name: 'Pen'})
+        .then(function(p) {
+          return request.patch('/products/1')
+            .send({name: 'Pencil'})
+            .expect(200);
+        })
+        .then(expectInjectedOptions);
+    });
+
+    it('injects options to updateAll()', function() {
+      return request.post('/products/update?where[name]=Pen')
+        .send({name: 'Pencil'})
+        .expect(200)
+        .then(expectInjectedOptions);
+    });
+  });
+
+  context('when deleting via REST', function() {
+    beforeEach(observeOptionsBeforeDelete);
+
+    it('injects options to deleteById()', function() {
+      return Product.create({id: 1, name: 'Pen'})
+        .then(function(p) {
+          return request.delete('/products/1').expect(200);
+        })
+        .then(expectInjectedOptions);
+    });
+  });
+
+  context('when querying via REST', function() {
+    beforeEach(observeOptionsOnAccess);
+    beforeEach(givenProductId1);
+
+    it('injects options to find()', function() {
+      return request.get('/products').expect(200)
+        .then(expectInjectedOptions);
+    });
+
+    it('injects options to findById()', function() {
+      return request.get('/products/1').expect(200)
+        .then(expectInjectedOptions);
+    });
+
+    it('injects options to findOne()', function() {
+      return request.get('/products/findOne?where[id]=1').expect(200)
+        .then(expectInjectedOptions);
+    });
+
+    it('injects options to exists()', function() {
+      return request.head('/products/1').expect(200)
+        .then(expectInjectedOptions);
+    });
+
+    it('injects options to count()', function() {
+      return request.get('/products/count').expect(200)
+        .then(expectInjectedOptions);
+    });
+  });
+
+  context('when invoking prototype methods', function() {
+    beforeEach(observeOptionsOnAccess);
+    beforeEach(givenProductId1);
+
+    it('injects options to sharedCtor', function() {
+      Product.prototype.dummy = function(cb) { cb(); };
+      Product.remoteMethod('prototype.dummy', {});
+      return request.post('/products/1/dummy').expect(204)
+        .then(expectInjectedOptions);
+    });
+  });
+
+  // Catch: because relations methods are defined on "modelFrom",
+  // they will invoke createOptionsFromRemotingContext on "modelFrom" too,
+  // despite the fact that under the hood a method on "modelTo" is called.
+
+  context('hasManyThrough', function() {
+    var Category, ThroughModel;
+
+    beforeEach(givenCategoryHasManyProductsThroughAnotherModel);
+    beforeEach(givenCategoryAndProduct);
+
+    it('injects options to findById', function() {
+      observeOptionsOnAccess(Product);
+      return request.get('/categories/1/products/1').expect(200)
+        .then(expectOptionsInjectedFromCategory);
+    });
+
+    it('injects options to destroyById', function() {
+      observeOptionsBeforeDelete(Product);
+      return request.del('/categories/1/products/1').expect(204)
+        .then(expectOptionsInjectedFromCategory);
+    });
+
+    it('injects options to updateById', function() {
+      observeOptionsBeforeSave(Product);
+      return request.put('/categories/1/products/1')
+        .send({description: 'a description'})
+        .expect(200)
+        .then(expectInjectedOptions);
+    });
+
+    context('through-model operations', function() {
+      it('injects options to link', function() {
+        observeOptionsBeforeSave(ThroughModel);
+        return Product.create({id: 2, name: 'Car2'})
+          .then(function() {
+            return request.put('/categories/1/products/rel/2')
+              .send({description: 'a description'})
+              .expect(200);
+          })
+          .then(expectOptionsInjectedFromCategory);
+      });
+
+      it('injects options to unlink', function() {
+        observeOptionsBeforeDelete(ThroughModel);
+        return request.del('/categories/1/products/rel/1').expect(204)
+          .then(expectOptionsInjectedFromCategory);
+      });
+
+      it('injects options to exists', function() {
+        observeOptionsOnAccess(ThroughModel);
+        return request.head('/categories/1/products/rel/1').expect(200)
+          .then(expectOptionsInjectedFromCategory);
+      });
+    });
+
+    context('scope operations', function() {
+      it('injects options to get', function() {
+        observeOptionsOnAccess(Product);
+        return request.get('/categories/1/products').expect(200)
+          .then(expectOptionsInjectedFromCategory);
+      });
+
+      it('injects options to create', function() {
+        observeOptionsBeforeSave(Product);
+        return request.post('/categories/1/products')
+          .send({name: 'Pen'})
+          .expect(200)
+          .then(expectOptionsInjectedFromCategory);
+      });
+
+      it('injects options to delete', function() {
+        observeOptionsBeforeDelete(ThroughModel);
+        return request.del('/categories/1/products').expect(204)
+          .then(expectOptionsInjectedFromCategory);
+      });
+
+      it('injects options to count', function() {
+        observeOptionsOnAccess(ThroughModel);
+        return request.get('/categories/1/products/count').expect(200)
+          .then(expectOptionsInjectedFromCategory);
+      });
+    });
+
+    function givenCategoryHasManyProductsThroughAnotherModel() {
+      Category = app.registry.createModel(
+        'Category',
+        {name: String},
+        {forceId: false, replaceOnPUT: true});
+
+      app.model(Category, {dataSource: 'db'});
+      // This is a shortcut for creating CategoryProduct "through" model
+      Category.hasAndBelongsToMany(Product);
+
+      Category.createOptionsFromRemotingContext = function(ctx) {
+        return {injectedFrom: 'Category'};
+      };
+
+      ThroughModel = app.registry.getModel('CategoryProduct');
+    }
+
+    function givenCategoryAndProduct() {
+      return Category.create({id: 1, name: 'First Category'})
+        .then(function(cat) {
+          return cat.products.create({id: 1, name: 'Pen'});
+        });
+    }
+
+    function expectOptionsInjectedFromCategory() {
+      expect(actualOptions).to.have.property('injectedFrom', 'Category');
+    }
+  });
+
+  context('hasOne', function() {
+    var Category;
+
+    beforeEach(givenCategoryHasOneProduct);
+    beforeEach(givenCategoryId1);
+
+    it('injects options to get', function() {
+      observeOptionsOnAccess(Product);
+      return givenProductInCategory1()
+        .then(function() {
+          return request.get('/categories/1/product').expect(200);
+        })
+        .then(expectOptionsInjectedFromCategory);
+    });
+
+    it('injects options to create', function() {
+      observeOptionsBeforeSave(Product);
+      return request.post('/categories/1/product')
+        .send({name: 'Pen'})
+        .expect(200)
+        .then(expectOptionsInjectedFromCategory);
+    });
+
+    it('injects options to update', function() {
+      return givenProductInCategory1()
+        .then(function() {
+          observeOptionsBeforeSave(Product);
+          return request.put('/categories/1/product')
+            .send({description: 'a description'})
+            .expect(200);
+        })
+        .then(expectInjectedOptions);
+    });
+
+    it('injects options to destroy', function() {
+      observeOptionsBeforeDelete(Product);
+      return givenProductInCategory1()
+        .then(function() {
+          return request.del('/categories/1/product').expect(204);
+        })
+        .then(expectOptionsInjectedFromCategory);
+    });
+
+    function givenCategoryHasOneProduct() {
+      Category = app.registry.createModel(
+        'Category',
+        {name: String},
+        {forceId: false, replaceOnPUT: true});
+
+      app.model(Category, {dataSource: 'db'});
+      Category.hasOne(Product);
+
+      Category.createOptionsFromRemotingContext = function(ctx) {
+        return {injectedFrom: 'Category'};
+      };
+    }
+
+    function givenCategoryId1() {
+      return Category.create({id: 1, name: 'First Category'});
+    }
+
+    function givenProductInCategory1() {
+      return Product.create({id: 1, name: 'Pen', categoryId: 1});
+    }
+
+    function expectOptionsInjectedFromCategory() {
+      expect(actualOptions).to.have.property('injectedFrom', 'Category');
+    }
+  });
+
+  context('belongsTo', function() {
+    var Category;
+
+    beforeEach(givenCategoryBelongsToProduct);
+
+    it('injects options to get', function() {
+      observeOptionsOnAccess(Product);
+      return Product.create({id: 1, name: 'Pen'})
+        .then(function() {
+          return Category.create({id: 1, name: 'a name', productId: 1});
+        })
+        .then(function() {
+          return request.get('/categories/1/product').expect(200);
+        })
+        .then(expectOptionsInjectedFromCategory);
+    });
+
+    function givenCategoryBelongsToProduct() {
+      Category = app.registry.createModel(
+        'Category',
+        {name: String},
+        {forceId: false, replaceOnPUT: true});
+
+      app.model(Category, {dataSource: 'db'});
+      Category.belongsTo(Product);
+
+      Category.createOptionsFromRemotingContext = function(ctx) {
+        return {injectedFrom: 'Category'};
+      };
+    }
+
+    function givenCategoryId1() {
+      return Category.create({id: 1, name: 'First Category'});
+    }
+
+    function givenProductInCategory1() {
+      return Product.create({id: 1, name: 'Pen', categoryId: 1});
+    }
+
+    function expectOptionsInjectedFromCategory() {
+      expect(actualOptions).to.have.property('injectedFrom', 'Category');
+    }
+  });
+
+  function setupAppAndRequest() {
+    app = loopback({localRegistry: true});
+    app.dataSource('db', {connector: 'memory'});
+
+    Product = app.registry.createModel(
+      'Product',
+      {name: String},
+      {forceId: false, replaceOnPUT: true});
+
+    Product.createOptionsFromRemotingContext = function(ctx) {
+      return {injectedFrom: 'Product'};
+    };
+
+    app.model(Product, {dataSource: 'db'});
+
+    app.use(loopback.rest());
+    request = supertest(app);
+  }
+
+  function resetActualOptions() {
+    actualOptions = undefined;
+  }
+
+  function observeOptionsBeforeSave() {
+    var Model = arguments[0] || Product;
+    Model.observe('before save', function(ctx, next) {
+      actualOptions = ctx.options;
+      next();
+    });
+  }
+
+  function observeOptionsBeforeDelete() {
+    var Model = arguments[0] || Product;
+    Model.observe('before delete', function(ctx, next) {
+      actualOptions = ctx.options;
+      next();
+    });
+  }
+
+  function observeOptionsOnAccess() {
+    var Model = arguments[0] || Product;
+    Model.observe('access', function(ctx, next) {
+      actualOptions = ctx.options;
+      next();
+    });
+  }
+
+  function givenProductId1() {
+    return Product.create({id: 1, name: 'Pen'});
+  }
+
+  function expectInjectedOptions(name) {
+    expect(actualOptions).to.have.property('injectedFrom');
+  }
+});

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -886,4 +886,108 @@ describe.onServer('Remote Methods', function() {
       // fails on time-out when not implemented correctly
     });
   });
+
+  describe('Model.createOptionsFromRemotingContext', function() {
+    var app, TestModel, accessToken, userId, actualOptions;
+
+    before(setupAppAndRequest);
+    before(createUserAndAccessToken);
+
+    it('sets empty options.accessToken for anonymous requests', function(done) {
+      request(app).get('/TestModels/saveOptions')
+        .expect(204, function(err) {
+          if (err) return done(err);
+          expect(actualOptions).to.eql({accessToken: null});
+          done();
+        });
+    });
+
+    it('sets options.accessToken for authorized requests', function(done) {
+      request(app).get('/TestModels/saveOptions')
+        .set('Authorization', accessToken.id)
+        .expect(204, function(err) {
+          if (err) return done(err);
+          expect(actualOptions).to.have.property('accessToken');
+          expect(actualOptions.accessToken.toObject())
+            .to.eql(accessToken.toObject());
+          done();
+        });
+    });
+
+    it('allows "beforeRemote" hooks to contribute options', function(done) {
+      TestModel.beforeRemote('saveOptions', function(ctx, unused, next) {
+        ctx.args.options.hooked = true;
+        next();
+      });
+
+      request(app).get('/TestModels/saveOptions')
+        .expect(204, function(err) {
+          if (err) return done(err);
+          expect(actualOptions).to.have.property('hooked', true);
+          done();
+        });
+    });
+
+    it('allows apps to add options before remoting hooks', function(done) {
+      TestModel.createOptionsFromRemotingContext = function(ctx) {
+        return {hooks: []};
+      };
+
+      TestModel.beforeRemote('saveOptions', function(ctx, unused, next) {
+        ctx.args.options.hooks.push('beforeRemote');
+        next();
+      });
+
+      // In real apps, this code can live in a component or in a boot script
+      app.remotes().phases
+        .addBefore('invoke', 'options-from-request')
+        .use(function(ctx, next) {
+          ctx.args.options.hooks.push('custom');
+          next();
+        });
+
+      request(app).get('/TestModels/saveOptions')
+        .expect(204, function(err) {
+          if (err) return done(err);
+          expect(actualOptions.hooks).to.eql(['custom', 'beforeRemote']);
+          done();
+        });
+    });
+
+    function setupAppAndRequest() {
+      app = loopback({localRegistry: true, loadBuiltinModels: true});
+
+      app.dataSource('db', {connector: 'memory'});
+
+      TestModel = app.registry.createModel('TestModel', {base: 'Model'});
+      TestModel.saveOptions = function(options, cb) {
+        actualOptions = options;
+        cb();
+      };
+
+      TestModel.remoteMethod('saveOptions', {
+        accepts: {arg: 'options', type: 'object', http: 'optionsFromRequest'},
+        http: {verb: 'GET', path: '/saveOptions'},
+      });
+
+      app.model(TestModel, {dataSource: null});
+
+      app.enableAuth({dataSource: 'db'});
+
+      app.use(loopback.token());
+      app.use(loopback.rest());
+    }
+
+    function createUserAndAccessToken() {
+      var CREDENTIALS = {email: 'context@example.com', password: 'pass'};
+      var User = app.registry.getModel('User');
+      return User.create(CREDENTIALS)
+        .then(function(u) {
+          return User.login(CREDENTIALS);
+        }).then(function(token) {
+          accessToken = token;
+          userId = token.userId;
+        });
+    }
+  });
 });

--- a/test/remote-connector.test.js
+++ b/test/remote-connector.test.js
@@ -82,7 +82,7 @@ describe('RemoteConnector', function() {
 
     var ServerModel = this.ServerModel;
 
-    ServerModel.create = function(data, cb) {
+    ServerModel.create = function(data, options, cb) {
       calledServerCreate = true;
       data.id = 1;
       cb(null, data);

--- a/test/remoting.integration.js
+++ b/test/remoting.integration.js
@@ -280,7 +280,9 @@ function formatMethod(m) {
     arr.push([
       m.name,
       '(',
-      m.accepts.map(function(a) {
+      m.accepts.filter(function(a) {
+        return !(a.http && typeof a.http === 'function');
+      }).map(function(a) {
         return a.arg + ':' + a.type + (a.model ? ':' + a.model : '');
       }).join(','),
       ')',


### PR DESCRIPTION
Based on the feedback in #2762 and #1676, I would like to discuss a slightly improved proposal for [Injecting Remote Context via Options](https://github.com/strongloop/loopback/issues/1495).

Important points I am addressing:

 1. The "options" argument must be initialised in such way that HTTP clients cannot inject unwanted properties. E.g. the client must not be able to inject `options.accessToken` to override the access token set by the authorisation layer.
 2. The injected "options" argument must be "hidden" and excluded from the Swagger resource generated by `loopback-swagger`
 3. Developers must be able to configure the "options" argument via model JSON files
 4. It should be easy to customise the way how the "options" argument is built, preferably via a mixin. It should be easy to share and reuse such customisation via a loopback component (a standalone npm package).
 5. Ideally, multiple mixins can contribute additional context properties.
 6. Some context properties (e.g. full `currentUser`) may require async computation. This use case should be supported too.

Because we are unlikely to get this new API right on the first try, and because experimenting with features is difficult in LoopBack core, I would like to ship a minimal infrastructure that will allow 3rd party components to experiment with different approaches for building the "options" object, as we are already seeing to happen:

 - https://github.com/snowyu/loopback-component-remote-ctx.js
 - https://gist.github.com/ebarault/fdc39c5d07cc40f08664256f9e00905a

**Solution details**

Methods accepting an `options` argument should declare this argument in their remoting metadata and use a special value `optionsFromRequest` as the `http` mapping. This way there is no magic happening in `beforeRemote` hooks and method authors are in full control of how the `options` argument is (or is not) initialized.

Under the hood, this "magic string" value is converted by `Model.remoteMethod` to a function for strong-remoting, i.e. strong-remoting receives `accepts.http` as a function, which is already a well-supported use case.


An example using a trimmed-down metadata of `PersistedModel.create`:

``` js
PersistedModel.remoteMethod('create', {
  accepts: [
    {arg: 'data', type: 'object', model: typeName, http: {source: 'body'}},
    {arg: 'options', type: 'object', http: 'optionsFromRequest'},
  ],
  returns: {arg: 'data', type: typeName, root: true},
  http: {verb: 'post', path: '/'},
});
```

At runtime, `optionsFromRequest` invokes a static Model method called `createOptionsFromRemotingContext` to build the argument value. Subclasses and mixins are free to override this method, e.g. to return a class instance as shown in https://gist.github.com/ebarault/fdc39c5d07cc40f08664256f9e00905a.

In line with my goal of keeping this feature minimal, the built-in method returns options with a single property `accessToken`:

```js
  Model.createOptionsFromRemotingContext = function(ctx) {
    return {
      accessToken: ctx.req.accessToken,
    };
  };
```

**Extending the "options" object**

 1. Override `createOptionsFromRemotingContext` in your Model:

    ```js
    MyModel.createOptionsFromRemotingContext = function(ctx) {
      var base = this.base.createOptionsFromRemotingContext(ctx);
      return extend(base, {
        currentUserId: base.accessToken && base.accessToken.userId,
      });
    };
    ```

 1. Use a "beforeRemote" hook

    ```js
    MyModel.beforeRemote('saveOptions', function(ctx, unused, next) {
      if (!ctx.args.options.accessToken) return next();
      User.findById(ctx.args.options.accessToken.userId, function(err, user) {
        if (err) return next(err);
        ctx.args.options.currentUser = user;
        next();
      });
    });
    ```

 3. Use a custom strong-remoting phase that's run before any remoting hooks are triggered

    ```js
      app.remotes().phases
        .addBefore('invoke', 'options-from-request')
        .use(function(ctx, next) {
          if (!ctx.args.options.accessToken) return next();
          User.findById(ctx.args.options.accessToken.userId, function(err, user) {
            if (err) return next(err);
            ctx.args.options.currentUser = user;
            next();
          });
        });
    ```

**Caveats**

Relations methods are defined on "modelFrom", therefore they will invoke `createOptionsFromRemotingContext` on "modelFrom" too, despite the fact that under the hood a method on "modelTo" is called.

For example, if we have a relation called `Category hasMany Product`, then a request to `/categories/1/products` will call `Category.createOptionsFromRemotingContext` to build an options object that will be eventually passed to `Product.find`. This is a limitation of the current implementation of scope/relation methods, fixing it is out of scope of this pull request.

**Tasks**

- [x] Implement `optionsFromContext`
- [x] Modify `PersistedModel` methods
- [x] Modify relation methods

Out of scope:

- Propagate `options` in the authentication layer, see https://github.com/ebarault/loopback-sandbox/commit/09b9a8ccb76d426f8b3e20bc4b4f774f5a25fe61  

**What's next**

I would like to get more feedback on my proposal before moving forward.

 - @fabien @ebarault @snowyu @doublemarked  I hope that the solution proposed here will allow you to simplify the implementation of your custom "options"/"remotingContext" builders, so that you can remove the code injecting the "options" arg and focus on building the "options" arg instead. What's your opinion? Is there anything missing in my proposal, something that you would have to work-around in your mixins/components?
 - @raymondfeng @ritch What's your take? I know this proposal is probably not ideal and we may want to implement a different/better solution in long term. However, my intention here is to offer a reasonable solution that LoopBack users can start using *now*, instead of waiting for a hypothetical unicorn from the future.
 - @pulkitsinghal @diadara @azatoth @digitalsadhu @dancingshell @a-legrand @bostondv @yagobski @nidhhoggr @ryedin @ezraroi @rimvydas-urbonas @Morriz @wprater @eggerdo @hotaru355 @kevinsschmidt @tomhallam @pkgulati @souluniversal @pbtcjasper @denkan @mrfelton @zanemcca @guanbo @pongstr  @skyserpent @pkgulati @Saganus @chris-hydra @aorlic @fperks I am pinging you, since you were involved in the discussion at some point in the past. Do you have any opinion on my proposal? (I apologise to everyone who may feel spammed.)