### PR TITLE
fix(AccessContext): Tighten falsy userid/appid check

### DIFF
--- a/lib/access-context.js
+++ b/lib/access-context.js
@@ -61,16 +61,16 @@ function AccessContext(context) {
   var principalType = context.principalType || Principal.USER;
   var principalId = context.principalId || undefined;
   var principalName = context.principalName || undefined;
-  if (principalId) {
+  if (principalId != null) {
     this.addPrincipal(principalType, principalId, principalName);
   }
 
   var token = this.accessToken || {};
 
-  if (token.userId) {
+  if (token.userId != null) {
     this.addPrincipal(Principal.USER, token.userId);
   }
-  if (token.appId) {
+  if (token.appId != null) {
     this.addPrincipal(Principal.APPLICATION, token.appId);
   }
   this.remotingContext = context.remotingContext;
@@ -151,7 +151,7 @@ AccessContext.prototype.getAppId = function() {
  * @returns {boolean}
  */
 AccessContext.prototype.isAuthenticated = function() {
-  return !!(this.getUserId() || this.getAppId());
+  return this.getUserId() != null || this.getAppId() != null;
 };
 
 /*!


### PR DESCRIPTION
### Description

An application may have a use for a falsy ID. Tightening the check from `(!id)` to `(id != null)` solves this problem.

This PR is intended for the 2.x branch.

See also #2374

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
