### PR TITLE
model: fix two nested paths to same model

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -956,7 +956,7 @@ module.exports = function(registry) {
             lastArg.type === 'object' && lastArg.http;
 
           if (relation.multiple) {
-            sharedClass.defineMethod(methodName, opts, function(fkId) {
+            sharedClass.defineMethod(getterName + methodName, opts, function(fkId) {
               const args = Array.prototype.slice.call(arguments, 1);
               const cb = args[args.length - 1];
               const contextOptions =
@@ -975,7 +975,7 @@ module.exports = function(registry) {
               });
             }, method.isStatic);
           } else {
-            sharedClass.defineMethod(methodName, opts, function() {
+            sharedClass.defineMethod(getterName + methodName, opts, function() {
               const args = Array.prototype.slice.call(arguments);
               const cb = args[args.length - 1];
               const contextOptions =


### PR DESCRIPTION
### Description

When you have a model nested through two different models to the same base model the functions created on the base model clash.
Example:
 
      Book.hasMany(Page, {options: {nestRemoting: true}});
      Book.hasMany(Chapter, {options: {nestRemoting: true}});
      Page.hasMany(Note);
      Page.belongsTo(Book, {options: {nestRemoting: true}});
      Chapter.belongsTo(Book, {options: {nestRemoting: true}});
      Chapter.hasMany(Note);
     

Here Book has a clash at .prototype.__get__notes()
so in order to solve that this PR creates .prototype.__findById__chapters__get__notes() and .prototype.__findByID__pages__get__notes()


#### Related issues
- connect to #2346
- connect to #1853

### Description


#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
