### PR TITLE
test: fix too strict test assertion

### DIFF
--- a/test/loopback.test.js
+++ b/test/loopback.test.js
@@ -99,7 +99,7 @@ describe('loopback', function() {
 
       var actual = Object.getOwnPropertyNames(loopback);
       actual.sort();
-      expect(actual).to.eql(EXPECTED);
+      expect(actual).to.include.members(EXPECTED);
     });
   });
 


### PR DESCRIPTION
Rework the test verifying properties of `loopback` to ignore new express properties added after the test was written.

This change fixes the currently broken CI build and prevents similar breakages to happen in the future.