### PR TITLE
Update user.js

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -758,7 +758,7 @@ module.exports = function(User) {
             var accessToken = req && req.accessToken;
             var tokenID = accessToken && accessToken.id;
 
-            return tokenID;
+            return tokenID || '';
           }, description: 'Do not supply this argument, it is automatically extracted ' +
             'from request headers.',
           },


### PR DESCRIPTION
### Description
if no token provided for logout, then we set tokenID to empty string to throw a normal error "Error: access_token is a required argument" instead of "Error: Value is not a string"
