### PR TITLE
Use English when running Mocha tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -90,6 +90,7 @@ module.exports = function(grunt) {
         src: 'test/*.js',
         options: {
           reporter: 'dot',
+          require: require.resolve('./test/helpers/use-english.js'),
         },
       },
       'unit-xml': {

--- a/test/helpers/use-english.js
+++ b/test/helpers/use-english.js
@@ -1,0 +1,10 @@
+'use strict';
+
+var env = process.env;
+
+// delete any user-provided language settings
+delete env.LC_ALL;
+delete env.LC_MESSAGES;
+delete env.LANG;
+delete env.LANGUAGE;
+delete env.STRONGLOOP_GLOBALIZE_APP_LANGUAGE;

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -21,7 +21,6 @@ module.exports = function(config) {
     // list of files / patterns to load in the browser
     files: [
       'node_modules/es5-shim/es5-shim.js',
-      'test/support.js',
       'test/loopback.test.js',
       'test/model.test.js',
       // [rfeng] Browserified common/models/application.js

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,1 @@
+--require ./test/helpers/use-english


### PR DESCRIPTION
### Description

Fix Mocha setup to reset language settings to default English.

#### Related issues

- fixes #3105
- supersedes #3136

cc @pierreclr 

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- (n/a/) New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
