### PR TITLE
Check max password length in User.changePassword

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -421,6 +421,12 @@ module.exports = function(User) {
         return cb(err);
       }
 
+      try {
+        User.validatePassword(newPassword);
+      } catch (err) {
+        return cb(err);
+      }
+
       const delta = {password: newPassword};
       this.patchAttributes(delta, options, (err, updated) => cb(err));
     });

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -449,6 +449,25 @@ describe('User', function() {
         });
       });
     });
+
+    it('rejects changePassword when new password is longer than 72 chars', function() {
+      return User.create({email: 'test@example.com', password: pass72Char})
+        .then(u => u.changePassword(pass72Char, pass73Char))
+        .then(
+          success => { throw new Error('changePassword should have failed'); },
+          err => {
+            expect(err.message).to.match(/Password too long/);
+
+            // workaround for chai problem
+            //   object tested must be an array, an object, or a string,
+            //   but error given
+            const props = Object.assign({}, err);
+            expect(props).to.contain({
+              code: 'PASSWORD_TOO_LONG',
+              statusCode: 422,
+            });
+          });
+    });
   });
 
   describe('Access-hook for queries with email NOT case-sensitive', function() {
@@ -1339,7 +1358,7 @@ describe('User', function() {
         err => {
           // workaround for chai problem
           //   object tested must be an array, an object, or a string,
-          //    but error given
+          //   but error given
           const props = Object.assign({}, err);
           expect(props).to.contain({
             code: 'USER_NOT_FOUND',


### PR DESCRIPTION
### Description

The new `changePassword` API implemented by #3299 was not checking the maximum allowed password length, as added by #2580.

This patch fixes `changePassword` to validate the password before making the change.

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- #382

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
