### PR TITLE
Upgrade supertest to 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,8 +97,7 @@
     "sinon-chai": "^2.8.0",
     "strong-error-handler": "^1.0.1",
     "strong-task-emitter": "^0.0.6",
-    "supertest": "^2.0.0",
-    "supertest-as-promised": "^4.0.2"
+    "supertest": "^3.0.0"
   },
   "repository": {
     "type": "git",

--- a/test/context-options.test.js
+++ b/test/context-options.test.js
@@ -7,7 +7,7 @@
 
 var expect = require('chai').expect;
 var loopback = require('..');
-var supertest = require('supertest-as-promised')(require('bluebird'));
+var supertest = require('supertest');
 
 describe('OptionsFromRemotingContext', function() {
   var app, request, accessToken, userId, Product, actualOptions;

--- a/test/helpers/loopback-testing-helper.js
+++ b/test/helpers/loopback-testing-helper.js
@@ -184,7 +184,7 @@ _describe.whenCalledRemotely = function(verb, url, data, cb) {
       var test = this;
       this.http.end(function(err) {
         test.req = test.http.req;
-        test.res = test.http.res;
+        test.res = test.http.response;
         delete test.url;
 
         cb();

--- a/test/relations.integration.js
+++ b/test/relations.integration.js
@@ -191,7 +191,7 @@ describe('relations - integration', function() {
           if (err) return done(err);
 
           this.req = this.http.req;
-          this.res = this.http.res;
+          this.res = this.http.response;
 
           done();
         }.bind(this));


### PR DESCRIPTION
### Description

The new version of supertest comes with a built-in support for Promise-based usage.

Also fix tests relying on internal supertest API to keep working with
then new supertest internals after the upgrade.


#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
