### PR TITLE
Allow declarative nestRemoting for relations

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -286,6 +286,11 @@ module.exports = function(registry) {
           relation.type === 'referencesMany') {
           ModelCtor.hasManyRemoting(relationName, relation, define);
         }
+        // Automatically enable nestRemoting if the flag is set to true in the
+        // relation options
+        if (relation.options && relation.options.nestRemoting) {
+          ModelCtor.nestRemoting(relationName);
+        }
       }
 
       // handle scopes

--- a/test/relations.integration.js
+++ b/test/relations.integration.js
@@ -1475,7 +1475,7 @@ describe('relations - integration', function() {
       );
       app.model(Chapter, {dataSource: 'db'});
 
-      Book.hasMany(Page);
+      Book.hasMany(Page, {options: {nestRemoting: true}});
       Book.hasMany(Chapter);
       Page.hasMany(Note);
       Chapter.hasMany(Note);
@@ -1488,7 +1488,8 @@ describe('relations - integration', function() {
 
       Page.remoteMethod('__throw__errors', {isStatic: false, http: {path: '/throws', verb: 'get'}});
 
-      Book.nestRemoting('pages');
+      // Now `pages` has nestRemoting set to true and no need to call nestRemoting()
+      // Book.nestRemoting('pages');
       Book.nestRemoting('chapters');
       Image.nestRemoting('book');
 


### PR DESCRIPTION
Now relation.options.nestRemoting can be set to true so that
nestRemoting will be set up automatically without explicitly
calling MyModel.nestRemoting

For example:
```
Book.hasMany(Page, {options: {nestRemoting: true}});
```
Or
```
{
  "name": "Book",
  "base": "PersistedModel",
  "idInjection": true,
  "options": {
    "validateUpsert": true
  },
  "properties": {
    "name": {
      "type": "string"
    }
  },
  "validations": [],
  "relations": {
    "pages": {
      "type": "hasMany",
      "model": "Page",
      "options": {
        "nestRemoting": true
      },
      "foreignKey": "",
      "through": ""
    },
    "chapters": {
      "type": "hasMany",
      "model": "Chapter",
      "options": {
        "nestRemoting": true
      },
      "foreignKey": "",
      "through": ""
    }
  },
  "acls": [],
  "methods": {}
}
```

Doc to be updated - https://loopback.io/doc/en/lb3/Nested-queries.html