### PR TITLE
Fix relation race condition in model glob

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -534,83 +534,10 @@ function configureModel(ModelCtor, config, app) {
   config.dataSource = dataSource;
 
   app.registry.configureModel(ModelCtor, config);
-
-  setSharedMethodSharedProperties(ModelCtor, app, config);
-}
-
-function setSharedMethodSharedProperties(model, app, modelConfigs) {
-  var settings = {};
-
-  // apply config.json settings
-  var config = app.get('remoting');
-  var configHasSharedMethodsSettings = config &&
-      config.sharedMethods &&
-      typeof config.sharedMethods === 'object';
-  if (configHasSharedMethodsSettings)
-    util._extend(settings, config.sharedMethods);
-
-  // apply model-config.json settings
-  var modelConfig = modelConfigs.options;
-  var modelConfigHasSharedMethodsSettings = modelConfig &&
-      modelConfig.remoting &&
-      modelConfig.remoting.sharedMethods &&
-      typeof modelConfig.remoting.sharedMethods === 'object';
-  if (modelConfigHasSharedMethodsSettings)
-    util._extend(settings, modelConfig.remoting.sharedMethods);
-
-  // validate setting values
-  Object.keys(settings).forEach(function(setting) {
-    var settingValue = settings[setting];
-    var settingValueType = typeof settingValue;
-    if (settingValueType !== 'boolean')
-      throw new TypeError(g.f('Expected boolean, got %s', settingValueType));
-  });
-
-  // set sharedMethod.shared using the merged settings
-  var sharedMethods = model.sharedClass.methods({includeDisabled: true});
-
-  // re-map glob style values to regular expressions
-  var tests = Object
-    .keys(settings)
-    .filter(function(setting) {
-      return settings.hasOwnProperty(setting) && setting.indexOf('*') >= 0;
-    })
-    .map(function(setting) {
-      // Turn * into an testable regexp string
-      var glob = escapeRegExp(setting).replace(/\*/g, '(.)*');
-      return {regex: new RegExp(glob), setting: settings[setting]};
-    }) || [];
-  sharedMethods.forEach(function(sharedMethod) {
-    // use the specific setting if it exists
-    var methodName = sharedMethod.isStatic ? sharedMethod.name : 'prototype.' + sharedMethod.name;
-    var hasSpecificSetting = settings.hasOwnProperty(methodName);
-    if (hasSpecificSetting) {
-      if (settings[methodName] === false) {
-        sharedMethod.sharedClass.disableMethodByName(methodName);
-      } else {
-        sharedMethod.shared = true;
-      }
-    } else {
-      tests.forEach(function(glob) {
-        if (glob.regex.test(methodName)) {
-          if (glob.setting === false) {
-            sharedMethod.sharedClass.disableMethodByName(methodName);
-          } else {
-            sharedMethod.shared = true;
-          }
-        }
-      });
-    }
-  });
 }
 
 function clearHandlerCache(app) {
   app._handlers = undefined;
-}
-
-// Sanitize all RegExp reserved characters except * for pattern gobbing
-function escapeRegExp(str) {
-  return str.replace(/[\-\[\]\/\{\}\(\)\+\?\.\\\^\$\|]/g, '\\$&');
 }
 
 /**

--- a/lib/configure-shared-methods.js
+++ b/lib/configure-shared-methods.js
@@ -1,0 +1,75 @@
+'use strict';
+
+var util = require('util');
+var extend = require('util')._extend;
+var g = require('./globalize');
+
+module.exports = function(modelCtor, remotingConfig, modelConfig) {
+  var settings = {};
+
+  // apply config.json settings
+  var configHasSharedMethodsSettings = remotingConfig &&
+      remotingConfig.sharedMethods &&
+      typeof remotingConfig.sharedMethods === 'object';
+  if (configHasSharedMethodsSettings)
+    util._extend(settings, remotingConfig.sharedMethods);
+
+  // apply model-config.json settings
+  const options = modelConfig.options;
+  var modelConfigHasSharedMethodsSettings = options &&
+      options.remoting &&
+      options.remoting.sharedMethods &&
+      typeof options.remoting.sharedMethods === 'object';
+  if (modelConfigHasSharedMethodsSettings)
+    util._extend(settings, options.remoting.sharedMethods);
+
+  // validate setting values
+  Object.keys(settings).forEach(function(setting) {
+    var settingValue = settings[setting];
+    var settingValueType = typeof settingValue;
+    if (settingValueType !== 'boolean')
+      throw new TypeError(g.f('Expected boolean, got %s', settingValueType));
+  });
+
+  // set sharedMethod.shared using the merged settings
+  var sharedMethods = modelCtor.sharedClass.methods({includeDisabled: true});
+
+  // re-map glob style values to regular expressions
+  var tests = Object
+    .keys(settings)
+    .filter(function(setting) {
+      return settings.hasOwnProperty(setting) && setting.indexOf('*') >= 0;
+    })
+    .map(function(setting) {
+      // Turn * into an testable regexp string
+      var glob = escapeRegExp(setting).replace(/\*/g, '(.)*');
+      return {regex: new RegExp(glob), setting: settings[setting]};
+    }) || [];
+  sharedMethods.forEach(function(sharedMethod) {
+    // use the specific setting if it exists
+    var methodName = sharedMethod.isStatic ? sharedMethod.name : 'prototype.' + sharedMethod.name;
+    var hasSpecificSetting = settings.hasOwnProperty(methodName);
+    if (hasSpecificSetting) {
+      if (settings[methodName] === false) {
+        sharedMethod.sharedClass.disableMethodByName(methodName);
+      } else {
+        sharedMethod.shared = true;
+      }
+    } else {
+      tests.forEach(function(glob) {
+        if (glob.regex.test(methodName)) {
+          if (glob.setting === false) {
+            sharedMethod.sharedClass.disableMethodByName(methodName);
+          } else {
+            sharedMethod.shared = true;
+          }
+        }
+      });
+    }
+  });
+};
+
+// Sanitize all RegExp reserved characters except * for pattern gobbing
+function escapeRegExp(str) {
+  return str.replace(/[\-\[\]\/\{\}\(\)\+\?\.\\\^\$\|]/g, '\\$&');
+}

