### PR TITLE
Catch errors on invalidate update

### DIFF
--- a/test/user.test.js
+++ b/test/user.test.js
@@ -417,6 +417,39 @@ describe('User', function() {
       });
     });
 
+    it('rejects updating with empty password using replaceAttributes', function(done) {
+      User.create({email: 'b@example.com', password: pass72Char}, function(err, userCreated) {
+        if (err) return done(err);
+        userCreated.replaceAttributes({'password': ''}, function(err, userUpdated) {
+          expect(err.code).to.equal('INVALID_PASSWORD');
+          expect(err.statusCode).to.equal(422);
+          done();
+        });
+      });
+    });
+
+    it('rejects updating with empty password using updateOrCreate', function(done) {
+      User.create({email: 'b@example.com', password: pass72Char}, function(err, userCreated) {
+        if (err) return done(err);
+        User.updateOrCreate({id: userCreated.id, 'password': ''}, function(err, userUpdated) {
+          expect(err.code).to.equal('INVALID_PASSWORD');
+          expect(err.statusCode).to.equal(422);
+          done();
+        });
+      });
+    });
+
+    it('rejects updating with empty password using updateAll', function(done) {
+      User.create({email: 'b@example.com', password: pass72Char}, function(err, userCreated) {
+        if (err) return done(err);
+        User.updateAll({where: {id: userCreated.id}}, {'password': ''}, function(err, userUpdated) {
+          expect(err.code).to.equal('INVALID_PASSWORD');
+          expect(err.statusCode).to.equal(422);
+          done();
+        });
+      });
+    });
+
     it('rejects passwords longer than 72 characters', function(done) {
       User.create({email: 'b@c.com', password: pass73Char}, function(err) {
         expect(err.code).to.equal('PASSWORD_TOO_LONG');


### PR DESCRIPTION
### Description

Some methods needs to catch the error using callback, otherwise it may create an error that cannot be caught
#### Related issues

connect to https://github.com/strongloop/loopback-datasource-juggler/issues/1436
prerequisite: https://github.com/strongloop/loopback-datasource-juggler/pull/1464

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
