### PR TITLE
Added missing DateString type in loopback index

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,4 +25,5 @@ loopback.Remote = require('loopback-connector-remote');
  */
 
 loopback.GeoPoint = require('loopback-datasource-juggler/lib/geo').GeoPoint;
+loopback.DateString = require('loopback-datasource-juggler/lib/date-string');
 loopback.ValidationError = loopback.Model.ValidationError;

--- a/test/loopback.test.js
+++ b/test/loopback.test.js
@@ -46,6 +46,7 @@ describe('loopback', function() {
         'Checkpoint',
         'Connector',
         'DataSource',
+        'DateString',
         'Email',
         'GeoPoint',
         'KeyValueModel',


### PR DESCRIPTION
### Description
DateString type was missing in loopback index to match documentation.

#### Related issues

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
