### PR TITLE
Handle missing getUpdateOnlyProperties fn

### DIFF
--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -630,7 +630,8 @@ module.exports = function(registry) {
     // if there is atleast one updateOnly property, then we set
     // createOnlyInstance flag in __create__ to indicate loopback-swagger
     // code to create a separate model instance for create operation only
-    const updateOnlyProps = this.getUpdateOnlyProperties();
+    const updateOnlyProps = this.getUpdateOnlyProperties ?
+      this.getUpdateOnlyProperties() : false;
     const hasUpdateOnlyProps = updateOnlyProps && updateOnlyProps.length > 0;
 
     // This is just for LB 3.x


### PR DESCRIPTION
### Description

If the current scope (`this`) does not define a `.getUpdateOnlyProperties`
function, the `updateOnlyProps` value will now be set to false.

#### Related issues
Fixes regression in https://github.com/strongloop/loopback/pull/3548