### PR TITLE
Role model: resolves related models by name

### DIFF
--- a/common/models/role.js
+++ b/common/models/role.js
@@ -24,9 +24,9 @@ module.exports = function(Role) {
   Role.resolveRelatedModels = function() {
     if (!this.userModel) {
       var reg = this.registry;
-      this.roleMappingModel = reg.getModelByType(loopback.RoleMapping);
-      this.userModel = reg.getModelByType(loopback.User);
-      this.applicationModel = reg.getModelByType(loopback.Application);
+      this.roleMappingModel = reg.getModelByType('RoleMapping');
+      this.userModel = reg.getModelByType('User');
+      this.applicationModel = reg.getModelByType('Application');
     }
   };
 

--- a/test/role.test.js
+++ b/test/role.test.js
@@ -47,9 +47,6 @@ describe('role model', function() {
     ACL.roleMappingModel = RoleMapping;
     ACL.userModel = User;
     ACL.applicationModel = Application;
-    Role.roleMappingModel = RoleMapping;
-    Role.userModel = User;
-    Role.applicationModel = Application;
   });
 
   it('should define role/role relations', function(done) {


### PR DESCRIPTION
Resolve models related to the `Role` model by name instead of class instance. This allows to use `localRegistry` in `app` without monkeypatching `Role` manually

### Description

When loading the `Role` model into a custom registry (e.g. by setting `localRegistry` to `true` when instantiating the `app` object), static roles can not be resolved because the `RoleMapping` model used inside static methods (e.g. `Role.isInRole()`) is loaded into a different registry (i.e. loopback) and thus not attached to any `dataSource`.
This PR changes resolving models related to the `Role` model by name instead of by prototype, which leads to them being resolved from the same registry that `Role` is loaded in as well.

A similar issue (around the `ACL` model) was previously discussed with @bajtos and resolved in strongloop/loopback#2627

#### Related issues

- strongloop/loopback#2627

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
