### PR TITLE
Set juggler configs in options by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+2018-11-15, Version 3.24.0
+==========================
+
+ * Set juggler options for remote calls (Raymond Feng)
+
+ * Speed up ACL tests by reducing saltWorkFactor (Miroslav Bajtoš)
+
+
 2018-10-25, Version 3.23.2
 ==========================
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -470,14 +470,14 @@ module.exports = function(registry) {
 
     if (options.accepts) {
       options = extend({}, options);
-      options.accepts = setupOptionsArgs(options.accepts);
+      options.accepts = setupOptionsArgs(options.accepts, this);
     }
 
     this.sharedClass.defineMethod(name, options);
     this.emit('remoteMethodAdded', this.sharedClass);
   };
 
-  function setupOptionsArgs(accepts) {
+  function setupOptionsArgs(accepts, modelClass) {
     if (!Array.isArray(accepts))
       accepts = [accepts];
 
@@ -485,21 +485,33 @@ module.exports = function(registry) {
       if (arg.http && arg.http === 'optionsFromRequest') {
         // clone to preserve the input value
         arg = extend({}, arg);
-        arg.http = createOptionsViaModelMethod;
+        arg.http = createOptionsViaModelMethod.bind(modelClass);
       }
       return arg;
     });
   }
 
   function createOptionsViaModelMethod(ctx) {
-    var EMPTY_OPTIONS = {};
-    var ModelCtor = ctx.method && ctx.method.ctor;
-    if (!ModelCtor)
-      return EMPTY_OPTIONS;
+    var ModelCtor = (ctx.method && ctx.method.ctor) || this;
+
+    /**
+     * Configure default values for juggler settings to protect user-supplied
+     * input from attacking juggler
+     */
+    var DEFAULT_OPTIONS = {
+      // Default to `true` so that hidden properties cannot be used in query
+      prohibitHiddenPropertiesInQuery: ModelCtor._getProhibitHiddenPropertiesInQuery({}, true),
+      // Default to `12` for the max depth of a query object
+      maxDepthOfQuery: ModelCtor._getMaxDepthOfQuery({}, 12),
+      // Default to `32` for the max depth of a data object
+      maxDepthOfData: ModelCtor._getMaxDepthOfData({}, 32),
+    };
+
     if (typeof ModelCtor.createOptionsFromRemotingContext !== 'function')
-      return EMPTY_OPTIONS;
+      return DEFAULT_OPTIONS;
     debug('createOptionsFromRemotingContext for %s', ctx.method.stringName);
-    return ModelCtor.createOptionsFromRemotingContext(ctx);
+    return Object.assign(DEFAULT_OPTIONS,
+      ModelCtor.createOptionsFromRemotingContext(ctx));
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "inflection": "^1.6.0",
     "isemail": "^2.2.1",
     "loopback-connector-remote": "^3.0.0",
-    "loopback-datasource-juggler": "^3.18.0",
+    "loopback-datasource-juggler": "^3.28.0",
     "loopback-filters": "^1.0.0",
     "loopback-phase": "^3.0.0",
     "nodemailer": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback",
-  "version": "3.23.2",
+  "version": "3.24.0",
   "description": "LoopBack: Open Source Framework for Node.js",
   "homepage": "http://loopback.io",
   "keywords": [


### PR DESCRIPTION
### Description

This PR allows set `prohibitHiddenPropertiesInQuery`, `maxDepthOfQuery`, and `maxDepthOfData` in `options` for CRUD operations.

#### Related issues

https://github.com/strongloop/loopback-datasource-juggler/pull/1662

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
