### PR TITLE
Set password with token, disable password changes via patch/replace

### DIFF
--- a/common/models/user.json
+++ b/common/models/user.json
@@ -89,6 +89,13 @@
       "permission": "ALLOW",
       "property": "changePassword",
       "accessType": "EXECUTE"
+    },
+    {
+      "principalType": "ROLE",
+      "principalId": "$authenticated",
+      "permission": "ALLOW",
+      "property": "setPassword",
+      "accessType": "EXECUTE"
     }
   ],
   "relations": {

--- a/test/authorization-scopes.test.js
+++ b/test/authorization-scopes.test.js
@@ -82,7 +82,7 @@ describe('Authorization scopes', () => {
   }
 
   function givenRemoteMethodWithCustomScope() {
-    // Delete any previosly registered instance of the method "scoped"
+    // Delete any previously registered instance of the method "scoped"
     User.sharedClass._methods = User.sharedClass._methods
       .filter(m => m.name !== 'scoped');
 

--- a/test/authorization-scopes.test.js
+++ b/test/authorization-scopes.test.js
@@ -82,6 +82,10 @@ describe('Authorization scopes', () => {
   }
 
   function givenRemoteMethodWithCustomScope() {
+    // Delete any previosly registered instance of the method "scoped"
+    User.sharedClass._methods = User.sharedClass._methods
+      .filter(m => m.name !== 'scoped');
+
     const accessScopes = arguments[0] || [CUSTOM_SCOPE];
     User.scoped = function(cb) { cb(); };
     User.remoteMethod('scoped', {

--- a/test/helpers/wait-for-event.js
+++ b/test/helpers/wait-for-event.js
@@ -1,0 +1,17 @@
+// Copyright IBM Corp. 2013,2016. All Rights Reserved.
+// Node module: loopback
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+const Promise = require('bluebird');
+
+function waitForEvent(emitter, event) {
+  return new Promise((resolve, reject) => {
+    emitter.on(event, resolve);
+  });
+}
+
+module.exports = waitForEvent;
+

--- a/test/user-password.test.js
+++ b/test/user-password.test.js
@@ -1,0 +1,242 @@
+// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Node module: loopback
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+const expect = require('./helpers/expect');
+const errorHandler = require('strong-error-handler');
+const loopback = require('../');
+const Promise = require('bluebird');
+const request = require('supertest');
+const waitForEvent = require('./helpers/wait-for-event');
+
+describe('User.password', () => {
+  const credentials = {email: 'test@example.com', password: 'pass'};
+
+  let app, User, testUser, regularToken, resetToken;
+
+  context('restrict reset password token scope', () => {
+    beforeEach(givenAppWithRestrictionEnabled);
+
+    context('using regular access token', () => {
+      beforeEach(givenRegularAccessToken);
+
+      it('allows patching user name', () => {
+        return changeName(regularToken).expect(200);
+      });
+
+      it('allows patching user password', () => {
+        return patchPassword(regularToken).expect(200);
+      });
+
+      it('allows changing user password', () => {
+        return changePassword(regularToken).expect(204);
+      });
+
+      it('denies resetting user password', () => {
+        return resetPassword(regularToken).expect(401);
+      });
+    });
+
+    context('using password-reset token', () => {
+      beforeEach(givenResetPasswordToken);
+
+      it('denies patching user name', () => {
+        return changeName(resetToken).expect(401);
+      });
+
+      it('denies patching user password', () => {
+        return patchPassword(resetToken).expect(401);
+      });
+
+      it('denies changing user password', () => {
+        return changePassword(resetToken).expect(401);
+      });
+
+      it('allows resetting user password', () => {
+        return resetPassword(resetToken).expect(204);
+      });
+    });
+
+    function givenAppWithRestrictionEnabled() {
+      return givenAppWithUser({restrictResetPasswordTokenScope: true});
+    }
+  });
+
+  context('reject password changes via patch or replace', () => {
+    beforeEach(givenAppWithRejectionEnabled);
+    beforeEach(givenRegularAccessToken);
+
+    it('allows patching user name', () => {
+      return changeName(regularToken).expect(200);
+    });
+
+    it('denies patching user password', () => {
+      return patchPassword(regularToken).expect(401);
+    });
+
+    it('allows changing user password', () => {
+      return changePassword(regularToken).expect(204);
+    });
+
+    it('denies setPassword-like call with non-password changes', () => {
+      return patchNameAndPasswordDirectly().then(
+        function onSuccess() {
+          throw new Error('patchAttributes() should have failed');
+        },
+        function onError(err) {
+          expect(err.message).to.match(/Invalid use.*options.setPassword/);
+        });
+    });
+
+    function givenAppWithRejectionEnabled() {
+      return givenAppWithUser({rejectPasswordChangesViaPatchOrReplace: true});
+    }
+  });
+
+  context('all feature flags disabled', () => {
+    beforeEach(givenAppWithNoRestrictions);
+
+    context('using regular access token', () => {
+      beforeEach(givenRegularAccessToken);
+
+      it('allows changing user name', () => {
+        return changeName(regularToken).expect(200);
+      });
+
+      it('allows patching user password', () => {
+        return patchPassword(regularToken).expect(200);
+      });
+
+      it('allows changing user password', () => {
+        return changePassword(regularToken).expect(204);
+      });
+
+      it('allows resetting user password', () => {
+        return resetPassword(regularToken).expect(204);
+      });
+    });
+
+    context('using password-reset token', () => {
+      beforeEach(givenResetPasswordToken);
+
+      it('allows changing user name', () => {
+        return changeName(resetToken).expect(200);
+      });
+
+      it('allows patching user password', () => {
+        return patchPassword(resetToken).expect(200);
+      });
+
+      it('allows changing user password', () => {
+        return changePassword(resetToken).expect(204);
+      });
+
+      it('allows resetting user password', () => {
+        return resetPassword(resetToken).expect(204);
+      });
+    });
+
+    it('allows setPassword-like call with non-password changes', () => {
+      return patchNameAndPasswordDirectly().then(() => {
+        // test passed
+      });
+    });
+
+    function givenAppWithNoRestrictions() {
+      return givenAppWithUser({
+        rejectPasswordChangesViaPatchOrReplace: false,
+        restrictResetPasswordTokenScope: false,
+      });
+    }
+  });
+
+  function givenAppWithUser(userSettings) {
+    app = loopback({localRegistry: true, loadBuiltinModels: true});
+    app.set('remoting', {rest: {handleErrors: false}});
+    app.dataSource('db', {connector: 'memory'});
+
+    userSettings = Object.assign({
+      name: 'PwdUser',
+      base: 'User',
+      properties: {
+        name: 'string',
+      },
+
+      // Speed up the password hashing algorithm for tests
+      saltWorkFactor: 4,
+
+      http: {path: '/users'},
+    }, userSettings);
+
+    User = app.registry.createModel(userSettings);
+    app.model(User, {dataSource: 'db'});
+
+    const AccessToken = app.registry.getModel('AccessToken');
+    AccessToken.settings.relations.user.model = User.modelName;
+
+    app.enableAuth({dataSource: 'db'});
+
+    app.use(loopback.token());
+    app.use(loopback.rest());
+    app.use(function logUnexpectedError(err, req, res, next) {
+      const statusCode = err.statusCode || err.status;
+      if (statusCode > 400 && statusCode !== 401) {
+        console.log('Unexpected error for %s %s: %s %s',
+          req.method, req.path, statusCode, err.stack || err);
+      }
+      next(err);
+    });
+    app.use(errorHandler({debug: true, log: false}));
+
+    return User.create(credentials)
+      .then(u => {
+        testUser = u;
+        return u.setAttribute('emailVerified', true);
+      });
+  }
+
+  function givenRegularAccessToken() {
+    return User.login(credentials).then(t => regularToken = t);
+  }
+
+  function givenResetPasswordToken() {
+    return Promise.all([
+      User.resetPassword({email: credentials.email}),
+      waitForEvent(User, 'resetPasswordRequest'),
+    ])
+    .spread((reset, info) => resetToken = info.accessToken);
+  }
+
+  function changeName(token) {
+    return request(app).patch(`/users/${testUser.id}`)
+      .set('Authorization', token.id)
+      .send({name: 'New Name'});
+  }
+
+  function patchPassword(token) {
+    return request(app).patch(`/users/${testUser.id}`)
+      .set('Authorization', token.id)
+      .send({password: 'new-pass'});
+  }
+
+  function changePassword(token) {
+    return request(app).post('/users/change-password')
+      .set('Authorization', token.id)
+      .send({oldPassword: credentials.password, newPassword: 'new-pass'});
+  }
+
+  function resetPassword(token) {
+    return request(app).post('/users/reset-password')
+      .set('Authorization', token.id)
+      .send({newPassword: 'new-pass'});
+  }
+
+  function patchNameAndPasswordDirectly() {
+    return testUser.patchAttributes(
+      {password: 'new-pass', name: 'New Name'},
+      {setPassword: true});
+  }
+});

--- a/test/user.integration.js
+++ b/test/user.integration.js
@@ -155,13 +155,13 @@ describe('users - integration', function() {
         .expect(401);
     });
 
-    it('injects change password options from remoting context', function() {
+    it('uses change password options provided by the remoting context', function() {
       const User = app.models.User;
       const credentials = {email: 'inject@example.com', password: 'pass'};
 
-      let injectedOptions;
+      let observedOptions;
       User.observe('before save', (ctx, next) => {
-        injectedOptions = ctx.options;
+        observedOptions = ctx.options;
         next();
       });
 
@@ -177,11 +177,11 @@ describe('users - integration', function() {
             .expect(204);
         })
         .then(() => {
-          expect(injectedOptions).to.have.property('accessToken');
+          expect(observedOptions).to.have.property('accessToken');
         });
     });
 
-    it('resets user\'s password', function() {
+    it('resets the user\'s password', function() {
       const User = app.models.User;
       const credentials = {email: 'reset@example.com', password: 'pass'};
       return User.create(credentials)
@@ -206,7 +206,7 @@ describe('users - integration', function() {
         .then(isMatch => expect(isMatch, 'user has new password').to.be.true());
     });
 
-    it('rejects unauthenticated reset password request', function() {
+    it('rejects unauthenticated reset password requests', function() {
       return this.post('/api/users/reset-password')
         .send({
           newPassword: 'new password',
@@ -214,13 +214,13 @@ describe('users - integration', function() {
         .expect(401);
     });
 
-    it('injects reset password options from remoting context', function() {
+    it('uses password reset options provided by the remoting context', function() {
       const User = app.models.User;
       const credentials = {email: 'inject-reset@example.com', password: 'pass'};
 
-      let injectedOptions;
+      let observedOptions;
       User.observe('before save', (ctx, next) => {
-        injectedOptions = ctx.options;
+        observedOptions = ctx.options;
         next();
       });
 
@@ -235,7 +235,7 @@ describe('users - integration', function() {
             .expect(204);
         })
         .then(() => {
-          expect(injectedOptions).to.have.property('accessToken');
+          expect(observedOptions).to.have.property('accessToken');
         });
     });
   });

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -1402,13 +1402,13 @@ describe('User', function() {
           {hook: 'access', testFlag: true},
 
           // "before save" hook prepareForTokenInvalidation
-          {hook: 'access', testFlag: true},
+          {hook: 'access', setPassword: true, testFlag: true},
 
           // updateAttributes
-          {hook: 'before save', testFlag: true},
+          {hook: 'before save', setPassword: true, testFlag: true},
 
           // validate uniqueness of User.email
-          {hook: 'access', testFlag: true},
+          {hook: 'access', setPassword: true, testFlag: true},
         ]));
 
       function saveObservedOptionsForHook(name) {
@@ -1461,7 +1461,7 @@ describe('User', function() {
         });
     });
 
-    it('fails with 401 for unknown user', () => {
+    it('fails with 401 for unknown users', () => {
       return User.setPassword('unknown-id', 'pass').then(
         success => { throw new Error('setPassword should have failed'); },
         err => {
@@ -1489,13 +1489,13 @@ describe('User', function() {
           {hook: 'access', testFlag: true},
 
           // "before save" hook prepareForTokenInvalidation
-          {hook: 'access', testFlag: true},
+          {hook: 'access', setPassword: true, testFlag: true},
 
           // updateAttributes
-          {hook: 'before save', testFlag: true},
+          {hook: 'before save', setPassword: true, testFlag: true},
 
           // validate uniqueness of User.email
-          {hook: 'access', testFlag: true},
+          {hook: 'access', setPassword: true, testFlag: true},
         ]));
 
       function saveObservedOptionsForHook(name) {


### PR DESCRIPTION
### Description

**Add `User.setPassword(id, new, cb)`**

Implement a new method for changing user password with password-reset token but without the old password.

REST API

    POST /api/users/reset-password
    Authorization: your-password-reset-token-id
    Content-Type: application/json

    {"newPassword": "new-pass"}

JavaScript API

    User.setPassword(userId, newPassword[, cb])
    userInstance.setPassword(newPassword[, cb])

**Implement more secure password flow**

Improve the flow for setting/changing/resetting User password to make
it more secure.

 1. Modify `User.resetPassword` to create a token scoped to allow
    invocation of a single remote method: `User.setPassword`.

 2. Scope the method `User.setPassword` so that regular tokens created
    by `User.login` are not allowed to execute it.

For backwards compatibility, this new mode (flow) is enabled only
when User model setting `restrictResetPasswordTokenScope` is set to `true`.

 3. Changing the password via `User.prototype.patchAttributes`
    (and similar DAO methods) is no longer allowed. Applications
    must call `User.changePassword` and ask the user to provide
    the current (old) password.

For backwards compatibility, this new mode (flow) is enabled only
when User model setting `rejectPasswordChangesViaPatchOrReplace` is set to `true`.

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- Connect to #382
- Follow-up issue to write documentation, update the example repo and workspace templates: #3349 

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
