### PR TITLE
Use `localhost` instead of `::` for local

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -632,8 +632,7 @@ app.listen = function(cb) {
     }
 
     if (!self.get('url')) {
-      if (process.platform === 'win32' && listeningOnAll) {
-        // Windows browsers don't support `0.0.0.0` host in the URL
+      if (listeningOnAll) {
         // We are replacing it with localhost to build a URL
         // that can be copied and pasted into the browser.
         host = 'localhost';

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -839,8 +839,7 @@ describe('app', function() {
       app.set('host', undefined);
 
       app.listen(function() {
-        var host = process.platform === 'win32' ? 'localhost' : app.get('host');
-        var expectedUrl = 'http://' + host + ':' + app.get('port') + '/';
+        var expectedUrl = 'http://localhost:' + app.get('port') + '/';
         expect(app.get('url'), 'url').to.equal(expectedUrl);
 
         done();


### PR DESCRIPTION
### Description
As Sam said, we can use `localhost` instead of `::` for local.

#### Related issues

#3179

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
