### PR TITLE
Allow hash path in redirectUrl

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -427,7 +427,7 @@ module.exports = function(User) {
       '?uid=' +
       options.user.id +
       '&redirect=' +
-      options.redirect;
+      encodeURIComponent(options.redirect);
 
     options.templateFn = options.templateFn || createVerificationEmailBody;
 
@@ -814,7 +814,7 @@ module.exports = function(User) {
         if (!ctx.res) {
           return next(new Error(g.f('The transport does not support HTTP redirects.')));
         }
-        ctx.res.location(ctx.args.redirect);
+        ctx.res.location(decodeURIComponent(ctx.args.redirect));
         ctx.res.status(302);
       }
       next();


### PR DESCRIPTION
### Description
Allows GET variables and hash paths for redirecting user after email confirm.

#### Related issues

- #2307
