### PR TITLE
Do not add isStatic properties to method settings

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -273,7 +273,7 @@ Registry.prototype._defineRemoteMethods = function(ModelCtor, methods) {
 
     if (typeof meta.isStatic !== 'boolean') {
       key = isStatic ? key : m[1];
-      meta.isStatic = isStatic;
+      meta = Object.assign({}, meta, {isStatic});
     } else if (meta.isStatic && m) {
       throw new Error(g.f('Remoting metadata for %s.%s {{"isStatic"}} does ' +
       'not match new method name-based style.', ModelCtor.modelName, key));

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -1032,4 +1032,18 @@ describe.onServer('Remote Methods', function() {
         });
     }
   });
+
+  describe('Create Model with remote methods from JSON description', function() {
+    it('does not add isStatic properties to the method settings', function() {
+      const app = loopback();
+      const Foo = app.registry.createModel({
+        name: 'Foo',
+        methods: {
+          staticMethod: {},
+        },
+      });
+      app.model(Foo);
+      expect(app.models.Foo.settings.methods.staticMethod).to.eql({});
+    });
+  });
 });


### PR DESCRIPTION
### Description

As discussed in #3529, here the PR to fix the issue where creating models from JSON descriptions modifies their remote method settings by adding `isStatic` properties to them. Once a model inherits from another, these `isStatic` properties would trigger deprecation warnings.

#### Related issues

- #3529

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
