### PR TITLE
Support for IBM Object Storage

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -225,6 +225,15 @@ app.models = function() {
  * @param {Object} config The data source config
  */
 app.dataSource = function(name, config) {
+  // some connectors are aliases to loopback-component-storage
+  if (['object-storage'].indexOf(config.connector) > -1) {
+    config.provider = 'openstack';
+    config.connector = 'loopback-component-storage';
+    config.useServiceCatalog = ('useServiceCatalog' in config) ? config.useServiceCatalog : true;
+    config.useInternal = ('useInternal' in config) ? config.useInternal : false;
+    config.keystoneAuthVersion = config.keystoneAuthVersion || 'v3';
+  }
+
   try {
     var ds = dataSourcesFromConfig(name, config, this.connectors, this.registry);
     this.dataSources[name] =

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "karma-phantomjs-launcher": "^1.0.0",
     "karma-script-launcher": "^1.0.0",
     "loopback-boot": "^2.7.0",
+    "loopback-component-storage": "^3.2.0",
     "loopback-context": "^1.0.0",
     "mocha": "^3.0.0",
     "nyc": "^10.1.2",

--- a/test/fixtures/object-storage-app/package.json
+++ b/test/fixtures/object-storage-app/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "object-storage-app",
+  "version": "1.0.0",
+  "main": "server/server.js"
+}

--- a/test/fixtures/object-storage-app/server/datasources.json
+++ b/test/fixtures/object-storage-app/server/datasources.json
@@ -1,0 +1,12 @@
+{
+  "My-Object-Storage": {
+    "username": "0",
+    "password": "*",
+    "name": "My-Object-Storage",
+    "authUrl": "https://identity.open.softlayer.com",
+    "tenantId": "1",
+    "domainId": "2",
+    "region": "dallas",
+    "connector": "object-storage"
+  }
+}

--- a/test/fixtures/object-storage-app/server/server.js
+++ b/test/fixtures/object-storage-app/server/server.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var loopback = require('../../../../');
+var boot = require('loopback-boot');
+var app = module.exports = loopback();
+
+boot(app, __dirname, function(err) {
+  if (err) {
+    console.log(err);
+    throw err;
+  }
+  app.emit('booted');
+});

--- a/test/object-storage.test.js
+++ b/test/object-storage.test.js
@@ -1,0 +1,23 @@
+'use strict';
+var assert = require('assert');
+
+describe('object-storage connector', function() {
+  it('should be set up as loopback-component-storage', function(done) {
+    this.timeout(10000);
+    var app = require('./fixtures/object-storage-app');
+    var booted = false;
+    app.on('booted', function() {
+      if (booted) return;
+      assert('MyObjectStorage' in app.datasources);
+      var ds = app.datasources.MyObjectStorage;
+      assert.equal(ds.name, 'loopback-component-storage');
+      assert.equal(ds.settings.connector, 'loopback-component-storage');
+      assert.equal(ds.settings.provider, 'openstack');
+      assert.equal(ds.settings.useServiceCatalog, true);
+      assert.equal(ds.settings.useInternal, false);
+      assert.equal(ds.settings.keystoneAuthVersion, 'v3');
+      booted = true;
+      done();
+    });
+  });
+});


### PR DESCRIPTION
### Description

Adds support for `object-storage` connector.

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- https://github.com/strongloop-internal/scrum-loopback/issues/1537

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
