### PR TITLE
Rectify to model

### DIFF
--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -1648,9 +1648,12 @@ module.exports = function(registry) {
         'which requires a string id with GUID/UUID default value.');
     }
 
-    Model.observe('after save', rectifyOnSave);
-
-    Model.observe('after delete', rectifyOnDelete);
+    Model.observe('after save', function (ctx, next) {
+      Model.rectifyOnSave(ctx, next);
+    });
+    Model.observe('after delete', function (ctx, next) {
+      Model.rectifyOnDelete(ctx, next);
+    });
 
     // Only run if the run time is server
     // Can switch off cleanup by setting the interval to -1
@@ -1671,7 +1674,7 @@ module.exports = function(registry) {
     }
   };
 
-  function rectifyOnSave(ctx, next) {
+  PersistedModel.rectifyOnSave = function(ctx, next) {
     var instance = ctx.instance || ctx.currentInstance;
     var id = instance ? instance.getId() :
       getIdFromWhereByModelId(ctx.Model, ctx.where);
@@ -1682,7 +1685,6 @@ module.exports = function(registry) {
       debug('context instance:%j currentInstance:%j where:%j data %j',
         ctx.instance, ctx.currentInstance, ctx.where, ctx.data);
     }
-
     if (id) {
       ctx.Model.rectifyChange(id, reportErrorAndNext);
     } else {
@@ -1695,9 +1697,9 @@ module.exports = function(registry) {
       }
       next();
     }
-  }
+  };
 
-  function rectifyOnDelete(ctx, next) {
+  PersistedModel.rectifyOnDelete = function(ctx, next) {
     var id = ctx.instance ? ctx.instance.getId() :
       getIdFromWhereByModelId(ctx.Model, ctx.where);
 
@@ -1719,7 +1721,7 @@ module.exports = function(registry) {
       }
       next();
     }
-  }
+  };
 
   function getIdFromWhereByModelId(Model, where) {
     var idName = Model.getIdName();


### PR DESCRIPTION
### Description
Allow after save and after delete to be overwritten on the model. This is needed for updateAll when using change detection, as the rectify step cannot determine which items have changed so it rectifies the entire model table. For example, if there are 100,000 items in a model table, and you do an updateAll with a where clause to update 20 items, the rectify will run against all 100,000 items as it does not know which items have changed.

If this function can be overwritten, then the application can handle rectify intelligently (e.g. by looking at a custom tenantID column).

#### Related issues

- None

### Checklist

- [x] New tests added or existing tests modified to cover all changes.
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
