### PR TITLE
Allow glob-style patterns for remote options

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -533,9 +533,9 @@ function configureModel(ModelCtor, config, app) {
   config = extend({}, config);
   config.dataSource = dataSource;
 
-  setSharedMethodSharedProperties(ModelCtor, app, config);
-
   app.registry.configureModel(ModelCtor, config);
+
+  setSharedMethodSharedProperties(ModelCtor, app, config);
 }
 
 function setSharedMethodSharedProperties(model, app, modelConfigs) {
@@ -568,21 +568,49 @@ function setSharedMethodSharedProperties(model, app, modelConfigs) {
 
   // set sharedMethod.shared using the merged settings
   var sharedMethods = model.sharedClass.methods({includeDisabled: true});
+
+  // re-map glob style values to regular expressions
+  var tests = Object
+    .keys(settings)
+    .filter(function(setting) {
+      return settings.hasOwnProperty(setting) && setting.indexOf('*') >= 0;
+    })
+    .map(function(setting) {
+      // Turn * into an testable regexp string
+      var glob = escapeRegExp(setting).replace(/\*/g, '(.)*');
+      return {regex: new RegExp(glob), setting: settings[setting]};
+    }) || [];
   sharedMethods.forEach(function(sharedMethod) {
     // use the specific setting if it exists
-    var hasSpecificSetting = settings.hasOwnProperty(sharedMethod.name);
+    var methodName = sharedMethod.isStatic ? sharedMethod.name : 'prototype.' + sharedMethod.name;
+    var hasSpecificSetting = settings.hasOwnProperty(methodName);
     if (hasSpecificSetting) {
-      sharedMethod.shared = settings[sharedMethod.name];
-    } else { // otherwise, use the default setting if it exists
-      var hasDefaultSetting = settings.hasOwnProperty('*');
-      if (hasDefaultSetting)
-        sharedMethod.shared = settings['*'];
+      if (settings[methodName] === false) {
+        sharedMethod.sharedClass.disableMethodByName(methodName);
+      } else {
+        sharedMethod.shared = true;
+      }
+    } else {
+      tests.forEach(function(glob) {
+        if (glob.regex.test(methodName)) {
+          if (glob.setting === false) {
+            sharedMethod.sharedClass.disableMethodByName(methodName);
+          } else {
+            sharedMethod.shared = true;
+          }
+        }
+      });
     }
   });
 }
 
 function clearHandlerCache(app) {
   app._handlers = undefined;
+}
+
+// Sanitize all RegExp reserved characters except * for pattern gobbing
+function escapeRegExp(str) {
+  return str.replace(/[\-\[\]\/\{\}\(\)\+\?\.\\\^\$\|]/g, '\\$&');
 }
 
 /**

--- a/test/loopback.test.js
+++ b/test/loopback.test.js
@@ -739,4 +739,141 @@ describe('loopback', function() {
       });
     }
   });
+
+  describe('Hiding shared methods', function() {
+    var app;
+
+    beforeEach(setupLoopback);
+
+    it('hides remote methods using fixed method names', function() {
+      var TestModel = app.registry.createModel(uniqueModelName);
+      app.model(TestModel, {
+        dataSource: null,
+        methods: {
+          staticMethod: {
+            isStatic: true,
+            http: {path: '/static'},
+          },
+        },
+        options: {
+          remoting: {
+            sharedMethods: {
+              staticMethod: false,
+            },
+          },
+        },
+      });
+
+      var publicMethods = getSharedMethods(TestModel);
+
+      expect(publicMethods).not.to.include.members([
+        'staticMethod',
+      ]);
+    });
+
+    it('hides remote methods using a glob pattern', function() {
+      var TestModel = app.registry.createModel(uniqueModelName);
+      app.model(TestModel, {
+        dataSource: null,
+        methods: {
+          staticMethod: {
+            isStatic: true,
+            http: {path: '/static'},
+          },
+          instanceMethod: {
+            isStatic: false,
+            http: {path: '/instance'},
+          },
+        },
+        options: {
+          remoting: {
+            sharedMethods: {
+              'prototype.*': false,
+            },
+          },
+        },
+      });
+
+      var publicMethods = getSharedMethods(TestModel);
+
+      expect(publicMethods).to.include.members([
+        'staticMethod',
+      ]);
+      expect(publicMethods).not.to.include.members([
+        'instanceMethod',
+      ]);
+    });
+
+    it('hides all remote methods using *', function() {
+      var TestModel = app.registry.createModel(uniqueModelName);
+      app.model(TestModel, {
+        dataSource: null,
+        methods: {
+          staticMethod: {
+            isStatic: true,
+            http: {path: '/static'},
+          },
+          instanceMethod: {
+            isStatic: false,
+            http: {path: '/instance'},
+          },
+        },
+        options: {
+          remoting: {
+            sharedMethods: {
+              '*': false,
+            },
+          },
+        },
+      });
+
+      var publicMethods = getSharedMethods(TestModel);
+
+      expect(publicMethods).to.be.empty();
+    });
+
+    it('hides methods for related models using globs', function() {
+      var TestModel = app.registry.createModel(uniqueModelName);
+      var RelatedModel = app.registry.createModel(uniqueModelName);
+      app.dataSource('test', {connector: 'memory'});
+      app.model(RelatedModel, {dataSource: 'test'});
+      app.model(TestModel, {
+        dataSource: 'test',
+        relations: {
+          related: {
+            type: 'hasOne',
+            model: RelatedModel,
+          },
+        },
+        options: {
+          remoting: {
+            sharedMethods: {
+              '*__related': false,
+            },
+          },
+        },
+      });
+
+      var publicMethods = getSharedMethods(TestModel);
+
+      expect(publicMethods).to.not.include.members([
+        'prototype.__create__related',
+      ]);
+    });
+
+    function setupLoopback() {
+      app = loopback({localRegistry: true});
+    }
+
+    function getSharedMethods(Model) {
+      return Model.sharedClass
+        .methods()
+        .filter(function(m) {
+          return m.shared === true;
+        })
+        .map(function(m) {
+          return m.stringName.replace(/^[^.]+\./, ''); // drop the class name
+        });
+    }
+  });
 });


### PR DESCRIPTION
### Description

This PR achieves two things:
1. By moving `setSharedMethodSharedProperties` to after registry configuration, shared methods on model relations can correctly be disabled (#2860)
2. By using a regex instead of hard-coded '*' we can use glob-style expressions to blanket disable methods (e.g. `__*__someRelation` to disable all remote methods of a model relationship)

Note, the reason I used string replacement for `*` instead of straight regular expressions is to make it backwards compatible ('*' will still enable/disable all methods)

#### Related issues

- 2860

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
