### PR TITLE
Support options.filter in createChangeStream

### DIFF
--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -15,6 +15,8 @@ var deprecated = require('depd')('loopback');
 var debug = require('debug')('loopback:persisted-model');
 var PassThrough = require('stream').PassThrough;
 var utils = require('./utils');
+var filterNodes = require('loopback-filters');
+
 var REPLICATION_CHUNK_SIZE = -1;
 
 module.exports = function(registry) {
@@ -1855,6 +1857,7 @@ module.exports = function(registry) {
       cb = options;
       options = undefined;
     }
+    cb = cb || utils.createPromiseCallback();
 
     var idName = this.getIdName();
     var Model = this;
@@ -1880,16 +1883,22 @@ module.exports = function(registry) {
     Model.observe('after save', changeHandler);
     Model.observe('after delete', deleteHandler);
 
+    return cb.promise;
+
     function changeHandler(ctx, next) {
       var change = createChangeObject(ctx, 'save');
-      changes.write(change);
+      if (change) {
+        changes.write(change);
+      }
 
       next();
     };
 
     function deleteHandler(ctx, next) {
       var change = createChangeObject(ctx, 'delete');
-      changes.write(change);
+      if (change) {
+        changes.write(change);
+      }
 
       next();
     };
@@ -1910,6 +1919,15 @@ module.exports = function(registry) {
       }
 
       var hasTarget = target === 0 || !!target;
+
+      // apply filtering if options is set
+      if (options) {
+        var filtered = filterNodes([data], options);
+        if (filtered.length !== 1) {
+          return null;
+        }
+        data = filtered[0];
+      }
 
       var change = {
         target: target,

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "isemail": "^2.2.1",
     "loopback-connector-remote": "^3.0.0",
     "loopback-datasource-juggler": "^3.9.3",
+    "loopback-filters": "^1.0.0",
     "loopback-phase": "^3.0.0",
     "nodemailer": "^2.5.0",
     "nodemailer-stub-transport": "^1.0.0",


### PR DESCRIPTION
### Description

The [documentation](https://apidocs.strongloop.com/loopback/#persistedmodel-createchangestream) refers to options.where as a valid argument in createChangeStream. But it is not implemented. This has been called out in #2074, but that had been closed.

This fix implements options.where and options.fields for createChangeStream.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to #2074

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
