### PR TITLE
Fix User.verify to convert ObjectID uid to string

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -438,7 +438,7 @@ module.exports = function(User) {
       displayPort +
       urlPath +
       '?' + qs.stringify({
-        uid: options.user[pkName],
+        uid: '' + options.user[pkName],
         redirect: options.redirect,
       });
 

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -1414,6 +1414,53 @@ describe('User', function() {
           });
       });
 
+      it('converts uid value to string', function(done) {
+        const idString = '58be263abc88dd483956030a';
+        let actualVerifyHref;
+
+        User.afterRemote('create', function(ctx, user, next) {
+          assert(user, 'afterRemote should include result');
+
+          var options = {
+            type: 'email',
+            to: user.email,
+            from: 'noreply@myapp.org',
+            redirect: '/',
+            protocol: ctx.req.protocol,
+            host: ctx.req.get('host'),
+            templateFn: function(options, cb) {
+              actualVerifyHref = options.verifyHref;
+              cb(null, 'dummy body');
+            },
+          };
+
+          // replace the string id with an object
+          // TODO: find a better way to do this
+          Object.defineProperty(user, 'pk', {
+            get: function() { return this.__data.pk; },
+            set: function(value) { this.__data.pk = value; },
+          });
+          user.pk = {toString: function() { return idString; }};
+
+          user.verify(options, function(err, result) {
+            expect(result.uid).to.exist().and.be.an('object');
+            expect(result.uid.toString()).to.equal(idString);
+            const parsed = url.parse(actualVerifyHref, true);
+            expect(parsed.query.uid, 'uid query field').to.eql(idString);
+            done();
+          });
+        });
+
+        request(app)
+          .post('/test-users')
+          .expect('Content-Type', /json/)
+          .expect(200)
+          .send({email: 'bar@bat.com', password: 'bar', pk: idString})
+          .end(function(err, res) {
+            if (err) return done(err);
+          });
+      });
+
       it('Verify a user\'s email address with custom token generator', function(done) {
         User.afterRemote('create', function(ctx, user, next) {
           assert(user, 'afterRemote should include result');


### PR DESCRIPTION
object id should be treated as string when serialized

### Description

This solves the issue when sending the verification email for users registered when using mongo connector and object id.

somehow the query string serializer cannot convert the object to string.


#### Related issues

