### PR TITLE
Improve base User extensibility

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -661,48 +661,8 @@ module.exports = function(User) {
     AccessToken.deleteAll({userId: {inq: userIds}}, cb);
   };
 
-  /*!
-   * Setup an extended user model.
-   */
-
-  User.setup = function() {
-    // We need to call the base class's setup method
-    User.base.setup.call(this);
+  User.setupRemoteMethods = function() {
     var UserModel = this;
-
-    // max ttl
-    this.settings.maxTTL = this.settings.maxTTL || DEFAULT_MAX_TTL;
-    this.settings.ttl = this.settings.ttl || DEFAULT_TTL;
-
-    UserModel.setter.email = function(value) {
-      if (!UserModel.settings.caseSensitiveEmail) {
-        this.$email = value.toLowerCase();
-      } else {
-        this.$email = value;
-      }
-    };
-
-    UserModel.setter.password = function(plain) {
-      if (typeof plain !== 'string') {
-        return;
-      }
-      if (plain.indexOf('$2a$') === 0 && plain.length === 60) {
-        // The password is already hashed. It can be the case
-        // when the instance is loaded from DB
-        this.$password = plain;
-      } else {
-        this.$password = this.constructor.hashPassword(plain);
-      }
-    };
-
-    // Make sure emailVerified is not set by creation
-    UserModel.beforeRemote('create', function(ctx, user, next) {
-      var body = ctx.req.body;
-      if (body && body.emailVerified) {
-        body.emailVerified = false;
-      }
-      next();
-    });
 
     UserModel.remoteMethod(
       'login',
@@ -780,13 +740,35 @@ module.exports = function(User) {
       }
       next();
     });
+  };
+
+  User.setupEmail = function() {
+    var UserModel = this;
+
+    UserModel.setter.email = function(value) {
+      if (!UserModel.settings.caseSensitiveEmail) {
+        this.$email = value.toLowerCase();
+      } else {
+        this.$email = value;
+      }
+    };
+
+    // Make sure emailVerified is not set by creation
+    UserModel.beforeRemote('create', function(ctx, user, next) {
+      var body = ctx.req.body;
+      if (body && body.emailVerified) {
+        body.emailVerified = false;
+      }
+      next();
+    });
 
     // default models
     assert(loopback.Email, 'Email model must be defined before User model');
     UserModel.email = loopback.Email;
+  };
 
-    assert(loopback.AccessToken, 'AccessToken model must be defined before User model');
-    UserModel.accessToken = loopback.AccessToken;
+  User.setupValidations = function() {
+    var UserModel = this;
 
     UserModel.validate('email', emailValidator, {
       message: g.f('Must provide a valid email'),
@@ -807,6 +789,42 @@ module.exports = function(User) {
       UserModel.validatesUniquenessOf('email', {message: 'Email already exists'});
       UserModel.validatesUniquenessOf('username', {message: 'User already exists'});
     }
+  };
+
+  /*!
+   * Setup an extended user model.
+   */
+
+  User.setup = function() {
+    // We need to call the base class's setup method
+    User.base.setup.call(this);
+    var UserModel = this;
+
+    // max ttl
+    this.settings.maxTTL = this.settings.maxTTL || DEFAULT_MAX_TTL;
+    this.settings.ttl = this.settings.ttl || DEFAULT_TTL;
+
+    UserModel.setter.password = function(plain) {
+      if (typeof plain !== 'string') {
+        return;
+      }
+      if (plain.indexOf('$2a$') === 0 && plain.length === 60) {
+        // The password is already hashed. It can be the case
+        // when the instance is loaded from DB
+        this.$password = plain;
+      } else {
+        this.$password = this.constructor.hashPassword(plain);
+      }
+    };
+
+    UserModel.setupEmail();
+
+    UserModel.setupRemoteMethods();
+
+    assert(loopback.AccessToken, 'AccessToken model must be defined before User model');
+    UserModel.accessToken = loopback.AccessToken;
+
+    UserModel.setupValidations();
 
     return UserModel;
   };
@@ -817,22 +835,25 @@ module.exports = function(User) {
 
   User.setup();
 
+  User.helpers = {};
+
   // --- OPERATION HOOKS ---
   //
   // Important: Operation hooks are inherited by subclassed models,
   // therefore they must be registered outside of setup() function
 
   // Access token to normalize email credentials
-  User.observe('access', function normalizeEmailCase(ctx, next) {
+  User.helpers.normalizeEmailCase = function(ctx, next) {
     if (!ctx.Model.settings.caseSensitiveEmail && ctx.query.where &&
         ctx.query.where.email && typeof(ctx.query.where.email) === 'string') {
       ctx.query.where.email = ctx.query.where.email.toLowerCase();
     }
     next();
-  });
+  };
+  User.observe('access', User.helpers.normalizeEmailCase);
 
   // Delete old sessions once email is updated
-  User.observe('before save', function beforeEmailUpdate(ctx, next) {
+  User.helpers.beforeEmailUpdate = function(ctx, next) {
     if (ctx.isNewInstance) return next();
     if (!ctx.where && !ctx.instance) return next();
     var where = ctx.where || {id: ctx.instance.id};
@@ -869,9 +890,10 @@ module.exports = function(User) {
 
       next();
     });
-  });
+  };
+  User.observe('before save', User.helpers.beforeEmailUpdate);
 
-  User.observe('after save', function afterEmailUpdate(ctx, next) {
+  User.helpers.afterEmailUpdate = function(ctx, next) {
     if (!ctx.instance && !ctx.data) return next();
     if (!ctx.hookState.originalUserData) return next();
 
@@ -886,7 +908,9 @@ module.exports = function(User) {
       return u.id;
     });
     ctx.Model._invalidateAccessTokensOfUsers(userIdsToExpire, next);
-  });
+  };
+
+  User.observe('after save', User.helpers.afterEmailUpdate);
 };
 
 function emailValidator(err, done) {


### PR DESCRIPTION
### Description

The intention here is to provide a Base User that can easily be extended.
One simple exemple is that when you want to extend it to work with multiple emails, you currently cannot overwrite many email related functionality.

New methods that can be accessed and overwritten:
 - User.setupRemoteMethods
 - User.setupEmail
 - User.setupValidations
 - User.helpers.normalizeEmailCase
 - User.helpers.beforeEmailUpdate
 - User.helpers.afterEmailUpdate

This is just a style refactor no new methods or functionality were added.

#### Related issues

- None

### Checklist

- [no need] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
