### PR TITLE
Fix role check in apps with multiple user models

### DIFF
--- a/lib/access-context.js
+++ b/lib/access-context.js
@@ -84,10 +84,10 @@ function AccessContext(context) {
     this.addPrincipal(principalType, principalId, principalName);
   }
 
-  var token = this.accessToken || {};
+  const token = this.accessToken;
 
   if (token.userId != null) {
-    this.addPrincipal(Principal.USER, token.userId);
+    this.addPrincipal(token.principalType || Principal.USER, token.userId);
   }
   if (token.appId != null) {
     this.addPrincipal(Principal.APPLICATION, token.appId);


### PR DESCRIPTION
Fix the bug where the access context was created with incorrect principal type when the application has multiple user models configured, and custom roles were not honored as a result.

Close #3829

@akki-ng This patch is inspired by your #3823 but fixes a different and smaller problem. Could you please take a look at the proposed code changes too?

@ebarault If you can, then please review my changes too, they are related to you work on multi-user-model support.