--- a/lib/loopback.js
+++ b/lib/loopback.js
@@ -18,6 +18,7 @@ var merge = require('util')._extend;
 var assert = require('assert');
 var Registry = require('./registry');
 var juggler = require('loopback-datasource-juggler');
+var configureSharedMethods = require('./configure-shared-methods');
 
 /**
  * LoopBack core module. It provides static properties and
@@ -77,6 +78,13 @@ function createApplication(options) {
   merge(app, proto);
 
   app.loopback = loopback;
+
+  app.on('modelRemoted', function() {
+    app.models().forEach(function(Model) {
+      if (!Model.config) return;
+      configureSharedMethods(Model, app.get('remoting'), Model.config);
+    });
+  });
 
   // Create a new instance of models registry per each app instance
   app.models = function() {

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -179,6 +179,8 @@ Registry.prototype.configureModel = function(ModelCtor, config) {
   var settings = ModelCtor.settings;
   var modelName = ModelCtor.modelName;
 
+  ModelCtor.config = config;
+
   // Relations
   if (typeof config.relations === 'object' && config.relations !== null) {
     var relations = settings.relations = settings.relations || {};


### PR DESCRIPTION
### Description

#3504 added support for glob-style patterns when disabling remote methods. However, if a related model is attached _after_ the initial model is configured, the globs do not work. I have updated to reconfigure shared method properties after each new model is attached to remoting.

This was not caught in testing of #3504 as the root model was attached after the related model. Have updated the test to fail without the fix.

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
