### PR TITLE
Warn about injectOptionsFromRemoteContext

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -248,6 +248,16 @@ module.exports = function(registry) {
       });
     };
 
+    if ('injectOptionsFromRemoteContext' in options) {
+      console.warn(g.f(
+        '%s is using model setting %s which is no longer available.',
+        typeName, 'injectOptionsFromRemoteContext'));
+      console.warn(g.f(
+        'Please rework your app to use the offical solution for injecting ' +
+          '"options" argument from request context,\nsee %s',
+        'http://loopback.io/doc/en/lb3/Using-current-context.html'));
+    }
+
     // resolve relation functions
     sharedClass.resolve(function resolver(define) {
       var relations = ModelCtor.relations || {};


### PR DESCRIPTION
The option injectOptionsFromRemoteContext was added to LoopBack 2.x only and is not available in LoopBack 3.x (and newer).

When a model with this option is encountered, we are printing a warning message now, to let the user know about this change between 2.x and 3.x.

Connect to #1495, see also #3048 which implemented the flag in 2.x

@superkhau PTAL
@crandmck could you please review the message?