### PR TITLE
clearHandlerCache when remote method added or disabled

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -151,9 +151,11 @@ app.model = function(Model, config) {
 
   var self = this;
   Model.on('remoteMethodDisabled', function(model, methodName) {
+    clearHandlerCache(self);
     self.emit('remoteMethodDisabled', model, methodName);
   });
   Model.on('remoteMethodAdded', function(model) {
+    clearHandlerCache(self);
     self.emit('remoteMethodAdded', model);
   });
 

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -719,17 +719,6 @@ describe('app', function() {
       expect(remoteMethodAddedClass).to.eql(Book.sharedClass);
     });
 
-    it.onServer('updates REST API when a new model is added', function(done) {
-      app.use(loopback.rest());
-      request(app).get('/colors').expect(404, function(err, res) {
-        if (err) return done(err);
-        var Color = PersistedModel.extend('color', {name: String});
-        app.model(Color);
-        Color.attachTo(db);
-        request(app).get('/colors').expect(200, done);
-      });
-    });
-
     it('accepts null dataSource', function(done) {
       app.model(MyTestModel, {dataSource: null});
       expect(MyTestModel.dataSource).to.eql(null);


### PR DESCRIPTION
### Description

fixes issue that Handler Cache won't change when remote method is added or disabled.

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
