### PR TITLE
Add User.changePassword(id, old, new, cb)

### DIFF
--- a/common/models/user.json
+++ b/common/models/user.json
@@ -82,6 +82,13 @@
       "permission": "ALLOW",
       "property": "resetPassword",
       "accessType": "EXECUTE"
+    },
+    {
+      "principalType": "ROLE",
+      "principalId": "$authenticated",
+      "permission": "ALLOW",
+      "property": "changePassword",
+      "accessType": "EXECUTE"
     }
   ],
   "relations": {


### PR DESCRIPTION
### Description

Implement a new method for changing user passwords the secure way.
The method requires the old password to be provided before a new
password can be used.

JavaScript API:

    User.changePassword(userId, oldPassword, newPassword[, cb])

REST API:

    POST /api/users/change-password
    Authorization: your-token-id
    Content-Type: application/json

    {"oldPassword":"old-pass", "newPassword": "new-pass"}

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- #382

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
