### PR TITLE
Fix handling of user verification options

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -603,11 +603,11 @@ module.exports = function(User) {
    */
 
   User.getVerifyOptions = function() {
-    const verifyOptions = {
+    const defaultOptions = {
       type: 'email',
       from: 'noreply@example.com',
     };
-    return this.settings.verifyOptions || verifyOptions;
+    return Object.assign({}, this.settings.verifyOptions || defaultOptions);
   };
 
   /**
@@ -699,10 +699,14 @@ module.exports = function(User) {
     var user = this;
     var userModel = this.constructor;
     var registry = userModel.registry;
-
+    verifyOptions = Object.assign({}, verifyOptions);
     // final assertion is performed once all options are assigned
     assert(typeof verifyOptions === 'object',
       'verifyOptions object param required when calling user.verify()');
+
+    // Shallow-clone the options object so that we don't override
+    // the global default options object
+    verifyOptions = Object.assign({}, verifyOptions);
 
     // Set a default template generation function if none provided
     verifyOptions.templateFn = verifyOptions.templateFn || createVerificationEmailBody;

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -1606,6 +1606,34 @@ describe('User', function() {
           done();
         });
 
+        it('returns same verifyOptions after verify user model', () => {
+          const defaultOptions = {
+            type: 'email',
+            from: 'test@example.com',
+          };
+          var verifyOptions = Object.assign({}, defaultOptions);
+          const user = new User({
+            email: 'example@example.com',
+            password: 'pass',
+            verificationToken: 'example-token',
+          });
+          return user
+            .verify(verifyOptions)
+            .then(res => expect(verifyOptions).to.eql(defaultOptions));
+        });
+
+        it('getVerifyOptions() always returns the same', () => {
+          const defaultOptions = {
+            type: 'email',
+            from: 'test@example.com',
+          };
+          User.settings.verifyOptions = Object.assign({}, defaultOptions);
+          var verifyOptions = User.getVerifyOptions();
+          verifyOptions.from = 'newTest@example.com';
+          verifyOptions.test = 'test';
+          expect(User.getVerifyOptions()).to.eql(defaultOptions);
+        });
+
         it('can be extended by user', function(done) {
           User.getVerifyOptions = function() {
             const base = User.base.getVerifyOptions();


### PR DESCRIPTION
### Description
Hi,

I submit this pull request because the Issue #3599, when the verification functionality is sent more than once, then the data change drastically. That is because the copy by reference that the User.getVerifyOptions() do inside its definition (when the correct verifyOptions settings are returned). After that, the data is modified and that modification implies a global modification (that means), information can reload and have some problems, like the issue #3599.

The change is in one line and its test should consider the result in the email or a debug of the generated html by User.verify() function.

#### Related issues
<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- fixes #3599 

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes in user.test.js -> 'returns same custom verify options after verify user model'
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
