### PR TITLE
Add unit test for empty password

### DIFF
--- a/test/user.test.js
+++ b/test/user.test.js
@@ -401,16 +401,31 @@ describe('User', function() {
     var pass73Char = pass72Char + '3';
     var passTooLong = pass72Char + 'WXYZ1234';
 
-    it('rejects passwords longer than 72 characters', function(done) {
-      try {
-        User.create({ email: 'b@c.com', password: pass73Char }, function(err) {
-          if (err) return done(err);
-          done(new Error('User.create() should have thrown an error.'));
+    it('rejects empty passwords creation', function(done) {
+      User.create({email: 'b@c.com', password: ''}, function(err) {
+          expect(err.code).to.equal('INVALID_PASSWORD');
+          expect(err.statusCode).to.equal(422);
+          done();
         });
-      } catch (e) {
-        expect(e).to.match(/Password too long/);
+    });
+
+    it('rejects updating with empty password', function(done) {
+        User.create({email: 'blank@c.com', password: pass72Char}, function(err, userCreated) {
+          if (err) return done(err);
+          userCreated.updateAttribute('password', '', function(err, userUpdated) {
+            expect(err.code).to.equal('INVALID_PASSWORD');
+            expect(err.statusCode).to.equal(422);
+            done();
+          });
+        });
+      });
+
+    it('rejects passwords longer than 72 characters', function(done) {
+      User.create({ email: 'b@c.com', password: pass73Char }, function(err) {
+        expect(err.code).to.equal('PASSWORD_TOO_LONG');
+        expect(err.statusCode).to.equal(422);
         done();
-      }
+      });
     });
 
     it('rejects a new user with password longer than 72 characters', function(done) {


### PR DESCRIPTION
### Description

Passwords with empty strings should be rejected
#### Related issues
connect to https://github.com/strongloop/loopback/issues/1364

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
