### PR TITLE
test: fix too strict test assertion

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "depd": "^1.0.0",
     "ejs": "^2.3.1",
     "errorhandler": "^1.3.4",
-    "express": "^4.12.2",
+    "express": "^4.16.2",
     "inflection": "^1.6.0",
     "isemail": "^1.2.0",
     "loopback-connector-remote": "^1.0.3",

--- a/test/loopback.test.js
+++ b/test/loopback.test.js
@@ -117,7 +117,7 @@ describe('loopback', function() {
 
       var actual = Object.getOwnPropertyNames(loopback);
       actual.sort();
-      expect(actual).to.eql(EXPECTED);
+      expect(actual).to.include.members(EXPECTED);
     });
   });
 
@@ -530,6 +530,11 @@ describe('loopback', function() {
     it('inherits properties from express', function() {
       var express = require('express');
       for (var i in express) {
+        // Express added back body-parsing middleware in v4.16.0, see
+        // https://github.com/expressjs/express/issues/2211
+        // However, we are keeping them deprecated in 2.x,
+        // because it's in LTS  mode
+        if (i === 'json' || i === 'urlencoded') continue;
         expect(loopback).to.have.property(i, express[i]);
       }
     });


### PR DESCRIPTION
Rework the test verifying properties of `loopback` to ignore new express properties added after the test was written.

Ignore "json" and "urlencoded" middleware that was added back to Express, keep using our wrappers printing a deprecation message. (See https://github.com/expressjs/express/issues/2211)

This is a back-port of #3637 with few additional changes.
