### PR TITLE
Forward options in prepareForTokenInvalidation [2.x]

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -886,7 +886,7 @@ module.exports = function(User) {
       where[pkName] = ctx.instance[pkName];
     }
 
-    ctx.Model.find({where: where}, function(err, userInstances) {
+    ctx.Model.find({where: where}, ctx.options, function(err, userInstances) {
       if (err) return next(err);
       ctx.hookState.originalUserData = userInstances.map(function(u) {
         var user = {};

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -8,6 +8,7 @@ var loopback = require('../');
 var User, AccessToken;
 var async = require('async');
 var url = require('url');
+var extend = require('util')._extend;
 
 describe('User', function() {
   this.timeout(10000);
@@ -2377,6 +2378,37 @@ describe('User', function() {
           done();
         });
       });
+    });
+
+    it('forwards the "options" argument', function(done) {
+      var options = {testFlag: true};
+      var observedOptions = [];
+
+      saveObservedOptionsForHook('access', User);
+      saveObservedOptionsForHook('before delete', AccessToken);
+
+      user.updateAttribute('password', 'newPass', options, function(err, updated) {
+        if (err) return done(err);
+
+        expect(observedOptions).to.eql([
+          // prepareForTokenInvalidation - load current instance data
+          {hook: 'access', testFlag: true},
+
+          // validate uniqueness of User.email
+          {hook: 'access', testFlag: true},
+
+          // _invalidateAccessTokensOfUsers - deleteAll
+          {hook: 'before delete', testFlag: true},
+        ]);
+        done();
+      });
+
+      function saveObservedOptionsForHook(name, model) {
+        model.observe(name, function(ctx, next) {
+          observedOptions.push(extend({hook: name}, ctx.options));
+          next();
+        });
+      }
     });
 
     it('preserves other user sessions if their password is  untouched', function(done) {


### PR DESCRIPTION
### Description

A follow-up for #3299 where I discovered that access-token-invalidation code is not forwarding the "options" argument in all places.

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- #382

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
