### PR TITLE
Make verifyUserRelations() more robust

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -497,19 +497,19 @@ app._verifyAuthModelRelations = function() {
   function verifyUserRelations(Model) {
     const hasManyTokens = Model.relations && Model.relations.accessTokens;
 
-    const relationsConfig = Model.settings.relations || {};
-    const hasPolyMorphicTokens = (relationsConfig.accessTokens || {}).polymorphic;
-    // display a temp warning message for users using multiple users config
-    if (hasPolyMorphicTokens) {
-      console.warn(
-        'The app configuration follows the multiple user models setup ' +
-          'as described in http://ibm.biz/setup-loopback-auth',
-        'The built-in role resolver $owner is not currently compatible ' +
-          'with this configuration and should not be used in production.');
+    if (hasManyTokens) {
+      // display a temp warning message for users using multiple users config
+      if (hasManyTokens.polymorphic) {
+        console.warn(
+          'The app configuration follows the multiple user models setup ' +
+            'as described in http://ibm.biz/setup-loopback-auth',
+          'The built-in role resolver $owner is not currently compatible ' +
+            'with this configuration and should not be used in production.');
+      }
+      return;
     }
 
-    if (hasManyTokens) return;
-
+    const relationsConfig = Model.settings.relations || {};
     const accessTokenName = (relationsConfig.accessTokens || {}).model;
     if (accessTokenName) {
       console.warn(


### PR DESCRIPTION
### Description
 Refactoring the verifyUserRelations function to :

- fix the app crash when the "accessTokens" relation is not correctly set up
- use more accurate condition in the first if statement 
- prevent the redundant test of "hasManyTokens" in the function 

See also #3934
