### PR TITLE
Remove unnecessary else, use early return

### DIFF
--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -617,9 +617,9 @@ module.exports = function(registry) {
 
     if (ds.idName) {
       return ds.idName(Model.modelName);
-    } else {
-      return 'id';
     }
+
+    return 'id';
   };
 
   PersistedModel.setupRemoting = function() {


### PR DESCRIPTION
### Description
No need to use else branch when returning from if branch.
Code is less indented this way and easier to extend (no need for if ... else if ... elseif ... etc).

#### Related issues
- None

### Checklist
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
