### PR TITLE
Add promise support to built-in model ACL

### DIFF
--- a/test/acl.test.js
+++ b/test/acl.test.js
@@ -90,6 +90,41 @@ describe('security scopes', function() {
 });
 
 describe('security ACLs', function() {
+  it('supports checkPermission() returning a promise', function() {
+    return ACL.create({
+      principalType: ACL.USER,
+      principalId: 'u001',
+      model: 'testModel',
+      property: ACL.ALL,
+      accessType: ACL.ALL,
+      permission: ACL.ALLOW,
+    })
+    .then(function() {
+      return ACL.checkPermission(ACL.USER, 'u001', 'testModel', 'name', ACL.ALL);
+    })
+    .then(function(access) {
+      assert(access.permission === ACL.ALLOW);
+    });
+  });
+
+  it('supports checkAccessForContext() returning a promise', function() {
+    var testModel = ds.createModel('testModel', {
+      acls: [
+        {principalType: ACL.USER, principalId: 'u001',
+          accessType: ACL.ALL, permission: ACL.ALLOW},
+      ],
+    });
+
+    return ACL.checkAccessForContext({
+      principals: [{type: ACL.USER, id: 'u001'}],
+      model: 'testModel',
+      accessType: ACL.ALL,
+    })
+    .then(function(access) {
+      assert(access.permission === ACL.ALLOW);
+    });
+  });
+
   it('should order ACL entries based on the matching score', function() {
     var acls = [
       {

--- a/test/role.test.js
+++ b/test/role.test.js
@@ -539,6 +539,13 @@ describe('role model', function() {
       });
     });
 
+    it('supports ACL.resolvePrincipal() returning a promise', function() {
+      return ACL.resolvePrincipal(ACL.USER, user.id)
+        .then(function(u) {
+          expect(u.id).to.eql(user.id);
+        });
+    });
+
     it('should resolve user by id', function(done) {
       ACL.resolvePrincipal(ACL.USER, user.id, function(err, u) {
         if (err) return done(err);
@@ -587,6 +594,13 @@ describe('role model', function() {
 
         done();
       });
+    });
+
+    it('supports ACL.isMappedToRole() returning a promise', function() {
+      return ACL.isMappedToRole(ACL.USER, user.username, 'admin')
+        .then(function(flag) {
+          expect(flag).to.be.true();
+        });
     });
 
     it('should report isMappedToRole by user.username', function(done) {


### PR DESCRIPTION
### Description

None of the functions from built-in acl.js currently support promises. this PR adds promise support by using loopback utils helper
 
#### Related issues
related issue: https://github.com/strongloop/loopback/issues/418
related PR (similar for built-in role model) : https://github.com/strongloop/loopback/pull/3146

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
