### PR TITLE
Handle missing getUpdateOnlyProperties fn on Model

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -766,7 +766,8 @@ module.exports = function(registry) {
     // if there is atleast one updateOnly property, then we set
     // createOnlyInstance flag in __create__ to indicate loopback-swagger
     // code to create a separate model instance for create operation only
-    const updateOnlyProps = this.getUpdateOnlyProperties();
+    const updateOnlyProps = this.getUpdateOnlyProperties ?
+      this.getUpdateOnlyProperties() : false;
     const hasUpdateOnlyProps = updateOnlyProps && updateOnlyProps.length > 0;
 
     var isStatic = scope.isStatic;


### PR DESCRIPTION
### Description

This is a follow-up PR for #3579, which only addressed `PersistedModel`, while still leaving `Model` vulnerable to the issue. See https://github.com/strongloop/loopback/pull/3579#issuecomment-335081112

If the current scope (`this`) does not define a `.getUpdateOnlyProperties`
function, the `updateOnlyProps` value will now be set to `false`.

#### Related issues
- Finishes incomplete fix from #3579
- Fixes regression in https://github.com/strongloop/loopback/pull/3548
