### PR TITLE
"strictObjectIDCoercion": true on role-mapping.json

### DIFF
--- a/common/models/role-mapping.json
+++ b/common/models/role-mapping.json
@@ -1,6 +1,7 @@
 {
   "name": "RoleMapping",
   "description": "Map principals to roles",
+  "strictObjectIDCoercion": true,
   "properties": {
     "id": {
       "type": "string",


### PR DESCRIPTION
### Description

How the json file is, loopback developers are currently unable to query RoleMappings by principalId, since most connectors (mongodb in my case) will overwrite the type of the principalId for the query to an ObjectId, which is incorrect behavior.

principalId is a string, as per this definition. So having the query cast to an ObjectId always returns no matches.


#### Related issues

- #3121 
