### PR TITLE
Fix "POST /reset-password" for multi-user setup

### DIFF
--- a/test/helpers/error-loggers.js
+++ b/test/helpers/error-loggers.js
@@ -1,0 +1,21 @@
+// Copyright IBM Corp. 2015,2016. All Rights Reserved.
+// Node module: loopback
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+exports.logAllServerErrors = function(app) {
+  exports.logServerErrorsOtherThan(-1, app);
+};
+
+exports.logServerErrorsOtherThan = function(statusCode, app) {
+  app.use((err, req, res, next) => {
+    if ((err.statusCode || 500) !== statusCode) {
+      console.log('Unhandled error for request %s %s: %s',
+        req.method, req.url, err.stack || err);
+    }
+    res.statusCode = err.statusCode || 500;
+    res.json(err);
+  });
+};


### PR DESCRIPTION
### Description

Fix the code extracting current user id from the access token provided
in the HTTP request, to allow only access tokens created by the target
user models to execute the action.

This fixes the following security vulnerability:

* A UserA with id 1 (for example), requires a resetToken1

* A UserB with the same id requires a resetToken2.

* Using resetToken2, use the UserAs/reset-password endpoint and change
  the password of UserA and/or vice-versa

Fix by @bajtos, I'm just here ~so I don't get fined~ to merge it.

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
