### PR TITLE
Fix "POST /change-password" for multi-user setup

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -1173,9 +1173,7 @@ module.exports = function(User) {
       {
         description: 'Change a user\'s password.',
         accepts: [
-          {arg: 'id', type: 'any',
-            http: ctx => ctx.req.accessToken && ctx.req.accessToken.userId,
-          },
+          {arg: 'id', type: 'any', http: getUserIdFromRequestContext},
           {arg: 'oldPassword', type: 'string', required: true, http: {source: 'form'}},
           {arg: 'newPassword', type: 'string', required: true, http: {source: 'form'}},
           {arg: 'options', type: 'object', http: 'optionsFromRequest'},


### PR DESCRIPTION
Fix the code extracting current user id from the access token provided
in the HTTP request, to allow only access tokens created by the target
user models to execute the action.

This fixes the following security vulnerability:

* We have two user models, e.g. Admin and Customer

* We have an Admin instance and a Customer instance with the same
  id and the same password.

* The Customer can change Admin's password using their
  regular access token.

This is a follow-up for https://github.com/strongloop/loopback/pull/3666.

#### Related issues

Connect to strongloop-internal/scrum-apex#309

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
