### PR TITLE
Forward options in prepareForTokenInvalidation

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -980,7 +980,7 @@ module.exports = function(User) {
       where[pkName] = ctx.instance[pkName];
     }
 
-    ctx.Model.find({where: where}, function(err, userInstances) {
+    ctx.Model.find({where: where}, ctx.options, function(err, userInstances) {
       if (err) return next(err);
       ctx.hookState.originalUserData = userInstances.map(function(u) {
         var user = {};


### PR DESCRIPTION
### Description

A follow-up for #3299 where I discovered that access-token-invalidation code is not forwarding the "options" argument in all places.

cc @ebarault 

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- #382
- forward-port #3309 from 2.x

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
