### PR TITLE
Fix creation of verification links [2.x]

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -13,6 +13,7 @@ var isEmail = require('isemail');
 var loopback = require('../../lib/loopback');
 var utils = require('../../lib/utils');
 var path = require('path');
+var qs = require('querystring');
 var SALT_WORK_FACTOR = 10;
 var crypto = require('crypto');
 var MAX_PASSWORD_LENGTH = 72;
@@ -428,10 +429,10 @@ module.exports = function(User) {
       options.host +
       displayPort +
       urlPath +
-      '?uid=' +
-      options.user[pkName] +
-      '&redirect=' +
-      options.redirect;
+      '?' + qs.stringify({
+        uid: options.user[pkName],
+        redirect: options.redirect,
+      });
 
     options.templateFn = options.templateFn || createVerificationEmailBody;
 


### PR DESCRIPTION
### Description

Fix User.prototype.verify to call `querystring.stringify` instead
of concatenating query-string components directly.

In particular, this fixes the bug where `options.redirect` containing
a hash fragment like `#/home?arg1=value1&arg2=value2` produced incorrect
URL, because the `redirect` value was not correctly encoded.

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

 - backport #3185
 - see bug #2307

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
