### PR TITLE
Add new event "remoteMethodAdded"

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -153,6 +153,9 @@ app.model = function(Model, config) {
   Model.on('remoteMethodDisabled', function(model, methodName) {
     self.emit('remoteMethodDisabled', model, methodName);
   });
+  Model.on('remoteMethodAdded', function(model) {
+    self.emit('remoteMethodAdded', model);
+  });
 
   Model.shared = isPublic;
   Model.app = this;

--- a/lib/model.js
+++ b/lib/model.js
@@ -468,6 +468,7 @@ module.exports = function(registry) {
     }
 
     this.sharedClass.defineMethod(name, options);
+    this.emit('remoteMethodAdded', this.sharedClass);
   };
 
   function setupOptionsArgs(accepts) {
@@ -969,6 +970,8 @@ module.exports = function(registry) {
           }
         }
       });
+
+      this.emit('remoteMethodAdded', this.sharedClass);
 
       if (options.hooks === false) return; // don't inherit before/after hooks
 

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -686,6 +686,33 @@ describe('app', function() {
       expect(disabledRemoteMethod).to.eql('findOne');
     });
 
+    it('emits a `remoteMethodAdded` event', function() {
+      app.dataSource('db', {connector: 'memory'});
+      var Book = app.registry.createModel(
+        'Book',
+        {name: 'string'},
+        {plural: 'books'}
+      );
+      app.model(Book, {dataSource: 'db'});
+
+      var Page = app.registry.createModel(
+        'Page',
+        {name: 'string'},
+        {plural: 'pages'}
+      );
+      app.model(Page, {dataSource: 'db'});
+
+      Book.hasMany(Page);
+
+      var remoteMethodAddedClass;
+      app.on('remoteMethodAdded', function(sharedClass) {
+        remoteMethodAddedClass = sharedClass;
+      });
+      Book.nestRemoting('pages');
+      expect(remoteMethodAddedClass).to.exist();
+      expect(remoteMethodAddedClass).to.eql(Book.sharedClass);
+    });
+
     it.onServer('updates REST API when a new model is added', function(done) {
       app.use(loopback.rest());
       request(app).get('/colors').expect(404, function(err, res) {

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -852,6 +852,42 @@ describe.onServer('Remote Methods', function() {
 
       expect(callbackSpy).to.have.been.calledWith(TestModel.sharedClass, 'findOne');
     });
+
+    it('emits a `remoteMethodAdded` event', function() {
+      var app = loopback();
+      app.dataSource('db', {connector: 'memory'});
+
+      var User = app.registry.getModel('User');
+      app.model(User, {dataSource: 'db'});
+
+      var Token = app.registry.getModel('AccessToken');
+      app.model(Token, {dataSource: 'db'});
+
+      var callbackSpy = require('sinon').spy();
+      var TestModel = app.models.User;
+      TestModel.on('remoteMethodAdded', callbackSpy);
+      TestModel.nestRemoting('accessTokens');
+
+      expect(callbackSpy).to.have.been.calledWith(TestModel.sharedClass);
+    });
+  });
+
+  it('emits a `remoteMethodAdded` event from remoteMethod', function() {
+    var app = loopback();
+    var model = PersistedModel.extend('TestModelForAddingRemoteMethod');
+    app.dataSource('db', {connector: 'memory'});
+    app.model(model, {dataSource: 'db'});
+
+    var callbackSpy = require('sinon').spy();
+    var TestModel = app.models.TestModelForAddingRemoteMethod;
+    TestModel.on('remoteMethodAdded', callbackSpy);
+    TestModel.remoteMethod('getTest', {
+      accepts: {arg: 'options', type: 'object', http: 'optionsFromRequest'},
+      returns: {arg: 'test', type: 'object'},
+      http: {verb: 'GET', path: '/test'},
+    });
+
+    expect(callbackSpy).to.have.been.calledWith(TestModel.sharedClass);
   });
 
   describe('Model.getApp(cb)', function() {


### PR DESCRIPTION
### Description

Add new event `remoteMethodAdded` triggered when nestRemoting is called

#### Related issues

#2409
strongloop/loopback-component-explorer#167

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
