### PR TITLE
Fix package.json CI downstreamIgnoreList nesting

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,12 +113,14 @@
   },
   "config": {
     "ci": {
-      "debug": "*,-mocha:*,-eslint:*",
-      "downstreamIgnoreList": [
-        "dashboard-controller",
-        "gateway-director-management-interface"
-      ]
+      "debug": "*,-mocha:*,-eslint:*"
     }
+  },
+  "ci": {
+    "downstreamIgnoreList": [
+      "dashboard-controller",
+      "gateway-director-management-interface"
+    ]
   },
   "license": "MIT"
 }


### PR DESCRIPTION
### Description
in https://github.com/strongloop/loopback/pull/3000#issuecomment-270188007 ci should be a root element of package.json,
not under config


#### Related issues
#3000 #3006

