### PR TITLE
Fix bugs with case insensitive user emails

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -1061,7 +1061,7 @@ module.exports = function(User) {
     this.settings.ttl = this.settings.ttl || DEFAULT_TTL;
 
     UserModel.setter.email = function(value) {
-      if (!UserModel.settings.caseSensitiveEmail) {
+      if (!UserModel.settings.caseSensitiveEmail && typeof value === 'string') {
         this.$email = value.toLowerCase();
       } else {
         this.$email = value;

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -138,16 +138,29 @@ describe('User', function() {
       });
     });
 
-    it('Email is required', function(done) {
-      User.create({password: '123'}, function(err) {
-        assert(err);
-        assert.equal(err.name, 'ValidationError');
-        assert.equal(err.statusCode, 422);
-        assert.equal(err.details.context, User.modelName);
-        assert.deepEqual(err.details.codes.email, ['presence']);
+    it('fails when the required email is missing (case-sensitivity on)', () => {
+      User.create({password: '123'})
+        .then(
+          success => { throw new Error('create should have failed'); },
+          err => {
+            expect(err.name).to.equal('ValidationError');
+            expect(err.statusCode).to.equal(422);
+            expect(err.details.context).to.equal(User.modelName);
+            expect(err.details.codes.email).to.deep.equal(['presence']);
+          });
+    });
 
-        done();
-      });
+    it('fails when the required email is missing (case-sensitivity off)', () => {
+      User.settings.caseSensitiveEmail = false;
+      User.create({email: undefined, password: '123'})
+        .then(
+          success => { throw new Error('create should have failed'); },
+          err => {
+            expect(err.name).to.equal('ValidationError');
+            expect(err.statusCode).to.equal(422);
+            expect(err.details.context).to.equal(User.modelName);
+            expect(err.details.codes.email).to.deep.equal(['presence']);
+          });
     });
 
     // will change in future versions where password will be optional by default


### PR DESCRIPTION
### Description

Fixes user email setter not accounting for the presence of undefined email addresses when attempting to convert them to lowercase when email case sensitivity is disabled.

Fixes like where query filter not accounting for case insensitive email addresses.

#### Related issues

- connect to #3772

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
