### PR TITLE
fix: disallow queries in username and email fields

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -232,18 +232,39 @@ module.exports = function(User) {
     var query = self.normalizeCredentials(credentials, realmRequired,
       realmDelimiter);
 
-    if (realmRequired && !query.realm) {
-      var err1 = new Error(g.f('{{realm}} is required'));
-      err1.statusCode = 400;
-      err1.code = 'REALM_REQUIRED';
-      fn(err1);
-      return fn.promise;
+    if (realmRequired) {
+      if (!query.realm) {
+        var err1 = new Error(g.f('{{realm}} is required'));
+        err1.statusCode = 400;
+        err1.code = 'REALM_REQUIRED';
+        fn(err1);
+        return fn.promise;
+      } else if (typeof query.realm !== 'string') {
+        var err5 = new Error(g.f('Invalid realm'));
+        err5.statusCode = 400;
+        err5.code = 'INVALID_REALM';
+        fn(err5);
+        return fn.promise;
+      }
     }
     if (!query.email && !query.username) {
       var err2 = new Error(g.f('{{username}} or {{email}} is required'));
       err2.statusCode = 400;
       err2.code = 'USERNAME_EMAIL_REQUIRED';
       fn(err2);
+      return fn.promise;
+    }
+    if (query.username && typeof query.username !== 'string') {
+      var err3 = new Error(g.f('Invalid username'));
+      err3.statusCode = 400;
+      err3.code = 'INVALID_USERNAME';
+      fn(err3);
+      return fn.promise;
+    } else if (query.email && typeof query.email !== 'string') {
+      var err4 = new Error(g.f('Invalid email'));
+      err4.statusCode = 400;
+      err4.code = 'INVALID_EMAIL';
+      fn(err4);
       return fn.promise;
     }
 

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -652,6 +652,37 @@ describe('User', function() {
       });
     });
 
+    it('should not allow queries in email field', function(done) {
+      User.login({email: {'neq': 'x'}, password: 'x'}, function(err, accessToken) {
+        assert(err);
+        assert.equal(err.code, 'INVALID_EMAIL');
+        assert(!accessToken);
+
+        done();
+      });
+    });
+
+    it('should not allow queries in username field', function(done) {
+      User.login({username: {'neq': 'x'}, password: 'x'}, function(err, accessToken) {
+        assert(err);
+        assert.equal(err.code, 'INVALID_USERNAME');
+        assert(!accessToken);
+
+        done();
+      });
+    });
+
+    it('should not allow queries in realm field', function(done) {
+      User.settings.realmRequired = true;
+      User.login({username: 'x', password: 'x', realm: {'neq': 'x'}}, function(err, accessToken) {
+        assert(err);
+        assert.equal(err.code, 'INVALID_REALM');
+        assert(!accessToken);
+
+        done();
+      });
+    });
+
     it('Login a user by providing credentials with TTL', function(done) {
       User.login(validCredentialsWithTTL, function(err, accessToken) {
         assertGoodToken(accessToken, validCredentialsUser);


### PR DESCRIPTION
### Description

Disables queries in the username and email fields while logging in.

#### Related issues

https://github.com/strongloop/loopback/issues/4195

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
