### PR TITLE
Update all rectify

### DIFF
--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -1648,9 +1648,12 @@ module.exports = function(registry) {
         'which requires a string id with GUID/UUID default value.');
     }
 
-    Model.observe('after save', rectifyOnSave);
-
-    Model.observe('after delete', rectifyOnDelete);
+    Model.observe('after save', function (ctx, next) {
+      Model.rectifyOnSave(ctx, next);
+    });
+    Model.observe('after delete', function (ctx, next) {
+      Model.rectifyOnDelete(ctx, next);
+    });
 
     // Only run if the run time is server
     // Can switch off cleanup by setting the interval to -1
@@ -1671,7 +1674,7 @@ module.exports = function(registry) {
     }
   };
 
-  function rectifyOnSave(ctx, next) {
+  PersistedModel.rectifyOnSave = function(ctx, next) {
     var instance = ctx.instance || ctx.currentInstance;
     var id = instance ? instance.getId() :
       getIdFromWhereByModelId(ctx.Model, ctx.where);
@@ -1682,7 +1685,6 @@ module.exports = function(registry) {
       debug('context instance:%j currentInstance:%j where:%j data %j',
         ctx.instance, ctx.currentInstance, ctx.where, ctx.data);
     }
-
     if (id) {
       ctx.Model.rectifyChange(id, reportErrorAndNext);
     } else {
@@ -1695,9 +1697,9 @@ module.exports = function(registry) {
       }
       next();
     }
-  }
+  };
 
