### PR TITLE
Fix context passing in OWNER role resolver

### DIFF
--- a/common/models/role.js
+++ b/common/models/role.js
@@ -182,7 +182,8 @@ module.exports = function(Role) {
     var user = context.getUser();
     var userId = user && user.id;
     var principalType = user && user.principalType;
-    Role.isOwner(modelClass, modelId, userId, principalType, callback);
+    var opts = {accessToken: context.accessToken};
+    Role.isOwner(modelClass, modelId, userId, principalType, opts, callback);
   });
 
   function isUserClass(modelClass) {
@@ -213,15 +214,21 @@ module.exports = function(Role) {
    * @param {*} modelId The model ID
    * @param {*} userId The user ID
    * @param {String} principalType The user principalType (optional)
+   * @options {Object} options
+   * @property {accessToken} The access token used to authorize the current user.
    * @callback {Function} [callback] The callback function
    * @param {String|Error} err The error string or object
    * @param {Boolean} isOwner True if the user is an owner.
    * @promise
    */
-  Role.isOwner = function isOwner(modelClass, modelId, userId, principalType, callback) {
-    if (!callback && typeof principalType === 'function') {
+  Role.isOwner = function isOwner(modelClass, modelId, userId, principalType, options, callback) {
+    if (!callback && typeof options === 'function') {
+      callback = options;
+      options = {};
+    } else if (!callback && typeof principalType === 'function') {
       callback = principalType;
       principalType = undefined;
+      options = {};
     }
     principalType = principalType || Principal.USER;
 
@@ -251,7 +258,7 @@ module.exports = function(Role) {
       return callback.promise;
     }
 
-    modelClass.findById(modelId, function(err, inst) {
+    modelClass.findById(modelId, options, function(err, inst) {
       if (err || !inst) {
         debug('Model not found for id %j', modelId);
         return callback(err, false);


### PR DESCRIPTION
### Description

With the move to explicit context passing of an `options` object, internal calls to `find` etc need to be updated to pass the necessary information along, too. In this case, `isOwner` calls `findById` on a Model, but does not pass an access token in `options`.

cc @DaGaMs @ebarault 

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- #3209 
- #3023 
- supersede #3211

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
