### PR TITLE
Use statusCode prop for user errors

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -326,7 +326,7 @@ module.exports = function(User) {
     var err;
     if (!tokenId) {
       err = new Error(g.f('{{accessToken}} is required to logout'));
-      err.status = 401;
+      err.statusCode = 401;
       process.nextTick(fn, err);
       return fn.promise;
     }
@@ -336,7 +336,7 @@ module.exports = function(User) {
         fn(err);
       } else if ('count' in info && info.count === 0) {
         err = new Error(g.f('Could not find {{accessToken}}'));
-        err.status = 401;
+        err.statusCode = 401;
         fn(err);
       } else {
         fn();

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -1280,7 +1280,7 @@ describe('User', function() {
     it('fails when accessToken is not provided', function(done) {
       User.logout(undefined, function(err) {
         expect(err).to.have.property('message');
-        expect(err).to.have.property('status', 401);
+        expect(err).to.have.property('statusCode', 401);
         done();
       });
     });
@@ -1288,7 +1288,7 @@ describe('User', function() {
     it('fails when accessToken is not found', function(done) {
       User.logout('expired-access-token', function(err) {
         expect(err).to.have.property('message');
-        expect(err).to.have.property('status', 401);
+        expect(err).to.have.property('statusCode', 401);
         done();
       });
     });


### PR DESCRIPTION
### Description

All other errors in the codebase se the `.statusCode` property - except these two which used `.status`. `strong-error-handler` is supposed to handle either but my issues were:

1. It was inconsistent
2. I habe started to get `Invalid Status Code: 0` errors logging out for these particular endpoint errors which went away after I fixed the above

