### PR TITLE
fix: `resetPasswordRequest` event is never emitted as callback is called Prematurely

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -992,13 +992,13 @@ module.exports = function(User) {
         if (err) {
           return cb(err);
         }
-        cb();
         UserModel.emit('resetPasswordRequest', {
           email: options.email,
           accessToken: accessToken,
           user: user,
           options: options,
         });
+        cb();
       }
     });
 


### PR DESCRIPTION
### Description
Password reset depends on the User Model firing the `resetPasswordRequest` event with a temporary Access Token. The event is never fired as the callback `cb` is called _before_ the event is emitted.

This is a simple fix to just move the `cb()` after the event emit.

Need it urgently for a project! Thanks!

#### Related issues

None

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
