### PR TITLE
Include link to docs in logoutSessions warning

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -839,7 +839,10 @@ module.exports = function(User) {
         '%s\'s settings (typically via common/models/*.json file).',
         'This setting is required for the invalidation algorithm to keep ',
         'the current session valid.',
-        ''
+        '',
+        'Learn more in our documentation at',
+        'https://loopback.io/doc/en/lb2/AccessToken-invalidation.html',
+        '',
       ].join('\n'), UserModel.modelName, UserModel.modelName);
     });
 


### PR DESCRIPTION
### Description

Make it easy for people encountering the long warning about "logoutSessionsOnSensitiveChanges" to find the relevant information in our documentation.

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- #3068

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
