### PR TITLE
Correct PrinciplaType for multiple extension of User models

### DIFF
--- a/lib/access-context.js
+++ b/lib/access-context.js
@@ -88,7 +88,9 @@ function AccessContext(context) {
   var token = this.accessToken || {};
 
   if (token.userId) {
-    this.addPrincipal(Principal.USER, token.userId);
+    var userPrincipalType =
+      (this.accessToken && this.accessToken.principalType) || Principal.USER;
+    this.addPrincipal(userPrincipalType, token.userId);
   }
   if (token.appId) {
     this.addPrincipal(Principal.APPLICATION, token.appId);


### PR DESCRIPTION
### Get the polymorphic PrincipalType while creating pricipal when multiple extensions of `User` model is used 

```The app configuration follows the multiple user models setup as described in http://ibm.biz/setup-loopback-auth The built-in role resolver $owner is not currently compatible with this configuration and should not be used in production.```

With this pull request $owner can be used.
