### PR TITLE
Fix Role.isOwner() when multiple user models

### DIFF
--- a/lib/access-context.js
+++ b/lib/access-context.js
@@ -128,6 +128,15 @@ AccessContext.prototype.addPrincipal = function(principalType, principalId, prin
  * @returns {*}
  */
 AccessContext.prototype.getUserId = function() {
+  var user = this.getUser();
+  return user && user.id;
+};
+
+/**
+ * Get the user
+ * @returns {*}
+ */
+AccessContext.prototype.getUser = function() {
   var BaseUser = this.registry.getModel('User');
   for (var i = 0; i < this.principals.length; i++) {
     var p = this.principals[i];
@@ -138,17 +147,16 @@ AccessContext.prototype.getUserId = function() {
 
     // the principalType must either be 'USER'
     if (p.type === Principal.USER) {
-      return p.id;
+      return {id: p.id, principalType: p.type};
     }
 
     // or permit to resolve a valid user model
     var userModel = this.registry.findModel(p.type);
     if (!userModel) continue;
     if (userModel.prototype instanceof BaseUser) {
-      return p.id;
+      return {id: p.id, principalType: p.type};
     }
   }
-  return null;
 };
 
 /**

--- a/test/role.test.js
+++ b/test/role.test.js
@@ -489,6 +489,50 @@ describe('role model', function() {
     });
   });
 
+  it('resolves OWNER via "userId" property with no relation', function() {
+    var Album = app.registry.createModel('Album', {
+      name: String,
+      userId: Number,
+    });
+    app.model(Album, {dataSource: 'db'});
+
+    var user;
+    return User.create({email: 'test@example.com', password: 'pass'})
+      .then(u => {
+        user = u;
+        return Album.create({name: 'Album 1', userId: user.id});
+      })
+      .then(album => {
+        return Role.isInRole(Role.OWNER, {
+          principalType: ACL.USER, principalId: user.id,
+          model: Album, id: album.id,
+        });
+      })
+      .then(isInRole => expect(isInRole).to.be.true());
+  });
+
+  it('resolves OWNER via "owner" property with no relation', function() {
+    var Album = app.registry.createModel('Album', {
+      name: String,
+      owner: Number,
+    });
+    app.model(Album, {dataSource: 'db'});
+
+    var user;
+    return User.create({email: 'test@example.com', password: 'pass'})
+      .then(u => {
+        user = u;
+        return Album.create({name: 'Album 1', owner: user.id});
+      })
+      .then(album => {
+        return Role.isInRole(Role.OWNER, {
+          principalType: ACL.USER, principalId: user.id,
+          model: Album, id: album.id,
+        });
+      })
+      .then(isInRole => expect(isInRole).to.be.true());
+  });
+
   describe('isMappedToRole', function() {
     var user, app, role;
 


### PR DESCRIPTION
### Description

When merging https://github.com/strongloop/loopback/pull/2971 which i authored, @bajtos noted a missing test on the built-in role resolver `$owner` which internally calls the `Role.isOwner()` method ([see here](https://github.com/strongloop/loopback/pull/2971#issuecomment-276900888))
The added test actually failed, allowing users from different models but with the same id), because the `Role.isOwner()` method was not checking the user's principalType.
(good catch @bajtos 👍 )

This PR fixes this issue (and adds the corresponding test)
see the inlined comment for detailed code review

#### Related PR

https://github.com/strongloop/loopback/pull/2971 (merged)
https://github.com/strongloop/loopback/pull/3140 (in progress, will be impacted)
++ any PR/issue where someone would try to iterate recursively along belongTo relations up to the owning user (need to find those)

<!--
Please use the following link syntaxes:


- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
