### PR TITLE
Fix false emailVerified on user model update

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -858,9 +858,9 @@ module.exports = function(User) {
         if (emailChanged && ctx.Model.settings.emailVerificationRequired) {
           ctx.instance.emailVerified = false;
         }
-      } else {
+      } else if (ctx.data.email) {
         var emailChanged = ctx.hookState.originalUserData.some(function(data) {
-          return ctx.data.email && data.email != ctx.data.email;
+          return data.email != ctx.data.email;
         });
         if (emailChanged && ctx.Model.settings.emailVerificationRequired) {
           ctx.data.emailVerified = false;

--- a/common/models/user.js
+++ b/common/models/user.js
@@ -860,7 +860,7 @@ module.exports = function(User) {
         }
       } else {
         var emailChanged = ctx.hookState.originalUserData.some(function(data) {
-          return data.email != ctx.data.email;
+          return ctx.data.email && data.email != ctx.data.email;
         });
         if (emailChanged && ctx.Model.settings.emailVerificationRequired) {
           ctx.data.emailVerified = false;

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -2315,6 +2315,28 @@ describe('User', function() {
       ], done);
     });
 
+    it('should not set verification to false after something other than email is updated',
+      function(done) {
+        User.settings.emailVerificationRequired = true;
+        async.series([
+          function updateUser(next) {
+            userInstance.updateAttribute('realm', 'test', function(err, info) {
+              if (err) return next (err);
+              assert.equal(info.realm, 'test');
+              next();
+            });
+          },
+          function findUser(next) {
+            User.findById(userInstance.id, function(err, info) {
+              if (err) return next (err);
+              assert.equal(info.realm, 'test');
+              assert.equal(info.emailVerified, true);
+              next();
+            });
+          },
+        ], done);
+      });
+
     function createOriginalUser(done) {
       var userData = {
         email: 'original@example.com',


### PR DESCRIPTION
### Description

Yesterday, the loopback we are using in our system was upgraded
via npm, and since the upgrade, we noticed that every time
the user model updates, the emailVerified column would change to false.

I took a look and realized there might be an error in https://github.com/strongloop/loopback/commit/eb640d8

The intent of the commit just mention is to make emailVerified false
when the email gets changed, but notice that ctx.data.email is null
on updates, so the condition is always met and emailVerified always
becomes false.

This commit fixes the issue just mentioned.

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)


