### PR TITLE
Ignore failing downstream dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,5 +122,12 @@
   },
   "copyright.owner": "IBM Corp.",
   "license": "MIT",
-  "author": "IBM Corp."
+  "author": "IBM Corp.",
+  "ci": {
+    "downstreamIgnoreList": [
+      "bluemix-service-broker",
+      "gateway-director-bluemix",
+      "plan-manager"
+    ]
+  }
 }


### PR DESCRIPTION
The following dependencies are always failing the CI builds, let's
ignore them when testing changes in `loopback` package:

- bluemix-service-broker
- gateway-director-bluemix
- plan-manager

