### PR TITLE
Fix access-token invalidation for missing relation

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -692,7 +692,8 @@ module.exports = function(User) {
     // add principalType in AccessToken.query if using polymorphic relations
     // between AccessToken and User
     var relatedUser = AccessToken.relations.user;
-    var isRelationPolymorphic = relatedUser.polymorphic && !relatedUser.modelTo;
+    var isRelationPolymorphic = relatedUser && relatedUser.polymorphic &&
+      !relatedUser.modelTo;
     if (isRelationPolymorphic) {
       query.principalType = this.modelName;
     }


### PR DESCRIPTION
### Description

Fix the code invalidating access tokens on user email/password changes to correctly handle the case when the relation "AccessToken belongs to (subclassed) user" is not configured.

cc @ebarault @greaterweb 

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- #3215

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
