### PR TITLE
handle $2b$ in hashed password check

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -1089,7 +1089,7 @@ module.exports = function(User) {
       if (typeof plain !== 'string') {
         return;
       }
-      if (plain.indexOf('$2a$') === 0 && plain.length === 60) {
+      if ((plain.indexOf('$2a$') === 0 || plain.indexOf('$2b$') === 0) && plain.length === 60) {
         // The password is already hashed. It can be the case
         // when the instance is loaded from DB
         this.$password = plain;


### PR DESCRIPTION
### Description

bcrypt made $2b$ the default in [bcrypt 2.0.0](https://github.com/kelektiv/node.bcrypt.js/blob/master/CHANGELOG.md#200-2018-04-07) breaking 13e618bff270ad5e41a0338b324783a307c298c5 

#### Related issues

strongloop/loopback-datasource-juggler#471

### Checklist

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
