### PR TITLE
Inject remote context createChangeStream method

### DIFF
--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -993,15 +993,8 @@ module.exports = function(registry) {
         {verb: 'post', path: '/change-stream'},
         {verb: 'get', path: '/change-stream'},
       ],
-      accepts: {
-        arg: 'options',
-        type: 'object',
-      },
-      returns: {
-        arg: 'changes',
-        type: 'ReadableStream',
-        json: true,
-      },
+      accepts: {arg: 'options', type: 'object', http: 'optionsFromRequest'},
+      returns: {arg: 'changes', type: 'ReadableStream', json: true},
     });
   };
 

--- a/test/context-options.test.js
+++ b/test/context-options.test.js
@@ -114,6 +114,11 @@ describe('OptionsFromRemotingContext', function() {
       return request.get('/products/count').expect(200)
         .then(expectInjectedOptions);
     });
+
+    it('injects options to createChangeStream()', function() {
+      return request.get('/products/change-stream').expect(200)
+        .then(expectInjectedOptions);
+    });
   });
 
   context('when invoking prototype methods', function() {


### PR DESCRIPTION
### Description

Implement, in addition to #3023, the injection of remote context to the options argument of the createChangeStream method.

#### Related issues

- #3023 

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
