### PR TITLE
add: exception for ppc64 and s390x to not run UI tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -226,8 +226,9 @@ module.exports = function(grunt) {
     });
   });
 
-  grunt.registerTask('skip-karma-on-windows', function() {
-    console.log('*** SKIPPING PHANTOM-JS BASED TESTS ON WINDOWS ***');
+  grunt.registerTask('skip-karma', function() {
+    console.log(`*** SKIPPING PHANTOM-JS BASED TESTS ON ${process.platform}` +
+      ` ${process.arch} ***`);
   });
 
   grunt.registerTask('e2e', ['e2e-server', 'karma:e2e']);
@@ -238,8 +239,9 @@ module.exports = function(grunt) {
   grunt.registerTask('test', [
     'eslint',
     process.env.JENKINS_HOME ? 'mochaTest:unit-xml' : 'mochaTest:unit',
-    process.env.JENKINS_HOME && /^win/.test(process.platform) ?
-      'skip-karma-on-windows' : 'karma:unit-once',
+    process.env.JENKINS_HOME && (/^win/.test(process.platform) ||
+      /^s390x/.test(process.arch) || /^ppc64/.test(process.arch)) ?
+      'skip-karma' : 'karma:unit-once',
   ]);
 
   // alias for sl-ci-run and `npm test`


### PR DESCRIPTION
### Description
`PhantomJs` does not support `ppc64` and `s390x` machines. 
This addition stops PhantomJs tests from running on these unsupported architectures, allowing the test suite to pass.

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
