### PR TITLE
setRemoting is defined for remoteChanges with http: { source: 'body' …

### DIFF
--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -897,9 +897,10 @@ module.exports = function(registry) {
         description: 'Get a set of deltas and conflicts since the given checkpoint.',
         accessType: 'READ',
         accepts: [
-          {arg: 'since', type: 'number', description: 'Find deltas since this checkpoint'},
-          {arg: 'remoteChanges', type: 'array', description: 'an array of change objects',
-            http: {source: 'body'}},
+          { arg: 'since', type: 'number', description: 'Find deltas since this checkpoint',
+            http: { source: 'form' }},
+          { arg: 'remoteChanges', type: 'array', description: 'an array of change objects',
+            http: { source: 'form' }}
         ],
         returns: {arg: 'result', type: 'object', root: true},
         http: {verb: 'post', path: '/diff'},

--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -908,7 +908,7 @@ module.exports = function(registry) {
       // set options.explicitSinceSource to true in model config
       // to explicitly set argument source and ensure its passed
       if (options.explicitSinceSource) {
-        diffOptions[0].accepts.http = {source: 'query'};
+        diffOptions.accepts[0].http = {source: 'query'};
       }
       setRemoting(PersistedModel, 'diff', diffOptions);
 

--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -893,18 +893,24 @@ module.exports = function(registry) {
     }
 
     if (options.trackChanges || options.enableRemoteReplication) {
-      setRemoting(PersistedModel, 'diff', {
+      var diffOptions = {
         description: 'Get a set of deltas and conflicts since the given checkpoint.',
         accessType: 'READ',
         accepts: [
-          { arg: 'since', type: 'number', description: 'Find deltas since this checkpoint',
-            http: { source: 'form' }},
-          { arg: 'remoteChanges', type: 'array', description: 'an array of change objects',
-            http: { source: 'form' }}
+          {arg: 'since', type: 'number', description: 'Find deltas since this checkpoint'},
+          {arg: 'remoteChanges', type: 'array', description: 'an array of change objects',
+            http: {source: 'body'}},
         ],
         returns: {arg: 'result', type: 'object', root: true},
         http: {verb: 'post', path: '/diff'},
-      });
+      };
+      // The since argument is not passed in remote requests
+      // set options.explicitSinceSource to true in model config
+      // to explicitly set argument source and ensure its passed
+      if (options.explicitSinceSource) {
+        diffOptions[0].accepts.http = {source: 'query'};
+      }
+      setRemoting(PersistedModel, 'diff', diffOptions);
 
       setRemoting(PersistedModel, 'changes', {
         description: 'Get the changes to a model since a given checkpoint.' +


### PR DESCRIPTION
### Description
In persitedModel diff method setRemoting is defined for remoteChanges with http: {source: 'body' }, and 'since' is not. strong-remoting only sets one parameter in the request body when it's defined like this. Fixed this bug by sending both params through form.

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- 3188 [https://github.com/strongloop/loopback/issues/3188](https://github.com/strongloop/loopback/issues/3188)

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