-  function rectifyOnDelete(ctx, next) {
+  PersistedModel.rectifyOnDelete = function(ctx, next) {
     var id = ctx.instance ? ctx.instance.getId() :
       getIdFromWhereByModelId(ctx.Model, ctx.where);
 
@@ -1719,7 +1721,7 @@ module.exports = function(registry) {
       }
       next();
     }
-  }
+  };
 
   function getIdFromWhereByModelId(Model, where) {
     var idName = Model.getIdName();

--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -1678,12 +1678,10 @@ module.exports = function(registry) {
         next();
         return;
       }
-      if (debug.enabled) {
-        debug('rectifyOnSave %s -> ' + (ids ? 'ids %j' : '%s'),
-          ctx.Model.modelName, ids ? ids : 'ALL');
-        debug('context instance:%j currentInstance:%j where:%j data %j',
-          ctx.instance, ctx.currentInstance, ctx.where, ctx.data);
-      }
+      debug('rectifyOnSave %s -> ' + (ids ? 'ids %j' : '%s'),
+        ctx.Model.modelName, ids ? ids : 'ALL');
+      debug('context instance:%j currentInstance:%j where:%j data %j',
+        ctx.instance, ctx.currentInstance, ctx.where, ctx.data);
 
       if (ids) {
         ctx.Model.rectifyChanges(ids, reportErrorAndNext);
@@ -1708,11 +1706,9 @@ module.exports = function(registry) {
         return;
       }
 
-      if (debug.enabled) {
-        debug('rectifyOnDelete %s -> ' + (ids ? 'ids %j' : '%s'),
-          ctx.Model.modelName, ids ? ids : 'ALL');
-        debug('context instance:%j where:%j', ctx.instance, ctx.where);
-      }
+      debug('rectifyOnDelete %s -> ' + (ids ? 'ids %j' : '%s'),
+        ctx.Model.modelName, ids ? ids : 'ALL');
+      debug('context instance:%j where:%j', ctx.instance, ctx.where);
 
       if (ids) {
         ctx.Model.rectifyChanges(ids, reportErrorAndNext);

--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -1674,8 +1674,8 @@ module.exports = function(registry) {
   function rectifyOnSave(ctx, next) {
     collateIdsFromContext(ctx, function(err, ids) {
       if (err) {
-        Model.handleChangeError(err, 'rectifyOnSave');
-        next();
+        ctx.Model.handleChangeError(err, 'rectifyOnSave');
+        next(err);
         return;
       }
       debug('rectifyOnSave %s -> ' + (ids ? 'ids %j' : '%s'),
@@ -1701,8 +1701,8 @@ module.exports = function(registry) {
   function rectifyOnDelete(ctx, next) {
     collateIdsFromContext(ctx, function(err, ids) {
       if (err) {
-        Model.handleChangeError(err, 'rectifyOnDelete');
-        next();
+        ctx.Model.handleChangeError(err, 'rectifyOnDelete');
+        next(err);
         return;
       }
 
@@ -1730,7 +1730,7 @@ module.exports = function(registry) {
     if (!!instance) {
       cb(null, [instance.getId()]);
     } else {
-      ctx.Model.getIdsFromWhere(ctx.where, cb);
+      ctx.Model.getIdsFromWhere(ctx.where, ctx, cb);
     }
   }
 
@@ -1738,11 +1738,12 @@ module.exports = function(registry) {
    * get the ids for a given where clause by checking for the id property.
    * This handles both single ids and arrays of ids asyncronously.
    * @param where the loopback where clause to analyse
+   * @param ctx the context of the operation, possibly used to retrieve IDs put in at a before save
    * @callback {Function} callback Callback function called with `(err, id)` arguments.
    * @param {Error} err Error object; see [Error object](http://docs.strongloop.com/display/LB/Error+object).
    * @param {Array} Array of loopback ids
    */
-  PersistedModel.getIdsFromWhere = function(where, cb) {
+  PersistedModel.getIdsFromWhere = function(where, ctx, cb) {
     var Model = this;
     // allowed to be an async request in the case that a query is needed.
     // e.g. to find all items of a particular tenantID specified in the where clause.

--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -1648,12 +1648,8 @@ module.exports = function(registry) {
         'which requires a string id with GUID/UUID default value.');
     }
 
-    Model.observe('after save', function(ctx, next) {
-      rectifyOnSave(ctx, next);
-    });
-    Model.observe('after delete', function(ctx, next) {
-      rectifyOnDelete(ctx, next);
-    });
+    Model.observe('after save', rectifyOnSave);
+    Model.observe('after delete', rectifyOnDelete);
 
     // Only run if the run time is server
     // Can switch off cleanup by setting the interval to -1

--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -1649,10 +1649,10 @@ module.exports = function(registry) {
     }
 
     Model.observe('after save', function(ctx, next) {
-      Model.rectifyOnSave(ctx, next);
+      rectifyOnSave(ctx, next);
     });
     Model.observe('after delete', function(ctx, next) {
-      Model.rectifyOnDelete(ctx, next);
+      rectifyOnDelete(ctx, next);
     });
 
     // Only run if the run time is server
@@ -1674,23 +1674,26 @@ module.exports = function(registry) {
     }
   };
 
-  PersistedModel.rectifyOnSave = function(ctx, next) {
-    var instance = ctx.instance || ctx.currentInstance;
-    var ids = instance ? [instance.getId()] :
-      getIdsFromWhereByModelId(ctx.Model, ctx.where);
+  function rectifyOnSave(ctx, next) {
+    collateIdsFromContext(ctx, function(err, ids) {
+      if (err) {
+        Model.handleChangeError(err, 'rectifyOnSave');
+        next();
+        return;
+      }
+      if (debug.enabled) {
+        debug('rectifyOnSave %s -> ' + (ids ? 'ids %j' : '%s'),
+          ctx.Model.modelName, ids ? ids : 'ALL');
+        debug('context instance:%j currentInstance:%j where:%j data %j',
+          ctx.instance, ctx.currentInstance, ctx.where, ctx.data);
+      }
 
-    if (debug.enabled) {
-      debug('rectifyOnSave %s -> ' + (ids ? 'ids %j' : '%s'),
-        ctx.Model.modelName, ids ? ids : 'ALL');
-      debug('context instance:%j currentInstance:%j where:%j data %j',
-        ctx.instance, ctx.currentInstance, ctx.where, ctx.data);
-    }
-
-    if (ids) {
-      ctx.Model.rectifyChanges(ids, reportErrorAndNext);
-    } else {
-      ctx.Model.rectifyAllChanges(reportErrorAndNext);
-    }
+      if (ids) {
+        ctx.Model.rectifyChanges(ids, reportErrorAndNext);
+      } else {
+        ctx.Model.rectifyAllChanges(reportErrorAndNext);
+      }
+    });
 
     function reportErrorAndNext(err) {
       if (err) {
@@ -1698,23 +1701,28 @@ module.exports = function(registry) {
       }
       next();
     }
-  };
+  }
 
-  PersistedModel.rectifyOnDelete = function(ctx, next) {
-    var id = ctx.instance ? [ctx.instance.getId()] :
-      getIdsFromWhereByModelId(ctx.Model, ctx.where);
+  function rectifyOnDelete(ctx, next) {
+    collateIdsFromContext(ctx, function(err, ids) {
+      if (err) {
+        Model.handleChangeError(err, 'rectifyOnDelete');
+        next();
+        return;
+      }
 
-    if (debug.enabled) {
-      debug('rectifyOnDelete %s -> ' + (ids ? 'ids %j' : '%s'),
-        ctx.Model.modelName, ids ? ids : 'ALL');
-      debug('context instance:%j where:%j', ctx.instance, ctx.where);
-    }
+      if (debug.enabled) {
+        debug('rectifyOnDelete %s -> ' + (ids ? 'ids %j' : '%s'),
+          ctx.Model.modelName, ids ? ids : 'ALL');
+        debug('context instance:%j where:%j', ctx.instance, ctx.where);
+      }
 
-    if (ids) {
-      ctx.Model.rectifyChanges(ids, reportErrorAndNext);
-    } else {
-      ctx.Model.rectifyAllChanges(reportErrorAndNext);
-    }
+      if (ids) {
+        ctx.Model.rectifyChanges(ids, reportErrorAndNext);
+      } else {
+        ctx.Model.rectifyAllChanges(reportErrorAndNext);
+      }
+    });
 
     function reportErrorAndNext(err) {
       if (err) {
@@ -1722,23 +1730,38 @@ module.exports = function(registry) {
       }
       next();
     }
-  };
+  }
 
-  function getIdsFromWhereByModelId(Model, where) {
+  function collateIdsFromContext(ctx, cb) {
+    var instance = ctx.instance || ctx.currentInstance;
+    if (!!instance) {
+      cb(null, [instance.getId()]);
+    } else {
+      ctx.Model.getIdsFromWhereByModelId(ctx.where, cb);
+    }
+  }
+
+  PersistedModel.getIdsFromWhereByModelId = function(where, cb) {
+    var Model = this;
+    // allowed to be an async request in the case that a query is needed.
+    // e.g. to find all items of a particular tenantID specified in the where clause.
+    var ids = null;
     var idName = Model.getIdName();
-    if (!(idName in where)) return undefined;
+    if (!(idName in where)) {
+      return cb(null, ids);
+    }
 
     var id = where[idName];
     // TODO(bajtos) support object values that are not LB conditions
     if (typeof id === 'string' || typeof id === 'number') {
-      return [id];
+      ids = [id];
     } else if (typeof id === 'object') {
       if (id.inq && Array.isArray(id.inq)) {
-        return id.inq;
+        ids = id.inq;
       }
     }
-    return undefined;
-  }
+    cb(null, ids);
+  };
 
   PersistedModel._defineChangeModel = function() {
     var BaseChangeModel = this.registry.getModel('Change');

--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -1676,17 +1676,18 @@ module.exports = function(registry) {
 
   PersistedModel.rectifyOnSave = function(ctx, next) {
     var instance = ctx.instance || ctx.currentInstance;
-    var id = instance ? instance.getId() :
-      getIdFromWhereByModelId(ctx.Model, ctx.where);
+    var ids = instance ? [instance.getId()] :
+      getIdsFromWhereByModelId(ctx.Model, ctx.where);
 
     if (debug.enabled) {
-      debug('rectifyOnSave %s -> ' + (id ? 'id %j' : '%s'),
-        ctx.Model.modelName, id ? id : 'ALL');
+      debug('rectifyOnSave %s -> ' + (ids ? 'ids %j' : '%s'),
+        ctx.Model.modelName, ids ? ids : 'ALL');
       debug('context instance:%j currentInstance:%j where:%j data %j',
         ctx.instance, ctx.currentInstance, ctx.where, ctx.data);
     }
-    if (id) {
-      ctx.Model.rectifyChange(id, reportErrorAndNext);
+
+    if (ids) {
+      ctx.Model.rectifyChanges(ids, reportErrorAndNext);
     } else {
       ctx.Model.rectifyAllChanges(reportErrorAndNext);
     }
@@ -1700,17 +1701,17 @@ module.exports = function(registry) {
   };
 
   PersistedModel.rectifyOnDelete = function(ctx, next) {
-    var id = ctx.instance ? ctx.instance.getId() :
-      getIdFromWhereByModelId(ctx.Model, ctx.where);
+    var id = ctx.instance ? [ctx.instance.getId()] :
+      getIdsFromWhereByModelId(ctx.Model, ctx.where);
 
     if (debug.enabled) {
-      debug('rectifyOnDelete %s -> ' + (id ? 'id %j' : '%s'),
-        ctx.Model.modelName, id ? id : 'ALL');
+      debug('rectifyOnDelete %s -> ' + (ids ? 'ids %j' : '%s'),
+        ctx.Model.modelName, ids ? ids : 'ALL');
       debug('context instance:%j where:%j', ctx.instance, ctx.where);
     }
 
-    if (id) {
-      ctx.Model.rectifyChange(id, reportErrorAndNext);
+    if (ids) {
+      ctx.Model.rectifyChanges(ids, reportErrorAndNext);
     } else {
       ctx.Model.rectifyAllChanges(reportErrorAndNext);
     }
@@ -1723,14 +1724,18 @@ module.exports = function(registry) {
     }
   };
 
-  function getIdFromWhereByModelId(Model, where) {
+  function getIdsFromWhereByModelId(Model, where) {
     var idName = Model.getIdName();
     if (!(idName in where)) return undefined;
 
     var id = where[idName];
     // TODO(bajtos) support object values that are not LB conditions
     if (typeof id === 'string' || typeof id === 'number') {
-      return id;
+      return [id];
+    } else if (typeof id === 'object') {
+      if (id.inq && Array.isArray(id.inq)) {
+        return id.inq;
+      }
     }
     return undefined;
   }
@@ -1793,6 +1798,19 @@ module.exports = function(registry) {
   PersistedModel.rectifyChange = function(id, callback) {
     var Change = this.getChangeModel();
     Change.rectifyModelChanges(this.modelName, [id], callback);
+  };
+
+  /**
+   * Specify that changes to the models with the given IDs have occurred.
+   *
+   * @param {Array} ids The IDs of the models that have changed.
+   * @callback {Function} callback
+   * @param {Error} err
+   */
+
+  PersistedModel.rectifyChanges = function(ids, callback) {
+    var Change = this.getChangeModel();
+    Change.rectifyModelChanges(this.modelName, ids, callback);
   };
 
   PersistedModel.findLastChange = function(id, cb) {

--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -1734,11 +1734,19 @@ module.exports = function(registry) {
     if (!!instance) {
       cb(null, [instance.getId()]);
     } else {
-      ctx.Model.getIdsFromWhereByModelId(ctx.where, cb);
+      ctx.Model.getIdsFromWhere(ctx.where, cb);
     }
   }
 
-  PersistedModel.getIdsFromWhereByModelId = function(where, cb) {
+  /**
+   * get the ids for a given where clause by checking for the id property.
+   * This handles both single ids and arrays of ids asyncronously.
+   * @param where the loopback where clause to analyse
+   * @callback {Function} callback Callback function called with `(err, id)` arguments.
+   * @param {Error} err Error object; see [Error object](http://docs.strongloop.com/display/LB/Error+object).
+   * @param {Array} Array of loopback ids
+   */
+  PersistedModel.getIdsFromWhere = function(where, cb) {
     var Model = this;
     // allowed to be an async request in the case that a query is needed.
     // e.g. to find all items of a particular tenantID specified in the where clause.

--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -1648,10 +1648,10 @@ module.exports = function(registry) {
         'which requires a string id with GUID/UUID default value.');
     }
 
-    Model.observe('after save', function (ctx, next) {
+    Model.observe('after save', function(ctx, next) {
       Model.rectifyOnSave(ctx, next);
     });
-    Model.observe('after delete', function (ctx, next) {
+    Model.observe('after delete', function(ctx, next) {
       Model.rectifyOnDelete(ctx, next);
     });
 

--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -1649,6 +1649,7 @@ module.exports = function(registry) {
     }
 
     Model.observe('after save', rectifyOnSave);
+
     Model.observe('after delete', rectifyOnDelete);
 
     // Only run if the run time is server

--- a/test/replication.test.js
+++ b/test/replication.test.js
@@ -132,7 +132,7 @@ describe('Replication / Change APIs', function() {
     }
   });
 
-  describe('optimization check rectifyChange Vs rectifyAllChanges', function() {
+  describe('optimization check rectifyChanges Vs rectifyAllChanges', function() {
     beforeEach(function initialData(done) {
       var data = [{name: 'John', surname: 'Doe'}, {name: 'Jane', surname: 'Roe'}];
       async.waterfall([
@@ -157,6 +157,25 @@ describe('Replication / Change APIs', function() {
       });
     });
 
+    it('should call rectifyChanges when ids are passed for rectifyOnDelete', function(done) {
+      var calls = mockSourceModelRectify();
+      SourceModel.find({}, function(err, data) {
+
+        // find the ids of John and Jane
+        var ids = data.map(function(item) {
+          return item.id;
+        });
+
+        SourceModel.destroyAll({id: {inq: ids}}, function(err, data) {
+          if (err) return done(err);
+
+          expect(calls).to.eql(['rectifyChanges']);
+
+          done();
+        });
+      });
+    });
+
     it('should call rectifyAllChanges if no id is passed for rectifyOnSave', function(done) {
       var calls = mockSourceModelRectify();
       var newData = {'name': 'Janie'};
@@ -169,7 +188,27 @@ describe('Replication / Change APIs', function() {
       });
     });
 
-    it('rectifyOnDelete for Delete should call rectifyChange instead of rectifyAllChanges', function(done) {
+    it('should call rectifyChanges when ids are passed for rectifyOnSave', function(done) {
+      var calls = mockSourceModelRectify();
+      var newData = {'name': 'Janie'};
+      SourceModel.find({}, function(err, data) {
+
+        // find the ids of John and Jane
+        var ids = data.map(function(item) {
+          return item.id;
+        });
+
+        SourceModel.update({id: {inq: ids}}, newData, function(err, data) {
+          if (err) return done(err);
+
+          expect(calls).to.eql(['rectifyChanges']);
+
+          done();
+        });
+      });
+    });
+
+    it('rectifyOnDelete for Delete should call rectifyChanges instead of rectifyAllChanges', function(done) {
       var calls = mockTargetModelRectify();
       async.waterfall([
         function(callback) {
@@ -177,12 +216,12 @@ describe('Replication / Change APIs', function() {
         },
         function(data, callback) {
           SourceModel.replicate(TargetModel, callback);
-          // replicate should call `rectifyOnDelete` and then `rectifyChange` not `rectifyAllChanges` through `after delete` operation
+          // replicate should call `rectifyOnDelete` and then `rectifyChanges` not `rectifyAllChanges` through `after delete` operation
         }
       ], function(err, results) {
         if (err) return done(err);
 
-        expect(calls).to.eql(['rectifyChange']);
+        expect(calls).to.eql(['rectifyChanges']);
 
         done();
       });
@@ -229,7 +268,7 @@ describe('Replication / Change APIs', function() {
       });
     });
 
-    it('rectifyOnSave for Update should call rectifyChange instead of rectifyAllChanges', function(done) {
+    it('rectifyOnSave for Update should call rectifyChanges instead of rectifyAllChanges', function(done) {
       var calls = mockTargetModelRectify();
       var newData = {'name': 'Janie'};
       async.waterfall([
@@ -238,12 +277,12 @@ describe('Replication / Change APIs', function() {
         },
         function(data, callback) {
           SourceModel.replicate(TargetModel, callback);
-          // replicate should call `rectifyOnSave` and then `rectifyChange` not `rectifyAllChanges` through `after save` operation
+          // replicate should call `rectifyOnSave` and then `rectifyChanges` not `rectifyAllChanges` through `after save` operation
         }
       ], function(err, result) {
         if (err) return done(err);
 
-        expect(calls).to.eql(['rectifyChange']);
+        expect(calls).to.eql(['rectifyChanges']);
 
         done();
       });
@@ -292,7 +331,7 @@ describe('Replication / Change APIs', function() {
       });
     });
 
-    it('rectifyOnSave for Create should call rectifyChange instead of rectifyAllChanges', function(done) {
+    it('rectifyOnSave for Create should call rectifyChanges instead of rectifyAllChanges', function(done) {
       var calls = mockTargetModelRectify();
       var newData = [{name: 'Janie', surname: 'Doe'}];
       async.waterfall([
@@ -301,12 +340,12 @@ describe('Replication / Change APIs', function() {
         },
         function(data, callback) {
           SourceModel.replicate(TargetModel, callback);
-          // replicate should call `rectifyOnSave` and then `rectifyChange` not `rectifyAllChanges` through `after save` operation
+          // replicate should call `rectifyOnSave` and then `rectifyChanges` not `rectifyAllChanges` through `after save` operation
         }
       ], function(err, result) {
         if (err) return done(err);
 
-        expect(calls).to.eql(['rectifyChange']);
+        expect(calls).to.eql(['rectifyChanges']);
 
         done();
       });
@@ -317,6 +356,11 @@ describe('Replication / Change APIs', function() {
 
       SourceModel.rectifyChange = function(id, cb) {
         calls.push('rectifyChange');
+        process.nextTick(cb);
+      };
+
+      SourceModel.rectifyChanges = function(id, cb) {
+        calls.push('rectifyChanges');
         process.nextTick(cb);
       };
 
@@ -333,6 +377,11 @@ describe('Replication / Change APIs', function() {
 
       TargetModel.rectifyChange = function(id, cb) {
         calls.push('rectifyChange');
+        process.nextTick(cb);
+      };
+
+      TargetModel.rectifyChanges = function(id, cb) {
+        calls.push('rectifyChanges');
         process.nextTick(cb);
       };
 

--- a/test/replication.test.js
+++ b/test/replication.test.js
@@ -249,7 +249,7 @@ describe('Replication / Change APIs', function() {
       var sourceCalls = mockSourceModelRectify();
 
       // overwrite rectifyOnDelete
-      SourceModel.getIdsFromWhere = function(where, cb) {
+      SourceModel.getIdsFromWhere = function(where, ctx, cb) {
         var ids = where.name === 'Jane' ? ['abc', 'def'] : null;
         cb(null, ids);
       };
@@ -265,6 +265,21 @@ describe('Replication / Change APIs', function() {
         if (err) return done(err);
         expect(sourceCalls).to.eql(['rectifyChanges']);
         done();
+      });
+    });
+
+    it('rectifyOnDelete for destroyAll when overwritten should handle error case', function(done) {
+
+      // overwrite rectifyOnDelete
+      SourceModel.getIdsFromWhere = function(where, ctx, cb) {
+
+        cb('An Error Occurred', null);
+      };
+      SourceModel.once('error', function() {
+        done();
+      });
+      SourceModel.destroyAll({name: 'Jane'}, function(err, results) {
+        expect(err).to.equal('An Error Occurred');
       });
     });
 
@@ -312,7 +327,7 @@ describe('Replication / Change APIs', function() {
       var newData = {'name': 'Janie'};
 
       // overwrite rectifyOnSave
-      SourceModel.getIdsFromWhere = function(where, cb) {
+      SourceModel.getIdsFromWhere = function(where, ctx, cb) {
         var ids = where.name === 'Jane' ? ['abc', 'def'] : null;
         cb(null, ids);
       };
@@ -328,6 +343,21 @@ describe('Replication / Change APIs', function() {
         if (err) return done(err);
         expect(sourceCalls).to.eql(['rectifyChanges']);
         done();
+      });
+    });
+
+    it('rectifyOnSave for updateAll when overwritten should handle error case', function(done) {
+
+      // overwrite rectifyOnSave
+      SourceModel.getIdsFromWhere = function(where, ctx, cb) {
+
+        cb('An Error Occurred', null);
+      };
+      SourceModel.once('error', function() {
+        done();
+      });
+      SourceModel.updateAll({name: 'Jane'}, function(err, results) {
+        expect(err).to.equal('An Error Occurred');
       });
     });
 

--- a/test/replication.test.js
+++ b/test/replication.test.js
@@ -249,7 +249,7 @@ describe('Replication / Change APIs', function() {
       var sourceCalls = mockSourceModelRectify();
 
       // overwrite rectifyOnSave
-      SourceModel.getIdsFromWhereByModelId = function(where, cb) {
+      SourceModel.getIdsFromWhere = function(where, cb) {
         var ids = where.name === 'Jane' ? ['abc', 'def'] : null;
         cb(null, ids);
       };
@@ -312,7 +312,7 @@ describe('Replication / Change APIs', function() {
       var newData = {'name': 'Janie'};
 
       // overwrite rectifyOnSave
-      SourceModel.getIdsFromWhereByModelId = function(where, cb) {
+      SourceModel.getIdsFromWhere = function(where, cb) {
         var ids = where.name === 'Jane' ? ['abc', 'def'] : null;
         cb(null, ids);
       };

--- a/test/replication.test.js
+++ b/test/replication.test.js
@@ -248,7 +248,7 @@ describe('Replication / Change APIs', function() {
     it('rectifyOnDelete for destroyAll should call rectifyChange instead of rectifyAllChanges when overwritten', function(done) {
       var sourceCalls = mockSourceModelRectify();
 
-      // overwrite rectifyOnSave
+      // overwrite rectifyOnDelete
       SourceModel.getIdsFromWhere = function(where, cb) {
         var ids = where.name === 'Jane' ? ['abc', 'def'] : null;
         cb(null, ids);

--- a/test/replication.test.js
+++ b/test/replication.test.js
@@ -249,9 +249,9 @@ describe('Replication / Change APIs', function() {
       var sourceCalls = mockSourceModelRectify();
 
       // overwrite rectifyOnSave
-      SourceModel.rectifyOnDelete = function(ctx, next) {
-        var id = 'abc';
-        ctx.Model.rectifyChange(id, next);
+      SourceModel.getIdsFromWhereByModelId = function(where, cb) {
+        var ids = where.name === 'Jane' ? ['abc', 'def'] : null;
+        cb(null, ids);
       };
       async.waterfall([
         function(callback) {
@@ -263,7 +263,7 @@ describe('Replication / Change APIs', function() {
         }
       ], function(err, result) {
         if (err) return done(err);
-        expect(sourceCalls).to.eql(['rectifyChange']);
+        expect(sourceCalls).to.eql(['rectifyChanges']);
         done();
       });
     });
@@ -312,9 +312,9 @@ describe('Replication / Change APIs', function() {
       var newData = {'name': 'Janie'};
 
       // overwrite rectifyOnSave
-      SourceModel.rectifyOnSave = function(ctx, next) {
-        var id = 'abc';
-        ctx.Model.rectifyChange(id, next);
+      SourceModel.getIdsFromWhereByModelId = function(where, cb) {
+        var ids = where.name === 'Jane' ? ['abc', 'def'] : null;
+        cb(null, ids);
       };
       async.waterfall([
         function(callback) {
@@ -326,7 +326,7 @@ describe('Replication / Change APIs', function() {
         }
       ], function(err, result) {
         if (err) return done(err);
-        expect(sourceCalls).to.eql(['rectifyChange']);
+        expect(sourceCalls).to.eql(['rectifyChanges']);
         done();
       });
     });


### PR DESCRIPTION
### Description
Allow getIdsFromWhere to be overwritten on the model. This is needed for updateAll when using change detection, as the rectify step cannot determine which items have changed so it rectifies the entire model table. For example, if there are 100,000 items in a model table, and you do an updateAll with a where clause to update 20 items, the rectify will run against all 100,000 items as it does not know which items have changed.

The getIdsFromWhereByModelId handles finding ids in 'inq' where clauses by default.

Now that this function can be overwritten, the application can handle more complex rectify where clauses more intelligently (e.g. by looking at a custom tenantID column to find all ids that would have changed).


#### Related issues

- None

### Checklist

- [x] New tests added or existing tests modified to cover all changes.
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
