### PR TITLE
Add nyc coverage, report data to coveralls.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 node_modules
 dist
 *xunit.xml
+.nyc_output/

--- a/.nycrc
+++ b/.nycrc
@@ -1,0 +1,7 @@
+{
+  "exclude":  [
+    "Gruntfile.js",
+    "test/**/*.js"
+  ],
+  "cache": true
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,5 @@ node_js:
   - "4"
   - "6"
   - "7"
+after_success: npm run coverage
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   ],
   "scripts": {
     "lint": "grunt eslint",
-    "test": "grunt mocha-and-karma"
+    "coverage": "nyc report --reporter=text-lcov | coveralls",
+    "test": "nyc grunt mocha-and-karma"
   },
   "engines": {
     "node": ">=4.0.0"
@@ -65,6 +66,7 @@
     "browserify": "^13.1.0",
     "chai": "^3.5.0",
     "cookie-parser": "^1.3.4",
+    "coveralls": "^2.11.15",
     "dirty-chai": "^1.2.2",
     "eslint-config-loopback": "^8.0.0",
     "express-session": "^1.14.0",
@@ -89,6 +91,7 @@
     "loopback-boot": "^2.7.0",
     "loopback-context": "^1.0.0",
     "mocha": "^3.0.0",
+    "nyc": "^10.1.2",
     "phantomjs-prebuilt": "^2.1.7",
     "sinon": "^1.13.0",
     "sinon-chai": "^2.8.0",


### PR DESCRIPTION
### Description

 - Modify `npm test` to run all tests with code coverage enabled via `nyc`
 - Add a new script `npm run coverage` to report the coverage to coveralls.io
 - Add a Travis hook `after_success` to run the npm script reporting the coverage

@strongloop/loopback-devs PTAL