### PR TITLE
Make sure createOnlyInstance flag is calculated on the target model

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+2017-10-28, Version 3.16.1
+==========================
+
+ * Fix createOnlyInstance for related methods (Raymond Feng)
+
+
 2017-10-24, Version 3.16.0
 ==========================
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -763,12 +763,7 @@ module.exports = function(registry) {
     var pathName =
       (scope.options && scope.options.http && scope.options.http.path) || scopeName;
 
-    // if there is atleast one updateOnly property, then we set
-    // createOnlyInstance flag in __create__ to indicate loopback-swagger
-    // code to create a separate model instance for create operation only
-    const updateOnlyProps = this.getUpdateOnlyProperties ?
-      this.getUpdateOnlyProperties() : false;
-    const hasUpdateOnlyProps = updateOnlyProps && updateOnlyProps.length > 0;
+    var modelTo = scope.modelTo;
 
     var isStatic = scope.isStatic;
     var toModelName = scope.modelTo.modelName;
@@ -780,7 +775,15 @@ module.exports = function(registry) {
       // For a relation with through model, the toModelName should be the one
       // from the target model
       toModelName = relation.modelTo.modelName;
+      modelTo = relation.modelTo;
     }
+
+    // if there is atleast one updateOnly property, then we set
+    // createOnlyInstance flag in __create__ to indicate loopback-swagger
+    // code to create a separate model instance for create operation only
+    const updateOnlyProps = modelTo.getUpdateOnlyProperties ?
+      modelTo.getUpdateOnlyProperties() : false;
+    const hasUpdateOnlyProps = updateOnlyProps && updateOnlyProps.length > 0;
 
     define('__get__' + scopeName, {
       isStatic: isStatic,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback",
-  "version": "3.16.0",
+  "version": "3.16.1",
   "description": "LoopBack: Open Source Framework for Node.js",
   "homepage": "http://loopback.io",
   "keywords": [

--- a/test/remoting.integration.js
+++ b/test/remoting.integration.js
@@ -133,8 +133,8 @@ describe('remoting - integration', function() {
 
     it('should have correct signatures for hasMany methods',
       function() {
-        var physicianClass = findClass('store');
-        var methods = getFormattedPrototypeMethods(physicianClass.methods);
+        var storeClass = findClass('store');
+        var methods = getFormattedPrototypeMethods(storeClass.methods);
 
         var expectedMethods = [
           'prototype.__findById__widgets(fk:any):widget ' +
@@ -208,6 +208,15 @@ describe('remoting - integration', function() {
       var createMethod = getCreateMethod(customerClass.methods);
       assert(createMethod.accepts[0].createOnlyInstance === false);
     });
+
+    it('sets createOnlyInstance based on target model for scoped or related methods',
+      function() {
+        var userClass = findClass('user');
+        var createMethod = userClass.methods.find(function(m) {
+          return (m.name === 'prototype.__create__accessTokens');
+        });
+        assert(createMethod.accepts[0].createOnlyInstance === false);
+      });
   });
 });
 


### PR DESCRIPTION
For scoped or related create method, the createOnlyInstance flag should
be calculated on the target model. For example, User.createAccessTokens
should set the flag only if AccessToken has updateonly properties.

### Description


#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to https://github.com/strongloop/loopback/issues/3615

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
