### PR TITLE
Add nyc coverage, report data to coveralls.io [2.x]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 node_modules
 dist
 *xunit.xml
+.nyc_output/

--- a/.nycrc
+++ b/.nycrc
@@ -1,0 +1,7 @@
+{
+  "exclude":  [
+    "Gruntfile.js",
+    "test/**/*.js"
+  ],
+  "cache": true
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
   - "0.12"
   - "4"
   - "6"
+after_success: npm run coverage
 
 # see https://www.npmjs.com/package/phantomjs-prebuilt#continuous-integration
 cache:

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "mBaaS"
   ],
   "scripts": {
-    "test": "grunt mocha-and-karma"
+    "coverage": "nyc report --reporter=text-lcov | coveralls",
+    "test": "nyc grunt mocha-and-karma"
   },
   "dependencies": {
     "async": "^2.0.1",
@@ -67,6 +68,7 @@
     "browserify": "^13.1.0",
     "chai": "^3.5.0",
     "es5-shim": "^4.1.0",
+    "coveralls": "^2.11.15",
     "express-session": "^1.14.0",
     "grunt": "^1.0.1",
     "grunt-browserify": "^5.0.0",
@@ -90,6 +92,7 @@
     "loopback-datasource-juggler": "^2.19.1",
     "loopback-testing": "^1.4.0",
     "mocha": "^3.0.0",
+    "nyc": "^10.1.2",
     "phantomjs-prebuilt": "^2.1.7",
     "sinon": "^1.13.0",
     "sinon-chai": "^2.8.0",


### PR DESCRIPTION
backport #3165

 - Modify `npm test` to run all tests with code coverage enabled via `nyc`
 - Add a new script `npm run coverage` to report the coverage to coveralls.io
 - Add a Travis hook `after_success` to run the npm script reporting the coverage
