### PR TITLE
Fix construction of sharedCtor remoting metadata

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -126,17 +126,9 @@ module.exports = function(registry) {
     var options = this.settings;
     var typeName = this.modelName;
 
-    var remotingOptions = {};
-    extend(remotingOptions, options.remoting || {});
-
-    // create a sharedClass
-    var sharedClass = ModelCtor.sharedClass = new SharedClass(
-      ModelCtor.modelName,
-      ModelCtor,
-      remotingOptions
-    );
-
     // support remoting prototype methods
+    // it's important to setup this function *before* calling `new SharedClass`
+    // otherwise remoting metadata from our base model is picked up
     ModelCtor.sharedCtor = function(data, id, options, fn) {
       var ModelCtor = this;
 
@@ -207,6 +199,16 @@ module.exports = function(registry) {
     ];
 
     ModelCtor.sharedCtor.returns = {root: true};
+
+    var remotingOptions = {};
+    extend(remotingOptions, options.remoting || {});
+
+    // create a sharedClass
+    var sharedClass = ModelCtor.sharedClass = new SharedClass(
+      ModelCtor.modelName,
+      ModelCtor,
+      remotingOptions
+    );
 
     // before remote hook
     ModelCtor.beforeRemote = function(name, fn) {


### PR DESCRIPTION
Prevent the situation when we are configuring remoting metadata after strong-remoting has already picked up data from our parent (base) model.

This is a forward-port of fix that was made as part of #3048.