### PR TITLE
Fix Model#settings.acls doc type signature

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -102,7 +102,7 @@ module.exports = function(registry) {
    * @property {SharedClass} Model.sharedMethod The `strong-remoting` [SharedClass](http://apidocs.strongloop.com/strong-remoting/#sharedclass) that contains remoting (and http) metadata. Static property.
    * @property {Object} settings Contains additional model settings.
    * @property {string} settings.http.path Base URL of the model HTTP route.
-   * @property {Array.<string>} settings.acls Array of ACLs for the model.
+   * @property {Array.<Object>} settings.acls Array of ACLs for the model.
    * @class
    */
   var Model = registry.modelBuilder.define('Model');


### PR DESCRIPTION
### Description

It fixes Model#settings.acls doc type signature, it's an array of objects.

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
