### PR TITLE
Fix User.resetPassword to call createAccessToken() [2.x]

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -605,7 +605,7 @@ module.exports = function(User) {
         return cb(err);
       }
 
-      user.accessTokens.create({ ttl: ttl }, function(err, accessToken) {
+      user.createAccessToken(ttl, function(err, accessToken) {
         if (err) {
           return cb(err);
         }

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -1884,6 +1884,19 @@ describe('User', function() {
         });
       });
 
+      it('calls createAccessToken() to create the token', function(done) {
+        User.prototype.createAccessToken = function(ttl, cb) {
+          cb(null, new AccessToken({id: 'custom-token'}));
+        };
+
+        User.resetPassword({email: options.email}, function() {});
+
+        User.once('resetPasswordRequest', function(info) {
+          expect(info.accessToken.id).to.equal('custom-token');
+          done();
+        });
+      });
+
       it('Password reset over REST rejected without email address', function(done) {
         request(app)
           .post('/test-users/reset')


### PR DESCRIPTION
This allows User subclasses to override the algorithm used for building one-time access tokens for password recovery.

Back-port of #3120, see also #3020 

 cc @JonnyBGod