### PR TITLE
Refactor access token to make it extensible

### DIFF
--- a/server/middleware/token.js
+++ b/server/middleware/token.js
@@ -88,6 +88,9 @@ function escapeRegExp(str) {
  * @property {Boolean} [overwriteExistingToken] only has effect in combination with `enableDoublecheck`. If truthy, will allow to overwrite an existing accessToken.
  * @property {Function|String} [model] AccessToken model name or class to use.
  * @property {String} [currentUserLiteral] String literal for the current user.
+ * @property {Boolean} [bearerTokenBase64Encoded] Defaults to `true`. For `Bearer` token based `Authorization` headers,
+ * decode the value from `Base64`. If set to `false`, the decoding will be skipped and the token id will be the raw value
+ * parsed from the header.
  * @header loopback.token([options])
  */
 
@@ -104,6 +107,9 @@ function token(options) {
     currentUserLiteral = escapeRegExp(currentUserLiteral);
   }
 
+  if (options.bearerTokenBase64Encoded === undefined) {
+    options.bearerTokenBase64Encoded = true;
+  }
   var enableDoublecheck = !!options.enableDoublecheck;
   var overwriteExistingToken = !!options.overwriteExistingToken;
 

--- a/test/access-token.test.js
+++ b/test/access-token.test.js
@@ -115,14 +115,14 @@ describe('loopback.token(options)', function() {
     });
   });
 
