### PR TITLE
Warn on misconfigured access token user

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -398,7 +398,86 @@ app.enableAuth = function(options) {
     }
   };
 
+  this._verifyAuthModelRelations();
+
   this.isAuthEnabled = true;
+};
+
+app._verifyAuthModelRelations = function() {
+  // Allow unit-tests (but also LoopBack users) to disable the warnings
+  if (this.get('_verifyAuthModelRelations') === false) return;
+
+  const AccessToken = this.registry.findModel('AccessToken');
+  const User = this.registry.findModel('User');
+  this.models().forEach(Model => {
+    if (Model === AccessToken || Model.prototype instanceof AccessToken) {
+      scheduleVerification(Model, verifyAccessTokenRelations);
+    }
+
+    if (Model === User || Model.prototype instanceof User) {
+      scheduleVerification(Model, verifyUserRelations);
+    }
+  });
+
+  function scheduleVerification(Model, verifyFn) {
+    if (Model.dataSource) {
+      verifyFn(Model);
+    } else {
+      Model.on('attached', () => verifyFn(Model));
+    }
+  }
+
+  function verifyAccessTokenRelations(Model) {
+    const belongsToUser = Model.relations && Model.relations.user;
+    if (belongsToUser) return;
+
+    const relationsConfig = Model.settings.relations || {};
+    const userName = (relationsConfig.user || {}).model;
+    if (userName) {
+      console.warn(
+        'The model %j configures "belongsTo User-like models" relation ' +
+          'with target model %j. However, the model %j is not attached to ' +
+          'the application and therefore cannot be used by this relation. ' +
+          'This typically happens when the application has a custom ' +
+          'custom User subclass, but does not fix AccessToken relations ' +
+          'to use this new model.\n' +
+          'Learn more at http://ibm.biz/setup-loopback-auth',
+        Model.modelName, userName, userName);
+      return;
+    }
+
+    console.warn(
+      'The model %j does not have "belongsTo User-like model" relation ' +
+        'configured.\n' +
+        'Learn more at http://ibm.biz/setup-loopback-auth',
+      Model.modelName);
+  }
+
+  function verifyUserRelations(Model) {
+    const hasManyTokens = Model.relations && Model.relations.accessTokens;
+    if (hasManyTokens) return;
+
+    const relationsConfig = Model.settings.relations || {};
+    const accessTokenName = (relationsConfig.accessTokens || {}).model;
+    if (accessTokenName) {
+      console.warn(
+        'The model %j configures "hasMany AccessToken-like models" relation ' +
+          'with target model %j. However, the model %j is not attached to ' +
+          'the application and therefore cannot be used by this relation. ' +
+          'This typically happens when the application has a custom ' +
+          'AccessToken subclass, but does not fix User relations to use this ' +
+          'new model.\n' +
+          'Learn more at http://ibm.biz/setup-loopback-auth',
+        Model.modelName, accessTokenName, accessTokenName);
+      return;
+    }
+
+    console.warn(
+      'The model %j does not have "hasMany AccessToken-like models" relation ' +
+        'configured.\n' +
+        'Learn more at http://ibm.biz/setup-loopback-auth',
+      Model.modelName);
+  }
 };
 
 app.boot = function(options) {

--- a/lib/builtin-models.js
+++ b/lib/builtin-models.js
@@ -4,6 +4,9 @@
 // License text available at https://opensource.org/licenses/MIT
 
 'use strict';
+
+const assert = require('assert');
+
 module.exports = function(registry) {
   // NOTE(bajtos) we must use static require() due to browserify limitations
 
@@ -52,8 +55,33 @@ module.exports = function(registry) {
     require('../common/models/checkpoint.js'));
 
   function createModel(definitionJson, customizeFn) {
+    // Clone the JSON definition to allow applications
+    // to modify model settings while not affecting
+    // settings of new models created in the local registry
+    // of another app.
+    // This is needed because require() always returns the same
+    // object instance it loaded during the first call.
+    definitionJson = cloneDeepJson(definitionJson);
+
     var Model = registry.createModel(definitionJson);
     customizeFn(Model);
     return Model;
   }
 };
+
+// Because we are cloning objects created by JSON.parse,
+// the cloning algorithm can stay much simpler than a general-purpose
+// "cloneDeep" e.g. from lodash.
+function cloneDeepJson(obj) {
+  const result = Array.isArray(obj) ? [] : {};
+  assert.equal(Object.getPrototypeOf(result), Object.getPrototypeOf(obj));
+  for (const key in obj) {
+    const value = obj[key];
+    if (typeof value === 'object') {
+      result[key] = cloneDeepJson(value);
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}

--- a/test/access-token.test.js
+++ b/test/access-token.test.js
@@ -454,6 +454,10 @@ describe('app.enableAuth()', function() {
 
     ACL = app.registry.getModel('ACL');
 
+    // Fix User's "hasMany accessTokens" relation to use our new MyToken model
+    const User = app.registry.getModel('User');
+    User.settings.relations.accessTokens.model = 'MyToken';
+
     app.enableAuth({dataSource: 'db'});
   });
   beforeEach(createTestingToken);

--- a/test/access-token.test.js
+++ b/test/access-token.test.js
@@ -13,17 +13,23 @@ var loopback = require('../');
 var extend = require('util')._extend;
 var session = require('express-session');
 var request = require('supertest');
-var app = loopback();
 
-var Token = loopback.AccessToken.extend('MyToken');
-var ds = loopback.createDataSource({connector: loopback.Memory});
-Token.attachTo(ds);
-var ACL = loopback.ACL;
+var Token, ACL;
 
 describe('loopback.token(options)', function() {
   var app;
   beforeEach(function(done) {
-    app = loopback();
+    app = loopback({localRegistry: true, loadBuiltinModels: true});
+    app.dataSource('db', {connector: 'memory'});
+
+    Token = app.registry.createModel({
+      name: 'MyToken',
+      base: 'AccessToken',
+    });
+    app.model(Token, {dataSource: 'db'});
+
+    ACL = app.registry.getModel('ACL');
+
     createTestingToken.call(this, done);
   });
 
@@ -284,7 +290,6 @@ describe('loopback.token(options)', function() {
       ' when enableDoubkecheck is true',
     function(done) {
       var token = this.token;
-      var app = loopback();
       app.use(function(req, res, next) {
         req.accessToken = null;
         next();
@@ -319,7 +324,6 @@ describe('loopback.token(options)', function() {
     function(done) {
       var token = this.token;
       var tokenStub = {id: 'stub id'};
-      var app = loopback();
       app.use(function(req, res, next) {
         req.accessToken = tokenStub;
 
@@ -439,8 +443,18 @@ describe('AccessToken', function() {
 describe('app.enableAuth()', function() {
   var app;
   beforeEach(function setupAuthWithModels() {
-    app = loopback();
-    app.enableAuth({dataSource: ds});
+    app = loopback({localRegistry: true, loadBuiltinModels: true});
+    app.dataSource('db', {connector: 'memory'});
+
+    Token = app.registry.createModel({
+      name: 'MyToken',
+      base: 'AccessToken',
+    });
+    app.model(Token, {dataSource: 'db'});
+
+    ACL = app.registry.getModel('ACL');
+
+    app.enableAuth({dataSource: 'db'});
   });
   beforeEach(createTestingToken);
 
@@ -517,7 +531,7 @@ describe('app.enableAuth()', function() {
   });
 
   it('stores token in the context', function(done) {
-    var TestModel = loopback.createModel('TestModel', {base: 'Model'});
+    var TestModel = app.registry.createModel('TestModel', {base: 'Model'});
     TestModel.getToken = function(cb) {
       var ctx = LoopBackContext.getCurrentContext();
       cb(null, ctx && ctx.get('accessToken') || null);
@@ -527,7 +541,6 @@ describe('app.enableAuth()', function() {
       http: {verb: 'GET', path: '/token'},
     });
 
-    var app = loopback();
     app.model(TestModel, {dataSource: null});
 
     app.enableAuth();
@@ -552,8 +565,6 @@ describe('app.enableAuth()', function() {
 
   // See https://github.com/strongloop/loopback-context/issues/6
   it('checks whether context is active', function(done) {
-    var app = loopback();
-
     app.enableAuth();
     app.use(contextMiddleware());
     app.use(session({
@@ -603,7 +614,8 @@ function createTestApp(testToken, settings, done) {
     currentUserLiteral: 'me',
   }, settings.token);
 
-  var app = loopback();
+  var app = loopback({localRegistry: true, loadBuiltinModels: true});
+  app.dataSource('db', {connector: 'memory'});
 
   app.use(cookieParser('secret'));
   app.use(loopback.token(tokenSettings));
@@ -635,7 +647,7 @@ function createTestApp(testToken, settings, done) {
     res.status(200).send(result);
   });
   app.use(loopback.rest());
-  app.enableAuth();
+  app.enableAuth({dataSource: 'db'});
 
   Object.keys(appSettings).forEach(function(key) {
     app.set(key, appSettings[key]);
@@ -657,10 +669,8 @@ function createTestApp(testToken, settings, done) {
     modelOptions[key] = modelSettings[key];
   });
 
-  var TestModel = loopback.PersistedModel.extend('test', {}, modelOptions);
-
-  TestModel.attachTo(loopback.memory());
-  app.model(TestModel);
+  var TestModel = app.registry.createModel('test', {}, modelOptions);
+  app.model(TestModel, {dataSource: 'db'});
 
   return app;
 }

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -888,6 +888,10 @@ describe('app', function() {
       var Customer = app.registry.createModel('Customer', {}, {base: 'User'});
       app.model(Customer, {dataSource: 'db'});
 
+      // Fix AccessToken's "belongsTo user" relation to use our new Customer model
+      const AccessToken = app.registry.getModel('AccessToken');
+      AccessToken.settings.relations.user.model = 'Customer';
+
       app.enableAuth({dataSource: 'db'});
 
       expect(Object.keys(app.models)).to.not.include('User');

--- a/test/fixtures/access-control/common/models/access-token.json
+++ b/test/fixtures/access-control/common/models/access-token.json
@@ -15,5 +15,12 @@
       "principalId": "$everyone",
       "property": "create"
     }
-  ]
+  ],
+  "relations": {
+    "user": {
+      "type": "belongsTo",
+      "model": "user",
+      "foreignKey": "userId"
+    }
+  }
 }

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -2374,6 +2374,7 @@ describe('User', function() {
     it('handles subclassed user with no accessToken relation', () => {
       // setup a new LoopBack app, we don't want to use shared models
       app = loopback({localRegistry: true, loadBuiltinModels: true});
+      app.set('_verifyAuthModelRelations', false);
       app.set('remoting', {errorHandler: {debug: true, log: false}});
       app.dataSource('db', {connector: 'memory'});
       const User = app.registry.createModel({


### PR DESCRIPTION
### Description

Verify User and AccessToken relations at startup Modify `app.enableAuth()` to verify that (custom) User and AccessToken models have correctly configured their hasMany/belongsTo relations and print a warning otherwise.

As I was fixing the tests reporting this new warning, I discovered few other issues that I needed to fix first - see the first three commits  abf8246, c45954c and f0c9700.

The warning and the tests are fixed by the last commit f0d6416.

I think we should wait with merging this pull request until there is a doc page written where we explain users how to fix this problem, so that we can add URL of this doc page to the new warnings.

cc @ebarault @greaterweb

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- #3215

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
