### PR TITLE
Update LB3 to be active LTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,15 @@ For more details, see [https://loopback.io/](https://loopback.io/).
 
 ## Module Long Term Support Policy
 
+LoopBack 3.x is now in active LTS.
+
 This module adopts the [Module Long Term Support (LTS)](http://github.com/CloudNativeJS/ModuleLTS) policy, with the following End Of Life (EOL) dates:
 
-| Module Version   | Release Date | Minimum EOL | EOL With     | Status  |
-|------------------|--------------|-------------|--------------|---------|
-| 3.x.x	         | Sept 2016    | Dec 2019    |              | Current |
-| 2.x.x	         | July 2014    | Apr 2019    | Node.js 6.x  | LTS     |
+| Version    | Status          | Published | EOL                  |
+| ---------- | --------------- | --------- | -------------------- |
+| LoopBack 4 | Current         | Oct 2018  | Apr 2021 _(minimum)_ |
+| Loopback 3 | Active LTS      | Dec 2016  | Dec 2019             |
+| Loopback 2 | Maintenance LTS | Jul 2014  | Apr 2019             |
 
 Learn more about our LTS plan in [docs](https://loopback.io/doc/en/contrib/Long-term-support.html).
 


### PR DESCRIPTION
### Description
After LB4 GA, LB3 becomes the active LTS version
 
#### Related issues
https://github.com/strongloop/loopback-next/issues/1744
