### PR TITLE
Backport/babel es6 to es5

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,11 +67,13 @@
     "loopback-datasource-juggler": "^2.56.0"
   },
   "devDependencies": {
+    "babel-preset-es2015": "^6.24.1",
+    "babelify": "^7.3.0",
     "bluebird": "^3.4.1",
     "browserify": "^13.1.0",
     "chai": "^3.5.0",
-    "es5-shim": "^4.1.0",
     "coveralls": "^2.11.15",
+    "es5-shim": "^4.1.0",
     "express-session": "^1.14.0",
     "grunt": "^1.0.1",
     "grunt-browserify": "^5.0.0",

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -106,7 +106,15 @@ module.exports = function(config) {
       ],
       transform: [
         ['babelify', {
-          presets: 'es2015',
+          presets: [
+            ['es2015', {
+              // Disable transform-es2015-modules-commonjs which adds
+              // "use strict" to all files, even those that don't work
+              // in strict mode
+              // (e.g. chai, loopback-datasource-juggler, etc.)
+              modules: false,
+            }],
+          ],
           // By default, browserify does not transform node_modules
           // As a result, our dependencies like strong-remoting and juggler
           // are kept in original ES6 form that does not work in PhantomJS
@@ -114,15 +122,7 @@ module.exports = function(config) {
           // Prevent SyntaxError in strong-task-emitter:
           //   strong-task-emitter/lib/task.js (83:4):
           //   arguments is a reserved word in strict mode
-          // Prevent TypeError in chai:
-          //   'caller', 'callee', and 'arguments' properties may not be
-          //   accessed on strict mode functions or the arguments objects
-          //   for calls to them
-          // Prevent TypeError in loopback-datasource-juggler:
-          //   'caller', 'callee', and 'arguments' properties may not be
-          //   accessed on strict mode functions or the arguments objects
-          //   for calls to them
-          ignore: /node_modules\/(strong-task-emitter|chai|loopback-datasource-juggler)\//,
+          ignore: /node_modules\/(strong-task-emitter)\//,
         }],
       ],
       // transform: ['coffeeify'],

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -102,7 +102,28 @@ module.exports = function(config) {
         'passport',
         'passport-local',
         'superagent',
-        'supertest'
+        'supertest',
+      ],
+      transform: [
+        ['babelify', {
+          presets: 'es2015',
+          // By default, browserify does not transform node_modules
+          // As a result, our dependencies like strong-remoting and juggler
+          // are kept in original ES6 form that does not work in PhantomJS
+          global: true,
+          // Prevent SyntaxError in strong-task-emitter:
+          //   strong-task-emitter/lib/task.js (83:4):
+          //   arguments is a reserved word in strict mode
+          // Prevent TypeError in chai:
+          //   'caller', 'callee', and 'arguments' properties may not be
+          //   accessed on strict mode functions or the arguments objects
+          //   for calls to them
+          // Prevent TypeError in loopback-datasource-juggler:
+          //   'caller', 'callee', and 'arguments' properties may not be
+          //   accessed on strict mode functions or the arguments objects
+          //   for calls to them
+          ignore: /node_modules\/(strong-task-emitter|chai|loopback-datasource-juggler)\//,
+        }],
       ],
       // transform: ['coffeeify'],
       debug: true,
@@ -111,6 +132,6 @@ module.exports = function(config) {
     },
 
     // Add browserify to preprocessors
-    preprocessors: {'test/*': ['browserify']}
+    preprocessors: {'test/**/*.js': ['browserify']},
   });
 };


### PR DESCRIPTION
### Description
Backport for ES6->ES5 changes in Loopback 3.x tests/etc

#### Related issues
- introduced to 3.x in https://github.com/strongloop/loopback/pull/3173 and https://github.com/strongloop/loopback/pull/3174
- unblocks https://github.com/strongloop/loopback-datasource-juggler/pull/1545
