### PR TITLE
Support remoting adapters with no ctx.req object

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1046,7 +1046,7 @@ module.exports = function(registry) {
    */
   Model.createOptionsFromRemotingContext = function(ctx) {
     return {
-      accessToken: ctx.req.accessToken,
+      accessToken: ctx.req ? ctx.req.accessToken : null,
     };
   };
 

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -964,6 +964,12 @@ describe.onServer('Remote Methods', function() {
         });
     });
 
+    it('sets empty options.accessToken for requests coming from websocket/primus adapters', function() {
+      const primusContext = {};
+      const opts = TestModel.createOptionsFromRemotingContext(primusContext);
+      expect(opts).to.have.property('accessToken', null);
+    });
+
     it('allows apps to add options before remoting hooks', function(done) {
       TestModel.createOptionsFromRemotingContext = function(ctx) {
         return {hooks: []};


### PR DESCRIPTION
Reason: some strong-remoting adapters don't have the "req" object.

### Description

Not all strong-remoting adapters have the "req" property attached to the context.
The proposal changes implement a more restrictive check.


#### Related issues

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
