### PR TITLE
change format to double for prevalued JavaScript value

### DIFF
--- a/common/models/access-token.json
+++ b/common/models/access-token.json
@@ -7,6 +7,7 @@
     },
     "ttl": {
       "type": "number",
+      "format": "double",
       "ttl": true,
       "default": 1209600,
       "description": "time to live in seconds (2 weeks by default)"


### PR DESCRIPTION
Since the default value is set as a JavaScript Number so the result should be double as per Swagger Specification "Floating-point numbers with double precision."

https://swagger.io/docs/specification/data-models/data-types/

### Description


#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
