### PR TITLE
Fix logout to handle no or missing accessToken [2.x]

### DIFF
--- a/test/user.integration.js
+++ b/test/user.integration.js
@@ -148,6 +148,17 @@ describe('users - integration', function() {
         });
       });
     });
+
+    it('returns 401 on logout with no access token', function(done) {
+      this.post('/api/users/logout')
+        .expect(401, done);
+    });
+
+    it('returns 401 on logout with invalid access token', function(done) {
+      this.post('/api/users/logout')
+        .set('Authorization', 'unknown-token')
+        .expect(401, done);
+    });
   });
 
   describe('sub-user', function() {

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -1186,6 +1186,22 @@ describe('User', function() {
       }
     });
 
+    it('fails when accessToken is not provided', function(done) {
+      User.logout(undefined, function(err) {
+        expect(err).to.have.property('message');
+        expect(err).to.have.property('status', 401);
+        done();
+      });
+    });
+
+    it('fails when accessToken is not found', function(done) {
+      User.logout('expired-access-token', function(err) {
+        expect(err).to.have.property('message');
+        expect(err).to.have.property('status', 401);
+        done();
+      });
+    });
+
     function verify(token, done) {
       assert(token);
 


### PR DESCRIPTION
### Description

Return 401 when the request does not provide any accessToken argument
or the token was not found.

Also simplify the implementation of the `logout` method to make only
a single database call (`deleteById`) instead of `findById` + `delete`.

#### Related issues

Backport #1496