### PR TITLE
Fix context propagation broken by async@2.x

### DIFF
--- a/server/middleware/rest.js
+++ b/server/middleware/rest.js
@@ -73,8 +73,21 @@ function rest() {
     if (handlers.length === 1) {
       return handlers[0](req, res, next);
     }
-    async.eachSeries(handlers, function(handler, done) {
-      handler(req, res, done);
-    }, next);
+
+    executeHandlers(handlers, req, res, next);
   };
+}
+
+// A trimmed-down version of async.series that preserves current CLS context
+function executeHandlers(handlers, req, res, cb) {
+  var ix = -1;
+  next();
+
+  function next(err) {
+    if (err || ++ix >= handlers.length) {
+      cb(err);
+    } else {
+      handlers[ix](req, res, next);
+    }
+  }
 }


### PR DESCRIPTION
Rework the REST middleware to use a hand-written version of "async.eachSeries". Before this change, we were loosing CLS context when the application was relying on the REST middleware to load the context middleware.

This is fixing a problem introduced by post-1.0 versions of async, which we upgraded to via fea3b78.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- close  #3966

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)