### PR TITLE
Fix/is static method settings

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -273,7 +273,7 @@ Registry.prototype._defineRemoteMethods = function(ModelCtor, methods) {
 
     if (typeof meta.isStatic !== 'boolean') {
       key = isStatic ? key : m[1];
-      meta.isStatic = isStatic;
+      meta = Object.assign({}, meta, {isStatic});
     } else if (meta.isStatic && m) {
       throw new Error(g.f('Remoting metadata for %s.%s {{"isStatic"}} does ' +
       'not match new method name-based style.', ModelCtor.modelName, key));

--- a/test/fixtures/remote-methods/common/models/Foo.json
+++ b/test/fixtures/remote-methods/common/models/Foo.json
@@ -1,0 +1,7 @@
+{
+  "name": "Foo",
+  "base": "PersistedModel",
+  "methods": {
+    "staticMethod": {}
+  }
+}

--- a/test/fixtures/remote-methods/server/config.json
+++ b/test/fixtures/remote-methods/server/config.json
@@ -1,0 +1,10 @@
+{
+  "port": 3000,
+  "host": "127.0.0.1",
+  "remoting": {
+    "errorHandler": {
+      "debug": true,
+      "log": false
+    }
+  }
+}

--- a/test/fixtures/remote-methods/server/datasources.json
+++ b/test/fixtures/remote-methods/server/datasources.json
@@ -1,0 +1,6 @@
+{
+  "db": {
+    "name": "db",
+    "connector": "memory"
+  }
+}

--- a/test/fixtures/remote-methods/server/model-config.json
+++ b/test/fixtures/remote-methods/server/model-config.json
@@ -1,0 +1,39 @@
+{
+  "_meta": {
+    "sources": [
+      "loopback/common/models",
+      "loopback/server/models",
+      "../common/models",
+      "./models"
+    ],
+    "mixins": [
+      "loopback/common/mixins",
+      "loopback/server/mixins",
+      "../common/mixins",
+      "./mixins"
+    ]
+  },
+  "User": {
+    "dataSource": "db"
+  },
+  "AccessToken": {
+    "dataSource": "db",
+    "public": false
+  },
+  "ACL": {
+    "dataSource": "db",
+    "public": false
+  },
+  "RoleMapping": {
+    "dataSource": "db",
+    "public": false
+  },
+  "Role": {
+    "dataSource": "db",
+    "public": false
+  },
+  "Foo": {
+    "dataSource": "db",
+    "public": true
+  }
+}

--- a/test/fixtures/remote-methods/server/server.js
+++ b/test/fixtures/remote-methods/server/server.js
@@ -1,0 +1,12 @@
+// Copyright IBM Corp. 2015. All Rights Reserved.
+// Node module: loopback
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+var boot = require('loopback-boot');
+var loopback = require('../../../../index');
+
+var app = module.exports = loopback();
+boot(app, __dirname);
+app.use(loopback.rest());

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -14,6 +14,7 @@ var PersistedModel = loopback.PersistedModel;
 var Promise = require('bluebird');
 var TaskEmitter = require('strong-task-emitter');
 var request = require('supertest');
+var path = require('path');
 
 var expect = require('./helpers/expect');
 
@@ -1031,5 +1032,13 @@ describe.onServer('Remote Methods', function() {
           userId = token.userId;
         });
     }
+  });
+
+  describe('Create Model with remote methods from JSON description', function() {
+    it('does not add isStatic properties to the method settings', function() {
+      var app = require(path.join(__dirname,
+        'fixtures/remote-methods/server/server.js'));
+      assert.deepEqual(app.models.Foo.settings.methods.staticMethod, {});
+    });
   });
 });


### PR DESCRIPTION
### Description

As discussed in #3529, here the PR to fix the issue where creating models from JSON descriptions modifies their remote method settings by adding `isStatic` properties to them. Once a model inherits from another, these `isStatic` properties would trigger deprecation warnings.

#### Related issues

- #3529

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
