### PR TITLE
Use English when running Mocha tests [2.x]

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -88,7 +88,8 @@ module.exports = function(grunt) {
         src: 'test/*.js',
         options: {
           reporter: 'dot',
-        }
+          require: require.resolve('./test/helpers/use-english.js'),
+        },
       },
       'unit-xml': {
         src: 'test/*.js',

--- a/test/helpers/use-english.js
+++ b/test/helpers/use-english.js
@@ -1,0 +1,10 @@
+'use strict';
+
+var env = process.env;
+
+// delete any user-provided language settings
+delete env.LC_ALL;
+delete env.LC_MESSAGES;
+delete env.LANG;
+delete env.LANGUAGE;
+delete env.STRONGLOOP_GLOBALIZE_APP_LANGUAGE;

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,1 @@
+--require ./test/helpers/use-english


### PR DESCRIPTION
### Description

Fix Mocha setup to reset language settings to default English.

#### Related issues

- fixes #3105
- backports #3138

cc @pierreclr

