### PR TITLE
Add options.currentUserLiteral to loopback#rest

### DIFF
--- a/server/middleware/rest.js
+++ b/server/middleware/rest.js
@@ -29,7 +29,7 @@ module.exports = rest;
  * ```
  * For more information, see [Exposing models over a REST API](http://loopback.io/doc/en/lb2/Exposing-models-over-REST.html).
  * @header loopback.rest([options])
- * @property {String} [currentUserLiteral] String literal for the current user.
+ * @property {String} [currentUserLiteral] literal for the current user.
  */
 
 function rest(options) {
@@ -55,7 +55,11 @@ function rest(options) {
 
       if (app.isAuthEnabled) {
         var AccessToken = registry.getModelByType('AccessToken');
-        handlers.push(loopback.token({currentUserLiteral: currentUserLiteral, model: AccessToken, app: app}));
+        handlers.push(loopback.token({
+          currentUserLiteral: currentUserLiteral,
+          model: AccessToken,
+          app: app
+        }));
       }
 
       handlers.push(function(req, res, next) {

--- a/server/middleware/rest.js
+++ b/server/middleware/rest.js
@@ -29,7 +29,7 @@ module.exports = rest;
  * ```
  * For more information, see [Exposing models over a REST API](http://loopback.io/doc/en/lb2/Exposing-models-over-REST.html).
  * @header loopback.rest([options])
- * @property {String} [currentUserLiteral] literal for the current user.
+ * @property {String} [currentUserLiteral] String literal for the current user.
  */
 
 function rest(options) {
@@ -55,11 +55,7 @@ function rest(options) {
 
       if (app.isAuthEnabled) {
         var AccessToken = registry.getModelByType('AccessToken');
-        handlers.push(loopback.token({
-          currentUserLiteral: currentUserLiteral,
-          model: AccessToken,
-          app: app
-        }));
+        handlers.push(loopback.token({currentUserLiteral: currentUserLiteral, model: AccessToken, app: app}));
       }
 
       handlers.push(function(req, res, next) {

--- a/server/middleware/rest.js
+++ b/server/middleware/rest.js
@@ -32,7 +32,7 @@ module.exports = rest;
  * @property {String} [currentUserLiteral] String literal for the current user.
  */
 
-function rest() {
+function rest(options) {
   options = options || {};
   var currentUserLiteral = options.currentUserLiteral;
   var handlers; // Cached handlers

--- a/server/middleware/rest.js
+++ b/server/middleware/rest.js
@@ -23,13 +23,18 @@ module.exports = rest;
  *
  * For example:
  * ```js
- * app.use(loopback.rest());
+ * app.use(loopback.rest({
+ *   currentUserLiteral: 'me'
+ * }));
  * ```
  * For more information, see [Exposing models over a REST API](http://loopback.io/doc/en/lb2/Exposing-models-over-REST.html).
- * @header loopback.rest()
+ * @header loopback.rest([options])
+ * @property {String} [currentUserLiteral] String literal for the current user.
  */
 
 function rest() {
+  options = options || {};
+  var currentUserLiteral = options.currentUserLiteral;
   var handlers; // Cached handlers
 
   return function restApiHandler(req, res, next) {
@@ -50,7 +55,7 @@ function rest() {
 
       if (app.isAuthEnabled) {
         var AccessToken = registry.getModelByType('AccessToken');
-        handlers.push(loopback.token({model: AccessToken, app: app}));
+        handlers.push(loopback.token({currentUserLiteral: currentUserLiteral, model: AccessToken, app: app}));
       }
 
       handlers.push(function(req, res, next) {


### PR DESCRIPTION
### Description

Internally, loopback.rest uses loopback.token.

I think it would be usefull for developpers to be able to set the loopback#token currentUserLiteral of their REST API when they use loopback#rest, instead of load an other instance of loopback#token in the middlewares chain.

Maybe it would be better to pass all loopback#token options with something, like :
```javascript
loopback.rest({
    tokenOptions: {
        cookies: ['foo-auth'],
        headers: ['foo-auth', 'X-Foo-Auth'],
        params: ['foo-auth', 'foo_auth'],
        currentUserLiteral: 'me',
        ...
    }
});
```

or putting these options in remoting options, like :
```json
// in config.json
{
    "remoting": {
        "rest": {
            "tokenOptions": {
                "cookies": ["foo-auth"],
                "headers": ["foo-auth", "X-Foo-Auth"],
                "params": ["foo-auth", "foo_auth"],
                "currentUserLiteral": "me",
                "...."
            }
        }
    }
}
```



