### PR TITLE
Babelify juggler for Karma tests

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -106,7 +106,15 @@ module.exports = function(config) {
       ],
       transform: [
         ['babelify', {
-          presets: 'es2015',
+          presets: [
+            ['es2015', {
+              // Disable transform-es2015-modules-commonjs which adds
+              // "use strict" to all files, even those that don't work
+              // in strict mode
+              // (e.g. chai, loopback-datasource-juggler, etc.)
+              modules: false,
+            }],
+          ],
           // By default, browserify does not transform node_modules
           // As a result, our dependencies like strong-remoting and juggler
           // are kept in original ES6 form that does not work in PhantomJS
@@ -114,15 +122,7 @@ module.exports = function(config) {
           // Prevent SyntaxError in strong-task-emitter:
           //   strong-task-emitter/lib/task.js (83:4):
           //   arguments is a reserved word in strict mode
-          // Prevent TypeError in chai:
-          //   'caller', 'callee', and 'arguments' properties may not be
-          //   accessed on strict mode functions or the arguments objects
-          //   for calls to them
-          // Prevent TypeError in loopback-datasource-juggler:
-          //   'caller', 'callee', and 'arguments' properties may not be
-          //   accessed on strict mode functions or the arguments objects
-          //   for calls to them
-          ignore: /node_modules\/(strong-task-emitter|chai|loopback-datasource-juggler)\//,
+          ignore: /node_modules\/(strong-task-emitter)\//,
         }],
       ],
       debug: true,


### PR DESCRIPTION
### Description

Fix configuration of Karma:

 - Disable ES6 modules. The ES6 module transpiler is adding
  "use strict" to all source files, this breaks e.g. chai or juggler
 - Relax "ignore" setting to exclude only strong-task-emitter,
   thus bring back Babel transpilation for chai and juggler.


#### Related issues

This is a follow-up for #3173 that's required by https://github.com/strongloop/loopback-datasource-juggler/pull/1242

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
