### PR TITLE
Fix: treat empty access token string as undefined

### DIFF
--- a/common/models/access-token.js
+++ b/common/models/access-token.js
@@ -125,6 +125,11 @@ module.exports = function(AccessToken) {
       if (typeof id === 'string') {
         // Add support for oAuth 2.0 bearer token
         // http://tools.ietf.org/html/rfc6750
+
+        // To prevent Error: Model::findById requires the id argument
+        // with loopback-datasource-juggler 2.56.0+
+        if (id === '') continue;
+
         if (id.indexOf('Bearer ') === 0) {
           id = id.substring(7);
           if (options.bearerTokenBase64Encoded) {

--- a/test/access-token.test.js
+++ b/test/access-token.test.js
@@ -311,6 +311,16 @@ describe('loopback.token(options)', function() {
         .end(done);
     });
 
+  it('generates a 401 on a current user literal route with empty authToken',
+    function(done) {
+      var app = createTestApp(null, done);
+      request(app)
+        .get('/users/me')
+        .set('authorization', '')
+        .expect(401)
+        .end(done);
+    });
+
   it('generates a 401 on a current user literal route with invalid authToken',
     function(done) {
       var app = createTestApp(this.token, done);


### PR DESCRIPTION
#### Related issues
- Fixes  https://github.com/strongloop/loopback/issues/4078