### PR TITLE
Delete remote hooks when model is deleted

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -189,6 +189,9 @@ app.deleteModelByName = function(modelName) {
   const remotes = this.remotes();
   remotes.deleteClassByName(modelName);
   remotes.deleteTypeByName(modelName);
+  Object.keys(remotes.listenerTree).forEach(hooktype=>{
+    delete remotes.listenerTree[hooktype][modelName];
+  });
 
   if (ModelCtor && ModelCtor.dataSource) {
     ModelCtor.dataSource.deleteModelByName(modelName);

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -806,6 +806,23 @@ describe('app', function() {
         .to.not.contain('test-model');
     });
 
+    it('removes the model from remoting hooks', () => {
+      expect(Object.keys(app.remotes().listenerTree.before))
+        .to.contain('test-model');
+      expect(Object.keys(app.remotes().listenerTree.after))
+        .to.contain('test-model');
+      expect(Object.keys(app.remotes().listenerTree.afterError))
+        .to.contain('test-model');
+      app.deleteModelByName('test-model');
+
+      expect(Object.keys(app.remotes().listenerTree.before))
+        .to.not.contain('test-model');
+      expect(Object.keys(app.remotes().listenerTree.after))
+        .to.not.contain('test-model');
+      expect(Object.keys(app.remotes().listenerTree.afterError))
+        .to.not.contain('test-model');
+    });
+
     it('emits "modelDeleted" event', () => {
       const spy = sinon.spy();
       app.on('modelDeleted', spy);
@@ -820,6 +837,9 @@ describe('app', function() {
         name: 'test-model',
         base: 'Model',
       });
+      TestModel.beforeRemote('find', (ctx, next) => { next(); });
+      TestModel.afterRemote('find', (ctx, next) => { next(); });
+      TestModel.afterRemoteError('find', (ctx, next) => { next(); });
       app.model(TestModel, {dataSource: null});
     }
   });


### PR DESCRIPTION
### Description
fixing bug that when a model is deleted it's remote methods are not actually removed from app listener tree.

### Checklist
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
