### PR TITLE
fix: resolve customAccessToken warning error that causes app to crash

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -460,7 +460,7 @@ app._verifyAuthModelRelations = function() {
     const hasManyTokens = Model.relations && Model.relations.accessTokens;
 
     // display a temp warning message for users using multiple users config
-    if (hasManyTokens.polymorphic) {
+    if (hasManyTokens && Model.settings.relations.accessTokens.polymorphic) {
       console.warn(
         'The app configuration follows the multiple user models setup ' +
           'as described in http://ibm.biz/setup-loopback-auth',

--- a/lib/application.js
+++ b/lib/application.js
@@ -458,9 +458,10 @@ app._verifyAuthModelRelations = function() {
 
   function verifyUserRelations(Model) {
     const hasManyTokens = Model.relations && Model.relations.accessTokens;
-
+    const relationsConfig = Model.settings.relations || {};
+    const hasPolyMorphicTokens = (relationsConfig.accessTokens || {}).polymorphic; 
     // display a temp warning message for users using multiple users config
-    if (hasManyTokens && Model.settings.relations.accessTokens.polymorphic) {
+    if (hasPolyMorphicTokens) {
       console.warn(
         'The app configuration follows the multiple user models setup ' +
           'as described in http://ibm.biz/setup-loopback-auth',
@@ -470,7 +471,6 @@ app._verifyAuthModelRelations = function() {
 
     if (hasManyTokens) return;
 
-    const relationsConfig = Model.settings.relations || {};
     const accessTokenName = (relationsConfig.accessTokens || {}).model;
     if (accessTokenName) {
       console.warn(


### PR DESCRIPTION
### Description

In the present implementation `verifyUserRelations(Model)` sets a `const hasManyTokens` which seems to resolve to a boolean or undefined, so checking `hasManyTokens.polymorphic` throws an error.

It seems the intention is to check whether the the following conditions are met:
 1. a model has a hasMany accessTokens relation
 2. that relation is polymorphic

The proposed change should resolve correctly for any models that meet this criteria.