### PR TITLE
Add missing type to Role properties definition

### DIFF
--- a/common/models/role.json
+++ b/common/models/role.json
@@ -12,11 +12,12 @@
       "required": true
     },
     "description": "string",
-
     "created": {
+      "type":"date",
       "defaultFn": "now"
     },
     "modified": {
+      "type":"date",
       "defaultFn": "now"
     }
   },

--- a/test/role.test.js
+++ b/test/role.test.js
@@ -96,6 +96,14 @@ describe('role model', function() {
     });
   });
 
+  it('should generate created/modified properties', () => {
+    return Role.create({name: 'ADMIN'})
+      .then(role => {
+        expect(role.toJSON().created).to.be.instanceOf(Date);
+        expect(role.toJSON().modified).to.be.instanceOf(Date);
+      });
+  });
+
   it('should define role/user relations', function(done) {
     User.create({name: 'Raymond', email: 'x@y.com', password: 'foobar'}, function(err, user) {
       if (err) return done(err);


### PR DESCRIPTION
### Description

Fix "created" and "modified" to be defined with type "date".

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- #3114

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)

cc @jdhrivas 