### PR TITLE
Check whether getUpdateOnlyProperties is a fn

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -761,7 +761,7 @@ module.exports = function(registry) {
     // if there is atleast one updateOnly property, then we set
     // createOnlyInstance flag in __create__ to indicate loopback-swagger
     // code to create a separate model instance for create operation only
-    const updateOnlyProps = this.getUpdateOnlyProperties();
+    const updateOnlyProps = this.getUpdateOnlyProperties ? this.getUpdateOnlyProperties() : false;
     const hasUpdateOnlyProps = updateOnlyProps && updateOnlyProps.length > 0;
 
     var isStatic = scope.isStatic;


### PR DESCRIPTION
### Description

On upgrading to loopback 3.11.1 I get the following error.

`TypeError: this.getUpdateOnlyProperties is not a function`.

This PR checks whether getUpdateOnlyProperties is function before calling it. 

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
