### PR TITLE
test: add missing "return" in a promise-style test

### DIFF
--- a/test/user.test.js
+++ b/test/user.test.js
@@ -1407,7 +1407,7 @@ describe('User', function() {
     });
 
     it('changes the password - instance method', () => {
-      validCredentialsUser.changePassword(currentPassword, 'new password')
+      return validCredentialsUser.changePassword(currentPassword, 'new password')
         .then(() => {
           expect(arguments.length, 'changePassword promise resolution')
             .to.equal(0);


### PR DESCRIPTION
Before this change, when the test failed, the rejected promise
was not reported back to mocha and triggered "unhandled promise
rejection" warning only.

I noticed this problem while reviewing #3779 /cc @nitro404
