### PR TITLE
Passing options.verificationToken to options.templateFn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea
 .project
 .DS_Store
+.vscode/
 *.sublime*
 *.seed
 *.log

--- a/common/models/user.js
+++ b/common/models/user.js
@@ -450,6 +450,7 @@ module.exports = function(User) {
 
     // Set a default token generation function if one is not provided
     var tokenGenerator = options.generateVerificationToken || User.generateVerificationToken;
+    assert(typeof tokenGenerator === 'function', 'generateVerificationToken must be a function');
 
     tokenGenerator(user, function(err, token) {
       if (err) { return fn(err); }
@@ -467,6 +468,8 @@ module.exports = function(User) {
     // TODO - support more verification types
     function sendEmail(user) {
       options.verifyHref += '&token=' + user.verificationToken;
+
+      options.verificationToken = user.verificationToken;
 
       options.text = options.text || g.f('Please verify your email by opening ' +
         'this link in a web browser:\n\t%s', options.verifyHref);

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -1714,6 +1714,27 @@ describe('User', function() {
               .to.equal('#/some-path?a=1&b=2');
           });
       });
+
+      it('verify that options.templateFn receives options.verificationToken', function() {
+        return User.create({email: 'test1@example.com', password: 'pass'})
+          .then(user => {
+            let actualVerificationToken;
+            return user.verify({
+              type: 'email',
+              to: user.email,
+              from: 'noreply@myapp.org',
+              redirect: '#/some-path?a=1&b=2',
+              templateFn: (options, cb) => {
+                actualVerificationToken = options.verificationToken;
+                cb(null, 'dummy body');
+              },
+            })
+            .then(() => actualVerificationToken);
+          })
+          .then(token => {
+            expect(token).to.exist();
+          });
+      });
     });
 
     describe('User.confirm(options, fn)', function() {


### PR DESCRIPTION
Validating TypeError: tokenGenerator is not a function

Passing the token to the template function, for example:

You need to build several url to send email template.

user.verify({
// ...
  templateFn: createVerificationEmail,
});

function createVerificationEmail(options, cb) {
  options.verifyMovil = CONFIG.verifyHref + "/other.html?uid=" + options.user.id + ";token=" + options.verificationToken;

  var template = loopback.template(options.template);
  var body = template(options);
  cb(null, body);
}

### Description


#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
