### PR TITLE
Fix user-literal rewrite for anonymous requests

### DIFF
--- a/test/access-token.test.js
+++ b/test/access-token.test.js
@@ -190,6 +190,26 @@ describe('loopback.token(options)', function() {
         });
     });
 
+  it('should generate a 401 on a current user literal route without an authToken',
+    function(done) {
+      var app = createTestApp(null, done);
+      request(app)
+        .get('/users/me')
+        .set('authorization', null)
+        .expect(401)
+        .end(done);
+    });
+
+  it('should generate a 401 on a current user literal route with invalid authToken',
+    function(done) {
+      var app = createTestApp(this.token, done);
+      request(app)
+        .get('/users/me')
+        .set('Authorization', 'invald-token-id')
+        .expect(401)
+        .end(done);
+    });
+
   it('should skip when req.token is already present', function(done) {
     var tokenStub = { id: 'stub id' };
     app.use(function(req, res, next) {


### PR DESCRIPTION
### Description

Currently any `currentUserLiteral` routes when accessed with a bad
token throw a 500 due to a SQL error that is raised because
`Model.findById` is invoked with `id={currentUserLiteral}`
(`id=me` in our case) when the url rewrite fails.

This commit changes the token middleware to return 401 Not Authorized
when the client is requesting a currentUserLiteral route without
a valid access token.


#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- #3291 invalid token on currentUserLiteral throws 500
- backport #3292

cc @aaronbuchanan

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
