### PR TITLE
Correct PrincipalType for multiple extension of User models

### DIFF
--- a/common/models/role.js
+++ b/common/models/role.js
@@ -273,6 +273,10 @@ module.exports = function(Role) {
         process.nextTick(function() {
           callback(null, matches(modelId, userId));
         });
+      }else {
+        process.nextTick(function() {
+          callback(null, false);
+        });
       }
       return callback.promise;
     }

--- a/lib/access-context.js
+++ b/lib/access-context.js
@@ -86,8 +86,10 @@ function AccessContext(context) {
 
   var token = this.accessToken || {};
 
-  if (token.userId != null) {
-    this.addPrincipal(Principal.USER, token.userId);
+  if (token.userId) {
+    var userPrincipalType =
+      (this.accessToken && this.accessToken.principalType) || Principal.USER;
+    this.addPrincipal(userPrincipalType, token.userId);
   }
   if (token.appId != null) {
     this.addPrincipal(Principal.APPLICATION, token.appId);

--- a/lib/access-context.js
+++ b/lib/access-context.js
@@ -87,8 +87,7 @@ function AccessContext(context) {
   var token = this.accessToken || {};
 
   if (token.userId) {
-    var userPrincipalType =
-      (this.accessToken && this.accessToken.principalType) || Principal.USER;
+    const userPrincipalType = token.principalType || Principal.USER;
     this.addPrincipal(userPrincipalType, token.userId);
   }
   if (token.appId != null) {


### PR DESCRIPTION
#3679 
Patch is created along with the test case. Now access context will have the correct PrincipalType and ```getUser``` will work for all extensions of ```User``` model