### PR TITLE
Speed up ACL tests by reducing saltWorkFactor

### DIFF
--- a/test/acl.test.js
+++ b/test/acl.test.js
@@ -626,6 +626,9 @@ describe('authorized roles propagation in RemotingContext', function() {
     app.enableAuth({dataSource: 'db'});
     models = app.models;
 
+    // Speed up the password hashing algorithm for tests
+    models.User.settings.saltWorkFactor = 4;
+
     // creating a custom model
     const MyTestModel = app.registry.createModel('MyTestModel');
     app.model(MyTestModel, {dataSource: 'db'});


### PR DESCRIPTION
I noticed that some of our ACL tests are not reducing User's `saltWorkFactor` as other tests are already doing. This patch is fixing that.

Before:

```
$ mocha test/acl.test.js
[...]
  18 passing (726ms)
```

After:

```
$ mocha test/acl.test.js
[...]
  18 passing (257ms)
```

The code changing saltWorkFactor is mostly copy&pasted from elsewhere, see e.g. https://github.com/strongloop/loopback/blob/818a7506d8c659829058fb2451951333cf15a6c9/test/acl.test.js#L20-L21