### PR TITLE
Fix (what I believe to be) a small typo in doc

### DIFF
--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -380,7 +380,7 @@ module.exports = function(registry) {
    * [Where filter](http://loopback.io/doc/en/lb2/Where-filter.html#where-clause-for-other-methods).
    * @callback {Function} callback Callback function called with `(err, count)` arguments.  Required.
    * @param {Error} err Error object; see [Error object](http://loopback.io/doc/en/lb2/Error-object.html).
-   * @param {Number} count Number of instances updated.
+   * @param {Number} count Number of instances.
    */
 
   PersistedModel.count = function(where, cb) {


### PR DESCRIPTION
### Description
Fix (what I believe to be) a small typo in doc. 
This fix could be backported in version 2 too.

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes (no code change)
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