-  it('should populate req.token from the query string', function(done) {
+  it('populates req.token from the query string', function(done) {
     createTestAppAndRequest(this.token, done)
       .get('/?access_token=' + this.token.id)
       .expect(200)
       .end(done);
   });
 
-  it('should populate req.token from an authorization header', function(done) {
+  it('populates req.token from an authorization header', function(done) {
     createTestAppAndRequest(this.token, done)
       .get('/')
       .set('authorization', this.token.id)
@@ -130,7 +130,7 @@ describe('loopback.token(options)', function() {
       .end(done);
   });
 
-  it('should populate req.token from an X-Access-Token header', function(done) {
+  it('populates req.token from an X-Access-Token header', function(done) {
     createTestAppAndRequest(this.token, done)
       .get('/')
       .set('X-Access-Token', this.token.id)
@@ -138,7 +138,7 @@ describe('loopback.token(options)', function() {
       .end(done);
   });
 
-  it('should not search default keys when searchDefaultTokenKeys is false',
+  it('does not search default keys when searchDefaultTokenKeys is false',
   function(done) {
     var tokenId = this.token.id;
     var app = createTestApp(
@@ -162,10 +162,21 @@ describe('loopback.token(options)', function() {
     });
   });
 
-  it('should populate req.token from an authorization header with bearer token', function(done) {
+  it('populates req.token from an authorization header with bearer token with base64',
+  function(done) {
     var token = this.token.id;
     token = 'Bearer ' + new Buffer(token).toString('base64');
     createTestAppAndRequest(this.token, done)
+      .get('/')
+      .set('authorization', token)
+      .expect(200)
+      .end(done);
+  });
+
+  it('populates req.token from an authorization header with bearer token', function(done) {
+    var token = this.token.id;
+    token = 'Bearer ' + token;
+    createTestAppAndRequest(this.token, {token: {bearerTokenBase64Encoded: false}}, done)
       .get('/')
       .set('authorization', token)
       .expect(200)
@@ -214,7 +225,7 @@ describe('loopback.token(options)', function() {
     });
   });
 
-  it('should populate req.token from a secure cookie', function(done) {
+  it('populates req.token from a secure cookie', function(done) {
     var app = createTestApp(this.token, done);
 
     request(app)
@@ -227,7 +238,7 @@ describe('loopback.token(options)', function() {
       });
   });
 
-  it('should populate req.token from a header or a secure cookie', function(done) {
+  it('populates req.token from a header or a secure cookie', function(done) {
     var app = createTestApp(this.token, done);
     var id = this.token.id;
     request(app)
@@ -241,7 +252,7 @@ describe('loopback.token(options)', function() {
       });
   });
 
-  it('should rewrite url for the current user literal at the end without query',
+  it('rewrites url for the current user literal at the end without query',
     function(done) {
       var app = createTestApp(this.token, done);
       var id = this.token.id;
@@ -257,7 +268,7 @@ describe('loopback.token(options)', function() {
         });
     });
 
-  it('should rewrite url for the current user literal at the end with query',
+  it('rewrites url for the current user literal at the end with query',
     function(done) {
       var app = createTestApp(this.token, done);
       var id = this.token.id;
@@ -273,7 +284,7 @@ describe('loopback.token(options)', function() {
         });
     });
 
-  it('should rewrite url for the current user literal in the middle',
+  it('rewrites url for the current user literal in the middle',
     function(done) {
       var app = createTestApp(this.token, done);
       var id = this.token.id;
@@ -289,7 +300,7 @@ describe('loopback.token(options)', function() {
         });
     });
 
-  it('should generate a 401 on a current user literal route without an authToken',
+  it('generates a 401 on a current user literal route without an authToken',
     function(done) {
       var app = createTestApp(null, done);
       request(app)
@@ -299,7 +310,7 @@ describe('loopback.token(options)', function() {
         .end(done);
     });
 
-  it('should generate a 401 on a current user literal route with invalid authToken',
+  it('generates a 401 on a current user literal route with invalid authToken',
     function(done) {
       var app = createTestApp(this.token, done);
       request(app)
@@ -309,7 +320,7 @@ describe('loopback.token(options)', function() {
         .end(done);
     });
 
-  it('should skip when req.token is already present', function(done) {
+  it('skips when req.token is already present', function(done) {
     var tokenStub = {id: 'stub id'};
     app.use(function(req, res, next) {
       req.accessToken = tokenStub;
@@ -334,7 +345,7 @@ describe('loopback.token(options)', function() {
   });
 
   describe('loading multiple instances of token middleware', function() {
-    it('should skip when req.token is already present and no further options are set',
+    it('skips when req.token is already present and no further options are set',
     function(done) {
       var tokenStub = {id: 'stub id'};
       app.use(function(req, res, next) {
@@ -359,7 +370,7 @@ describe('loopback.token(options)', function() {
         });
     });
 
-    it('should not overwrite valid existing token (has "id" property) ' +
+    it('does not overwrite valid existing token (has "id" property) ' +
       ' when overwriteExistingToken is falsy',
     function(done) {
       var tokenStub = {id: 'stub id'};
@@ -388,7 +399,7 @@ describe('loopback.token(options)', function() {
         });
     });
 
-    it('should overwrite invalid existing token (is !== undefined and has no "id" property) ' +
+    it('overwrites invalid existing token (is !== undefined and has no "id" property) ' +
       ' when enableDoublecheck is true',
     function(done) {
       var token = this.token;
@@ -421,7 +432,7 @@ describe('loopback.token(options)', function() {
         });
     });
 
-    it('should overwrite existing token when enableDoublecheck ' +
+    it('overwrites existing token when enableDoublecheck ' +
       'and overwriteExistingToken options are truthy',
     function(done) {
       var token = this.token;
@@ -462,12 +473,20 @@ describe('loopback.token(options)', function() {
 describe('AccessToken', function() {
   beforeEach(createTestingToken);
 
-  it('should auto-generate id', function() {
+  it('has getIdForRequest method', function() {
+    expect(typeof Token.getIdForRequest).to.eql('function');
+  });
+
+  it('has resolve method', function() {
+    expect(typeof Token.resolve).to.eql('function');
+  });
+
+  it('generates id automatically', function() {
     assert(this.token.id);
     assert.equal(this.token.id.length, 64);
   });
 
-  it('should auto-generate created date', function() {
+  it('generates created date automatically', function() {
     assert(this.token.created);
     assert(Object.prototype.toString.call(this.token.created), '[object Date]');
   });
@@ -520,6 +539,54 @@ describe('AccessToken', function() {
         if (err) return done(err);
 
         expect(token.id).to.eql(expectedTokenId);
+
+        done();
+      });
+    });
+
+    it('allows getIdForRequest() to be overridden', function(done) {
+      var expectedTokenId = this.token.id;
+      var current = Token.getIdForRequest;
+      var called = false;
+      Token.getIdForRequest = function(req, options) {
+        called = true;
+        return expectedTokenId;
+      };
+      var req = mockRequest({
+        headers: {'authorization': 'dummy'},
+      });
+
+      Token.findForRequest(req, function(err, token) {
+        Token.getIdForRequest = current;
+        if (err) return done(err);
+
+        expect(token.id).to.eql(expectedTokenId);
+        expect(called).to.be.true();
+
+        done();
+      });
+    });
+
+    it('allows resolve() to be overridden', function(done) {
+      var expectedTokenId = this.token.id;
+      var current = Token.resolve;
+      var called = false;
+      Token.resolve = function(id, cb) {
+        called = true;
+        process.nextTick(function() {
+          cb(null, {id: expectedTokenId});
+        });
+      };
+      var req = mockRequest({
+        headers: {'authorization': expectedTokenId},
+      });
+
+      Token.findForRequest(req, function(err, token) {
+        Token.validate = current;
+        if (err) return done(err);
+
+        expect(token.id).to.eql(expectedTokenId);
+        expect(called).to.be.true();
 
         done();
       });
@@ -618,7 +685,7 @@ describe('app.enableAuth()', function() {
       });
   });
 
-  it('prevent remote call if the accessToken is missing and required', function(done) {
+  it('prevents remote call if the accessToken is missing and required', function(done) {
     createTestAppAndRequest(null, done)
       .del('/tests/123')
       .expect(401)


### PR DESCRIPTION
1. Make it possible to reuse getAccessTokenId
2. Introduce a flag to control if oAuth2 bearer token should be base64
encoded

### Description


#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
