### PR TITLE
Fix creation of verification links

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -13,6 +13,7 @@ var isEmail = require('isemail');
 var loopback = require('../../lib/loopback');
 var utils = require('../../lib/utils');
 var path = require('path');
+var qs = require('querystring');
 var SALT_WORK_FACTOR = 10;
 var crypto = require('crypto');
 var MAX_PASSWORD_LENGTH = 72;
@@ -436,10 +437,10 @@ module.exports = function(User) {
       options.host +
       displayPort +
       urlPath +
-      '?uid=' +
-      options.user[pkName] +
-      '&redirect=' +
-      options.redirect;
+      '?' + qs.stringify({
+        uid: options.user[pkName],
+        redirect: options.redirect,
+      });
 
     options.templateFn = options.templateFn || createVerificationEmailBody;
 

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -10,6 +10,7 @@ var request = require('supertest');
 var loopback = require('../');
 var User, AccessToken;
 var async = require('async');
+var url = require('url');
 
 describe('User', function() {
   this.timeout(10000);
@@ -1688,6 +1689,29 @@ describe('User', function() {
           })
           .then(function(result) {
             expect(result.email).to.not.have.property('template');
+          });
+      });
+
+      it('allows hash fragment in redirectUrl', function() {
+        return User.create({email: 'test@example.com', password: 'pass'})
+          .then(user => {
+            let actualVerifyHref;
+            return user.verify({
+              type: 'email',
+              to: user.email,
+              from: 'noreply@myapp.org',
+              redirect: '#/some-path?a=1&b=2',
+              templateFn: (options, cb) => {
+                actualVerifyHref = options.verifyHref;
+                cb(null, 'dummy body');
+              },
+            })
+            .then(() => actualVerifyHref);
+          })
+          .then(verifyHref => {
+            var parsed = url.parse(verifyHref, true);
+            expect(parsed.query.redirect, 'redirect query')
+              .to.equal('#/some-path?a=1&b=2');
           });
       });
     });


### PR DESCRIPTION
### Description

Fix User.prototype.verify to call `querystring.stringify` instead of concatenating query-string components directly.

In particular, this fixes the bug where `options.redirect` containing a hash fragment like `#/home?arg1=value1&arg2=value2` produced incorrect URL, because the `redirect` value was not correctly encoded.

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- See bug #2307
- Supersede #3035

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
