### PR TITLE
Update underscore.string to 3.3.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "strong-globalize": "^4.1.1",
     "strong-remoting": "^3.11.0",
     "uid2": "0.0.3",
-    "underscore.string": "^3.0.3"
+    "underscore.string": "^3.3.5"
   },
   "devDependencies": {
     "babel-preset-es2015": "^6.22.0",


### PR DESCRIPTION
### Description
Update dependency underscore.string to latest available: 3.3.5

#### Related issues

Fixes #4106 

### Checklist
- NSP vulnerability must be fixed
