### PR TITLE
fix custom token model in token middleware

### DIFF
--- a/server/middleware/token.js
+++ b/server/middleware/token.js
@@ -95,13 +95,7 @@ function token(options) {
     var app = req.app;
     var registry = app.registry;
     if (!TokenModel) {
-      if (registry === loopback.registry) {
-        TokenModel = options.model || loopback.AccessToken;
-      } else if (options.model) {
-        TokenModel = registry.getModel(options.model);
-      } else {
-        TokenModel = registry.getModel('AccessToken');
-      }
+      TokenModel = registry.getModel(options.model || 'AccessToken');
     }
 
     assert(typeof TokenModel === 'function',

--- a/test/fixtures/access-control/common/models/user.json
+++ b/test/fixtures/access-control/common/models/user.json
@@ -20,5 +20,5 @@
       "principalId": "$everyone"
     }
   ],
-  "replaceOnPUT": false  
+  "replaceOnPUT": false
 }


### PR DESCRIPTION
cc @bajtos @beeman 

### Description
Specifying a custom AccessToken model via the auth middleware options is broken when the app is using a single global registry.

The faulty line are 
```
if (registry === loopback.registry) {
  TokenModel = options.model || loopback.AccessToken;
} 
```
where `options.model` is the model name in the token middleware config, not the model itself
more comments inlined in the code itself

**Note**: New tests should be added to cover properly the scenario where a custom AccessToken is specified using the token middleware.

#### Related issues
https://github.com/strongloop/loopback.io/pull/297#issuecomment-283866261

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
