### PR TITLE
Preserve current session when invalidating tokens [2.x]

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -647,7 +647,12 @@ module.exports = function(User) {
     throw err;
   };
 
-  User._invalidateAccessTokensOfUsers = function(userIds, cb) {
+  User._invalidateAccessTokensOfUsers = function(userIds, options, cb) {
+    if (typeof options === 'function' && cb === undefined) {
+      cb = options;
+      options = {};
+    }
+
     if (!Array.isArray(userIds) || !userIds.length)
       return process.nextTick(cb);
 
@@ -656,7 +661,14 @@ module.exports = function(User) {
       return process.nextTick(cb);
 
     var AccessToken = accessTokenRelation.modelTo;
-    AccessToken.deleteAll({userId: {inq: userIds}}, cb);
+
+    var query = {userId: {inq: userIds}};
+    var tokenPK = AccessToken.definition.idName() || 'id';
+    if (options.accessToken && tokenPK in options.accessToken) {
+      query[tokenPK] = {neq: options.accessToken[tokenPK]};
+    }
+
+    AccessToken.deleteAll(query, options, cb);
   };
 
   /*!
@@ -873,7 +885,7 @@ module.exports = function(User) {
     }).map(function(u) {
       return u.id;
     });
-    ctx.Model._invalidateAccessTokensOfUsers(userIdsToExpire, next);
+    ctx.Model._invalidateAccessTokensOfUsers(userIdsToExpire, ctx.options, next);
   });
 };
 

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -1989,7 +1989,7 @@ describe('User', function() {
           User.login(currentEmailCredentials, function(err, accessToken1) {
             if (err) return next(err);
             assert(accessToken1.userId);
-            originalUserToken1 = accessToken1.id;
+            originalUserToken1 = accessToken1;
             next();
           });
         },
@@ -1997,7 +1997,7 @@ describe('User', function() {
           User.login(currentEmailCredentials, function(err, accessToken2) {
             if (err) return next(err);
             assert(accessToken2.userId);
-            originalUserToken2 = accessToken2.id;
+            originalUserToken2 = accessToken2;
             next();
           });
         },
@@ -2057,7 +2057,7 @@ describe('User', function() {
     it('keeps sessions AS IS if firstName is added using `updateAttributes`', function(done) {
       user.updateAttributes({'firstName': 'Janny'}, function(err, userInstance) {
         if (err) return done(err);
-        assertUntouchedTokens(done);
+        assertPreservedTokens(done);
       });
     });
 
@@ -2068,7 +2068,7 @@ describe('User', function() {
         email: currentEmailCredentials.email,
       }, function(err, userInstance) {
         if (err) return done(err);
-        assertUntouchedTokens(done);
+        assertPreservedTokens(done);
       });
     });
 
@@ -2303,9 +2303,11 @@ describe('User', function() {
     function assertPreservedTokens(done) {
       AccessToken.find({where: {userId: user.id}}, function(err, tokens) {
         if (err) return done(err);
-        expect(tokens.length).to.equal(2);
-        expect([tokens[0].id, tokens[1].id]).to.have.members([originalUserToken1,
-          originalUserToken2]);
+        var actualIds = tokens.map(function(t) { return t.id; });
+        actualIds.sort();
+        var expectedIds = [originalUserToken1.id, originalUserToken2.id];
+        expectedIds.sort();
+        expect(actualIds).to.eql(expectedIds);
         done();
       });
     }
@@ -2314,14 +2316,6 @@ describe('User', function() {
       AccessToken.find({where: {userId: user.id}}, function(err, tokens) {
         if (err) return done(err);
         expect(tokens.length).to.equal(0);
-        done();
-      });
-    }
-
-    function assertUntouchedTokens(done) {
-      AccessToken.find({where: {userId: user.id}}, function(err, tokens) {
-        if (err) return done(err);
-        expect(tokens.length).to.equal(2);
         done();
       });
     }

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -2252,6 +2252,19 @@ describe('User', function() {
       });
     });
 
+    it('preserves current session', function(done) {
+      var options = {accessToken: originalUserToken1};
+      user.updateAttribute('email', 'new@example.com', options, function(err) {
+        if (err) return done(err);
+        AccessToken.find({where: {userId: user.id}}, function(err, tokens) {
+          if (err) return done(err);
+          var tokenIds = tokens.map(function(t) { return t.id; });
+          expect(tokenIds).to.eql([originalUserToken1.id]);
+          done();
+        });
+      });
+    });
+
     it('preserves other user sessions if their password is  untouched', function(done) {
       var user1, user2, user1Token;
       async.series([


### PR DESCRIPTION
Back-port of #3098
See #3034

Important: the current session is preserved only when the User model has `injectOptionsFromRemoteContext` enabled or the application injects the "options" argument using a custom solution.

cc @ivanschwarz @doublemarked