### PR TITLE
NEW automatically set strong globalize to english when passing tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -234,6 +234,10 @@ module.exports = function(grunt) {
   // Default task.
   grunt.registerTask('default', ['browserify']);
 
+  grunt.registerTask('set-test-env', function() {
+    process.env.NODE_ENV = 'test';
+  });
+
   grunt.registerTask('test', [
     'eslint',
     process.env.JENKINS_HOME ? 'mochaTest:unit-xml' : 'mochaTest:unit',
@@ -242,5 +246,5 @@ module.exports = function(grunt) {
   ]);
 
   // alias for sl-ci-run and `npm test`
-  grunt.registerTask('mocha-and-karma', ['test']);
+  grunt.registerTask('mocha-and-karma', ['set-test-env', 'test']);
 };

--- a/lib/globalize.js
+++ b/lib/globalize.js
@@ -7,5 +7,10 @@
 var path = require('path');
 var SG = require('strong-globalize');
 
+if (process.env.NODE_ENV === 'test') {
+  module.exports = SG({language: 'en'});
+} else {
+  module.exports = SG();
+}
+
 SG.SetRootDir(path.join(__dirname, '..'), {autonomousMsgLoading: 'all'});
-module.exports = SG();


### PR DESCRIPTION
### Description

This PR automatically set strong-globalize language to `en` in `test` `NODE_ENV`.
It also set this env before runing test through grunt task 

#### Related issues

https://github.com/strongloop/loopback/issues/3105