### PR TITLE
Add a flag to preserve access tokens on email/password change

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -1385,6 +1385,8 @@ module.exports = function(User) {
 
     if (!newEmail && !newPassword) return next();
 
+    if (ctx.options.preserveAccessTokens) return next();
+
     var userIdsToExpire = ctx.hookState.originalUserData.filter(function(u) {
       return (newEmail && u.email !== newEmail) ||
         (newPassword && u.password !== newPassword);

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -2755,6 +2755,17 @@ describe('User', function() {
       ], done);
     });
 
+    it('keeps sessions sessions when preserveAccessTokens is passed in options', function(done) {
+      user.updateAttributes(
+        {email: 'invalidateAccessTokens@example.com'},
+        {preserveAccessTokens: true},
+        function(err, userInstance) {
+          if (err) return done(err);
+          assertPreservedTokens(done);
+        }
+      );
+    });
+
     it('preserves other users\' sessions if their email is  untouched', function(done) {
       var user1, user2, user3;
       async.series([


### PR DESCRIPTION
### Description
Added flag to avoid invalidate the accessTokens when changing the email/password on the user model.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- fixes https://github.com/strongloop/loopback/issues/3071

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
