### PR TITLE
[improve stale] Provide link to CODEOWNERS

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -20,4 +20,4 @@ markComment: >
 closeComment: >
   This issue has been closed due to continued inactivity. Thank you for your understanding.
   If you believe this to be in error, please contact one of the code owners,
-  listed in the `CODEOWNERS` file at the top-level of this repository.
+  listed in the [`CODEOWNERS`](https://github.com/strongloop/loopback/blob/master/CODEOWNERS) file at the top-level of this repository.


### PR DESCRIPTION
Currently, stale bot doesn't provide the link to the CODEOWNERS file, a person must have to browse for the file to open it. This PR adds a link to the CODEOWNERS file so that a person can directly open it.