### PR TITLE
CODEOWNERS: add nitro404

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,7 +4,7 @@
 
 # Current maintainers
 
-* @bajtos @fabien @clarkorz @ebarault @zbarbuto
+* @bajtos @fabien @clarkorz @ebarault @zbarbuto @nitro404
 
 # Alumni
 


### PR DESCRIPTION
🎉 @nitro404 welcome on board 🎉 

We use CODEOWNERS files to communicate who is maintaining which repository. As a side effect, people listed on the `*` line receive notifications about all new pull requests opened against the repository, thus having a chance to review and comment.

If you ever find these notifications as too much, then please open a pull request to change this file. It's possible to opt into notifications for certain files/directories only, or disable notifications completely as we did e.g. in https://github.com/strongloop/loopback-component-explorer/commit/fb8f871eed01cfe28a624eb925256f481c79d033.