### PR TITLE
[WIP] Fix CI build errors on Windows

### DIFF
--- a/test/user.test.js
+++ b/test/user.test.js
@@ -1520,7 +1520,7 @@ describe('User', function() {
             assert(result.token);
             assert.equal(result.token, 'token-123456');
             var msg = result.email.response.toString('utf-8');
-            assert(~msg.indexOf('token-123456'));
+            expect(msg).to.contain('token-123456');
 
             done();
           });

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -1501,7 +1501,7 @@ describe('User', function() {
             from: 'noreply@myapp.org',
             redirect: '/',
             protocol: ctx.req.protocol,
-            host: ctx.req.get('host'),
+            host: 'lb.io', // use a short hostname to avoid a line break
             generateVerificationToken: function(user, cb) {
               assert(user);
               assert.equal(user.email, 'bar@bat.com');


### PR DESCRIPTION
### Description

Our tests seem to be failing on Windows, see https://github.com/strongloop/loopback/pull/4079

```xml
<testcase classname="User Verification user.verify(options, fn)" 
  name="Verify a user&#x27;s email address with custom token generator" time="0"
><failure>0 == true
AssertionError: 0 == true
    at test\user.test.js:1523:13
    at common\models\user.js:150:273
    at Nodemailer.&#x3C;anonymous&#x3E; (node_modules\nodemailer\lib\nodemailer.js:329:26)
    at StubTransport.&#x3C;anonymous&#x3E; (node_modules\nodemailer-stub-transport\src\stub-transport.js:78:13)
    at Immediate._onImmediate (node_modules\async-listener\glue.js:188:31)</failure></testcase>
```

1. Improve the failing test to report a more helpful error message.
2. Fix the test to use a shorter URL not triggering a line break in unexpected place.

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)