### PR TITLE
Fix Model.exists() working for remote connector

### DIFF
--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -724,7 +724,8 @@ module.exports = function(registry) {
       description: 'Check whether a model instance exists in the data source.',
       accessType: 'READ',
       accepts: [
-        {arg: 'id', type: 'any', description: 'Model id', required: true},
+        {arg: 'id', type: 'any', description: 'Model id', required: true,
+          http: {source: 'path'}},
         {arg: 'options', type: 'object', http: 'optionsFromRequest'},
       ],
       returns: {arg: 'exists', type: 'boolean'},

--- a/test/util/model-tests.js
+++ b/test/util/model-tests.js
@@ -235,6 +235,27 @@ module.exports = function defineModelTestsWithDataSource(options) {
       });
     });
 
+    describe('Model.exists(id, [callback])', function() {
+      it('returns true when the model with the given id exists', function(done) {
+        User.create({first: 'max'}, function(err, user) {
+          if (err) return done(err);
+          User.exists(user.id, function(err, exist) {
+            if (err) return done(err);
+            assert.equal(exist, true);
+            done();
+          });
+        });
+      });
+
+      it('returns false when there is no model with the given id', function(done) {
+        User.exists('user-id-does-not-exist', function(err, exist) {
+          if (err) return done(err);
+          assert.equal(exist, false);
+          done();
+        });
+      });
+    });
+
     describe('Model.findById(id, callback)', function() {
       it('Find an instance by id', function(done) {
         User.create({first: 'michael', last: 'jordan', id: 23}, function() {


### PR DESCRIPTION
### Description
The `GET /Models/:id/exists` service doesn't work for remote connector. It proxies to `GET /Models/:id/exists?id=${id}` endpoint except the required

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
