### PR TITLE
Drop support for Node.js 4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - "4"
   - "6"
   - "8"
   - "10"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test": "nyc grunt mocha-and-karma"
   },
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=6"
   },
   "dependencies": {
     "async": "^2.0.1",


### PR DESCRIPTION
See https://github.com/strongloop/loopback/pull/3585 and #3907

Since it has been few months since Node.js 4.x reached end of life, this change will be released as semver-minor.