### PR TITLE
Fix CI on Node 7.7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   - "4"
   - "6"
-  - "7"
+  - "7.7.1" # locked down because of https://github.com/nodejs/node/pull/11762
 after_success: npm run coverage
 
 # see https://www.npmjs.com/package/phantomjs-prebuilt#continuous-integration


### PR DESCRIPTION
### Description

Add workaround for what seems to be a Node 7.7.2 regression: `net.createConnection(port)` is failing with the following error, see e.g. https://travis-ci.org/strongloop/loopback/jobs/209262349:

```
  1) loopback application pauses request stream during authentication:
     Uncaught TypeError: "listener" argument must be a function
    at Socket.connect (net.js:943:10)
    at Socket.connect (node_modules/async-listener/index.js:76:27)
    at Object.exports.connect.exports.createConnection (net.js:76:35)
    at sendHttpRequestInOnePacket (test/integration.test.js:77:24)
    at Server.<anonymous> (test/integration.test.js:19:7)
    at emitListeningNT (net.js:1302:10)
    at node_modules/async-listener/glue.js:188:31
    at _combinedTickCallback (internal/process/next_tick.js:77:11)
    at process._tickDomainCallback [as _tickCallback] (internal/process/next_tick.js:128:9)
```

The same code passes on Node 7.7.1, see e.g. https://travis-ci.org/strongloop/loopback/jobs/209009746.

My proposed workaround is to explicitly pass a no-op callback argument:

```js
net.createConnection(port, ()=>{});
```

Strangely enough, the problem CANNOT be reproduced when the failing test is run in isolation via `mocha test/integration.test.js`. To reproduce it, one has to add few more tests making HTTP requests, e.g. via

```
$ mocha -R dot test/access-control.integration.js test/integration.test.js
```

From looking at recent Node.js changes, it seems the problem was introduced by https://github.com/nodejs/node/commit/b56e851c4813bdec86e47e84d7c18527a01d4ffd from https://github.com/nodejs/node/pull/11667.

@joyeecheung @mcollina @jasnell you have authored/reviewed that patch, do you happen to have any insights on what may be wrong here?

cc @sam-github 