### PR TITLE
Fix acl.resolvePermission not working with wildcard request

### DIFF
--- a/common/models/acl.js
+++ b/common/models/acl.js
@@ -243,6 +243,7 @@ module.exports = function(ACL) {
         var permissionOrder = AccessContext.permissionOrder[permission];
         if (candidateOrder > permissionOrder) {
           permission = candidate.permission;
+          break;
         }
       }
     }

--- a/test/acl.test.js
+++ b/test/acl.test.js
@@ -186,6 +186,41 @@ describe('security ACLs', function() {
     // });
   });
 
+  it('should order ACL entries based on the matching score even with wildcard req', function() {
+    var acls = [
+      {
+        'model': 'account',
+        'accessType': '*',
+        'permission': 'DENY',
+        'principalType': 'ROLE',
+        'principalId': '$everyone',
+      },
+      {
+        'model': 'account',
+        'accessType': '*',
+        'permission': 'ALLOW',
+        'principalType': 'ROLE',
+        'principalId': '$owner',
+      }];
+    var req = {
+      model: 'account',
+      property: '*',
+      accessType: 'WRITE',
+    };
+
+    acls = acls.map(function(a) { return new ACL(a); });
+
+    var perm = ACL.resolvePermission(acls, req);
+    // remove the registry from AccessRequest instance to ease asserting.
+    // Check the above test case for more info.
+    delete perm.registry;
+    assert.deepEqual(perm, {model: 'account',
+      property: '*',
+      accessType: 'WRITE',
+      permission: 'ALLOW',
+      methodNames: []});
+  });
+
   it('should allow access to models for the given principal by wildcard', function() {
     // jscs:disable validateIndentation
     ACL.create({


### PR DESCRIPTION
### Description

When acl.resolvePermission was called with a request containing a wildcard, it would return the matching acl with lowest score instead of higher. 


#### Related issues

 - Fixes #2153
 - Also this was mentioned on [Stackoverflow](http://stackoverflow.com/q/42176493/774086).  

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
