### PR TITLE
fixed context passing in role resolver with `isOwner`

### DIFF
--- a/common/models/role.js
+++ b/common/models/role.js
@@ -182,7 +182,7 @@ module.exports = function(Role) {
     var user = context.getUser();
     var userId = user && user.id;
     var principalType = user && user.principalType;
-    Role.isOwner(modelClass, modelId, userId, principalType, callback);
+    Role.isOwner(modelClass, modelId, userId, principalType, context.accessToken, callback);
   });
 
   function isUserClass(modelClass) {
@@ -218,13 +218,16 @@ module.exports = function(Role) {
    * @param {Boolean} isOwner True if the user is an owner.
    * @promise
    */
-  Role.isOwner = function isOwner(modelClass, modelId, userId, principalType, callback) {
-    if (!callback && typeof principalType === 'function') {
+  Role.isOwner = function isOwner(modelClass, modelId, userId, principalType, accessToken, callback) {
+    if (!callback && typeof accessToken === 'function') {
+      callback = accessToken;
+      accessToken = undefined;
+    } else if (!callback && typeof principalType === 'function') {
       callback = principalType;
       principalType = undefined;
     }
     principalType = principalType || Principal.USER;
-
+    
     assert(modelClass, 'Model class is required');
     if (!callback) callback = utils.createPromiseCallback();
 
@@ -251,7 +254,7 @@ module.exports = function(Role) {
       return callback.promise;
     }
 
-    modelClass.findById(modelId, function(err, inst) {
+    modelClass.findById(modelId, {accessToken: accessToken}, function(err, inst) {
       if (err || !inst) {
         debug('Model not found for id %j', modelId);
         return callback(err, false);


### PR DESCRIPTION
### Description

With the move to explicit context passing of an `options` object, internal calls to `find` etc need to be updated to pass the necessary information along, too. In this case, `isOwner` calls `findById` on a Model, but does not pass an access token in `options`.
#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->
- #3209 
- #3023 

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
