### PR TITLE
Fix OWNER role to handle multiple relations

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -458,6 +458,16 @@ app._verifyAuthModelRelations = function() {
 
   function verifyUserRelations(Model) {
     const hasManyTokens = Model.relations && Model.relations.accessTokens;
+
+    // display a temp warning message for users using multiple users config
+    if (hasManyTokens.polymorphic) {
+      console.warn(
+        'The app configuration follows the multiple user models setup ' +
+          'as described in http://ibm.biz/setup-loopback-auth',
+          'The built-in role resolver $owner is not currently compatible ' +
+          'with this configuration and should not be used in production.');
+    }
+
     if (hasManyTokens) return;
 
     const relationsConfig = Model.settings.relations || {};


### PR DESCRIPTION
### Description

Fix the code resolving OWNER role to correctly handle the situation
where the target model has multiple "belongsTo" relations to the User
model.

Introduce a new model setting "ownerRelations" that enables the new
behavior. When "ownerRelations" is set to true, then all "belongsTo"
relations are considered as granting ownership. Alternatively,
"ownerRelations" can be set to an array of the relations which
are granting ownership.

For example, a document can "belongTo" an `author` and a `reviewer`,
but only the author is an owner, the reviewer is not. In this case,
`ownerRelations` should be set to `['author']`.

#### Related issues

- #3081 mainly
- #3105 because I encountered some problems passing the tests because of my french computer 
- #2454 (closed as a duplicate)
- see also https://github.com/strongloop/loopback/pull/3106