### PR TITLE
Preserve current session when invalidating access tokens

### DIFF
--- a/test/helpers/loopback-testing-helper.js
+++ b/test/helpers/loopback-testing-helper.js
@@ -34,6 +34,7 @@ _beforeEach.withApp = function(app) {
     this.get = _request.get;
     this.put = _request.put;
     this.del = _request.del;
+    this.patch = _request.patch;
 
     if (app.booting) {
       return app.once('booted', done);

--- a/test/user.integration.js
+++ b/test/user.integration.js
@@ -92,6 +92,20 @@ describe('users - integration', function() {
           done();
         });
     });
+
+    it('should preserve current session when invalidating tokens', function(done) {
+      var url = '/api/users/' + userId;
+      var self = this;
+      this.patch(url)
+        .send({email: 'new@example.com'})
+        .set('Authorization', accessToken)
+        .expect(200, function(err) {
+          if (err) return done(err);
+          self.get(url)
+            .set('Authorization', accessToken)
+            .expect(200, done);
+        });
+    });
   });
 
   describe('sub-user', function() {

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -2263,6 +2263,19 @@ describe('User', function() {
       });
     });
 
+    it('preserves current session', function(done) {
+      var options = {accessToken: originalUserToken1};
+      user.updateAttribute('email', 'new@example.com', options, function(err) {
+        if (err) return done(err);
+        AccessToken.find({where: {userId: user.id}}, function(err, tokens) {
+          if (err) return done(err);
+          var tokenIds = tokens.map(function(t) { return t.id; });
+          expect(tokenIds).to.eql([originalUserToken1.id]);
+          done();
+        });
+      });
+    });
+
     it('preserves other user sessions if their password is  untouched', function(done) {
       var user1, user2, user1Token;
       async.series([

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -2000,7 +2000,7 @@ describe('User', function() {
           User.login(currentEmailCredentials, function(err, accessToken1) {
             if (err) return next(err);
             assert(accessToken1.userId);
-            originalUserToken1 = accessToken1.id;
+            originalUserToken1 = accessToken1;
             next();
           });
         },
@@ -2008,7 +2008,7 @@ describe('User', function() {
           User.login(currentEmailCredentials, function(err, accessToken2) {
             if (err) return next(err);
             assert(accessToken2.userId);
-            originalUserToken2 = accessToken2.id;
+            originalUserToken2 = accessToken2;
             next();
           });
         },
@@ -2068,7 +2068,7 @@ describe('User', function() {
     it('keeps sessions AS IS if firstName is added using `updateAttributes`', function(done) {
       user.updateAttributes({'firstName': 'Janny'}, function(err, userInstance) {
         if (err) return done(err);
-        assertUntouchedTokens(done);
+        assertPreservedTokens(done);
       });
     });
 
@@ -2079,7 +2079,7 @@ describe('User', function() {
         email: currentEmailCredentials.email,
       }, function(err, userInstance) {
         if (err) return done(err);
-        assertUntouchedTokens(done);
+        assertPreservedTokens(done);
       });
     });
 
@@ -2314,9 +2314,11 @@ describe('User', function() {
     function assertPreservedTokens(done) {
       AccessToken.find({where: {userId: user.id}}, function(err, tokens) {
         if (err) return done(err);
-        expect(tokens.length).to.equal(2);
-        expect([tokens[0].id, tokens[1].id]).to.have.members([originalUserToken1,
-          originalUserToken2]);
+        var actualIds = tokens.map(function(t) { return t.id; });
+        actualIds.sort();
+        var expectedIds = [originalUserToken1.id, originalUserToken2.id];
+        expectedIds.sort();
+        expect(actualIds).to.eql(expectedIds);
         done();
       });
     };
@@ -2325,14 +2327,6 @@ describe('User', function() {
       AccessToken.find({where: {userId: user.id}}, function(err, tokens) {
         if (err) return done(err);
         expect(tokens.length).to.equal(0);
-        done();
-      });
-    }
-
-    function assertUntouchedTokens(done) {
-      AccessToken.find({where: {userId: user.id}}, function(err, tokens) {
-        if (err) return done(err);
-        expect(tokens.length).to.equal(2);
         done();
       });
     }


### PR DESCRIPTION
Fix User model to preserve the current session (provided via "options.accessToken") when invalidating access tokens after a change of email or password property.

See #3034

@superkhau please review

cc @ivanschwarz @doublemarked 