### PR TITLE
Update nestRemoting to pass optionsFromContext 

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -947,38 +947,45 @@ module.exports = function(registry) {
             }
           });
 
+          const lastArg = opts.accepts[opts.accepts.length - 1] || {};
+          const hasOptionsFromContext =
+            (lastArg.arg || lastArg.name) === 'options' &&
+            lastArg.type === 'object' && lastArg.http;
+
           if (relation.multiple) {
             sharedClass.defineMethod(methodName, opts, function(fkId) {
-              var args = Array.prototype.slice.call(arguments, 1);
-              var last = args[args.length - 1];
-              var cb = typeof last === 'function' ? last : null;
-              this[getterName](fkId, function(err, inst) {
-                if (err && cb) return cb(err);
+              const args = Array.prototype.slice.call(arguments, 1);
+              const cb = args[args.length - 1];
+              const contextOptions =
+                hasOptionsFromContext && args[args.length - 2] || {};
+              this[getterName](fkId, contextOptions, function(err, inst) {
+                if (err) return cb(err);
                 if (inst instanceof relation.modelTo) {
                   try {
                     nestedFn.apply(inst, args);
                   } catch (err) {
-                    if (cb) return cb(err);
+                    return cb(err);
                   }
-                } else if (cb) {
+                } else {
                   cb(err, null);
                 }
               });
             }, method.isStatic);
           } else {
             sharedClass.defineMethod(methodName, opts, function() {
-              var args = Array.prototype.slice.call(arguments);
-              var last = args[args.length - 1];
-              var cb = typeof last === 'function' ? last : null;
-              this[getterName](function(err, inst) {
-                if (err && cb) return cb(err);
+              const args = Array.prototype.slice.call(arguments);
+              const cb = args[args.length - 1];
+              const contextOptions =
+                hasOptionsFromContext && args[args.length - 2] || {};
+              this[getterName](contextOptions, function(err, inst) {
+                if (err) return cb(err);
                 if (inst instanceof relation.modelTo) {
                   try {
                     nestedFn.apply(inst, args);
                   } catch (err) {
-                    if (cb) return cb(err);
+                    return cb(err);
                   }
-                } else if (cb) {
+                } else {
                   cb(err, null);
                 }
               });

--- a/test/multiple-user-principal-types.test.js
+++ b/test/multiple-user-principal-types.test.js
@@ -695,7 +695,6 @@ describe('Multiple users with custom principalType', function() {
     });
 
     it('fails when the access token belongs to a different user mode', () => {
-      debugger;
       logServerErrorsOtherThan(403, app);
       return supertest(app)
         .post('/AnotherUsers/change-password')


### PR DESCRIPTION
### Description

Passes context values through when navigating relationships in nested models.

#### Related issues


- connect to #3680

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
