### PR TITLE
fix: resolve customAccessToken warning error that causes app to crash

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -497,8 +497,10 @@ app._verifyAuthModelRelations = function() {
   function verifyUserRelations(Model) {
     const hasManyTokens = Model.relations && Model.relations.accessTokens;
 
+    const relationsConfig = Model.settings.relations || {};
+    const hasPolyMorphicTokens = (relationsConfig.accessTokens || {}).polymorphic;
     // display a temp warning message for users using multiple users config
-    if (hasManyTokens.polymorphic) {
+    if (hasPolyMorphicTokens) {
       console.warn(
         'The app configuration follows the multiple user models setup ' +
           'as described in http://ibm.biz/setup-loopback-auth',
@@ -508,7 +510,6 @@ app._verifyAuthModelRelations = function() {
 
     if (hasManyTokens) return;
 
-    const relationsConfig = Model.settings.relations || {};
     const accessTokenName = (relationsConfig.accessTokens || {}).model;
     if (accessTokenName) {
       console.warn(


### PR DESCRIPTION
In the present implementation `verifyUserRelations(Model)` assumes that
`Model.relations.accessTokens` is always set, and as a result may
crash when trying to access `polymorphic` property of that relation.

It seems the intention is to check whether the the following conditions are met:
 1. a model has a hasMany accessTokens relation
 2. that relation is polymorphic

This commit fixes the problem by accounting for the case where the
accessTokens relation was not correctly set up.

This pull request supersedes https://github.com/strongloop/loopback/pull/3921, which was opened against a wrong branch (`3.x-latest`).

/cc @ryanxwelch 