### PR TITLE
Support middleware injected by AppDynamics

### DIFF
--- a/lib/server-app.js
+++ b/lib/server-app.js
@@ -221,12 +221,15 @@ proto.middleware = function(name, paths, handler) {
  */
 proto._findLayerByHandler = function(handler) {
   // Other handlers can be added to the stack, for example,
-  // NewRelic adds sentinel handler. We need to search the stack
+  // NewRelic adds sentinel handler, and AppDynamics adds
+  // some additional proxy info. We need to search the stack
   for (var k = this._router.stack.length - 1; k >= 0; k--) {
-    if (this._router.stack[k].handle === handler ||
-      // NewRelic replaces the handle and keeps it as __NR_original
-      this._router.stack[k].handle['__NR_original'] === handler
-    ) {
+    const isOriginal = this._router.stack[k].handle === handler;
+    const isNewRelic = this._router.stack[k].handle['__NR_original'] === handler;
+    const isAppDynamics = this._router.stack[k].handle['__appdynamicsProxyInfo__'] &&
+      this._router.stack[k].handle['__appdynamicsProxyInfo__']['orig'] === handler;
+
+    if (isOriginal || isNewRelic || isAppDynamics) {
       return this._router.stack[k];
     } else {
       // Aggressively check if the original handler has been wrapped

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -124,6 +124,28 @@ describe('app', function() {
         });
       });
 
+    it('allows handlers to be wrapped as __appdynamicsProxyInfo__ on express stack',
+      function(done) {
+        var myHandler = namedHandler('my-handler');
+        var wrappedHandler = function(req, res, next) {
+          myHandler(req, res, next);
+        };
+        wrappedHandler['__appdynamicsProxyInfo__'] = {
+          orig: myHandler,
+        };
+        app.middleware('routes:before', wrappedHandler);
+        var found = app._findLayerByHandler(myHandler);
+        expect(found).to.be.an('object');
+        expect(found).have.property('phase', 'routes:before');
+        executeMiddlewareHandlers(app, function(err) {
+          if (err) return done(err);
+
+          expect(steps).to.eql(['my-handler']);
+
+          done();
+        });
+      });
+
     it('allows handlers to be wrapped as a property on express stack',
       function(done) {
         var myHandler = namedHandler('my-handler');


### PR DESCRIPTION
### Description
Much like the workaround for `NewRelic`, `appd` replaces the express handle with its own, and stores it in `handle.__appdynamicsProxyInfo__.orig`.  This causes `proto._findLayerByHandler` to fail.

This pull request was originally created by @mikewli and @gconaty - I have updated it to include unit tests.

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
  - Unit tests have been added
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
  - All lint tests passes
