### PR TITLE
Fix User.verify to convert uid to string [2.x]

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -430,7 +430,7 @@ module.exports = function(User) {
       displayPort +
       urlPath +
       '?' + qs.stringify({
-        uid: options.user[pkName],
+        uid: '' + options.user[pkName],
         redirect: options.redirect,
       });
 


### PR DESCRIPTION
### Description

Applications using MongoDB connectors typically have `user.id`
property of type ObjectID.

This commit fixes the code building the verification URL to
correctly convert the user id value into string.

cc @phairow 

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- backport #3253

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
