### PR TITLE
Fix typo in jsdoc

### DIFF
--- a/lib/loopback.js
+++ b/lib/loopback.js
@@ -199,7 +199,7 @@ loopback.remoteMethod = function(fn, options) {
  *     var render = loopback.template('foo.ejs');
  *     var html = render({foo: 'bar'});
  *
- * @param {String} path Path to the template file.
+ * @param {String} file Path to the template file.
  * @returns {Function}
  */
 


### PR DESCRIPTION
### Description

Update a jsdoc thing to match the argument name.

(related issue & checklist not applicable).
