### PR TITLE
Fix updateAll remote

### DIFF
--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -849,12 +849,7 @@ module.exports = function(registry) {
       returns: {
         arg: 'info',
         description: 'Information related to the outcome of the operation',
-        type: {
-          count: {
-            type: 'number',
-            description: 'The number of instances updated',
-          },
-        },
+        type: 'object',
         root: true,
       },
       http: {verb: 'post', path: '/update'},


### PR DESCRIPTION
### Description


#### Related issues

connect to strongloop/loopback#3717

I manually tested the code, it fixes the bug in #3717, while I appreciate some opinion from `strong-remoting` expert before adding the test:

In this case IIUC we need the `info` object to have a property `count`, should we fix it by omitting the object details(like the current code change)? Or keep the detail as it is and create a function to resolve the type of an object?

