### PR TITLE
test: switch from PhantomJS to HeadlessChrome

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,18 +5,10 @@ node_js:
   - "10"
   - "12"
 
+addons:
+  chrome: stable
+
 after_success: npm run coverage
 
-# see https://www.npmjs.com/package/phantomjs-prebuilt#continuous-integration
-cache:
-  directories:
-    - travis_phantomjs
 before_install:
   - npm config set registry http://ci.strongloop.com:4873/
-  # Upgrade PhantomJS to v2.1.1.
-  - "export PHANTOMJS_VERSION=2.1.1"
-  - "export PATH=$PWD/travis_phantomjs/phantomjs-$PHANTOMJS_VERSION-linux-x86_64/bin:$PATH"
-  - "if [ $(phantomjs --version) != $PHANTOMJS_VERSION ]; then rm -rf $PWD/travis_phantomjs; mkdir -p $PWD/travis_phantomjs; fi"
-  - "if [ $(phantomjs --version) != $PHANTOMJS_VERSION ]; then wget https://github.com/Medium/phantomjs/releases/download/v$PHANTOMJS_VERSION/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2 -O $PWD/travis_phantomjs/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2; fi"
-  - "if [ $(phantomjs --version) != $PHANTOMJS_VERSION ]; then tar -xvf $PWD/travis_phantomjs/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2 -C $PWD/travis_phantomjs; fi"
-  - "phantomjs --version"

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -31,11 +31,6 @@ module.exports = function(grunt) {
         },
       },
     },
-    run: {
-      optionalInstall: {
-        exec: 'npm install --no-save --silent karma-phantomjs-launcher phantomjs-prebuilt',
-      },
-    },
     eslint: {
       gruntfile: {
         src: 'Gruntfile.js',
@@ -109,7 +104,7 @@ module.exports = function(grunt) {
     karma: {
       'unit-once': {
         configFile: 'test/karma.conf.js',
-        browsers: ['PhantomJS'],
+        browsers: ['ChromeHeadless'],
         singleRun: true,
         reporters: ['dots', 'junit'],
 
@@ -216,7 +211,6 @@ module.exports = function(grunt) {
   });
 
   // These plugins provide necessary tasks.
-  grunt.loadNpmTasks('grunt-run');
   grunt.loadNpmTasks('grunt-browserify');
   grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-eslint');
@@ -242,14 +236,12 @@ module.exports = function(grunt) {
   // Default task.
   grunt.registerTask('default', ['browserify']);
 
-  grunt.registerTask('phantomTests', ['run', 'karma:unit-once']);
-
   grunt.registerTask('test', [
     'eslint',
     process.env.JENKINS_HOME ? 'mochaTest:unit-xml' : 'mochaTest:unit',
     process.env.JENKINS_HOME && (/^win/.test(process.platform) ||
       /^s390x/.test(process.arch) || /^ppc64/.test(process.arch)) ?
-      'skip-karma' : 'phantomTests',
+      'skip-karma' : 'karma:unit-once',
   ]);
 
   // alias for sl-ci-run and `npm test`

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -104,7 +104,7 @@ module.exports = function(grunt) {
     karma: {
       'unit-once': {
         configFile: 'test/karma.conf.js',
-        browsers: ['ChromeHeadless'],
+        browsers: ['ChromeDocker'],
         singleRun: true,
         reporters: ['dots', 'junit'],
 

--- a/package.json
+++ b/package.json
@@ -98,7 +98,8 @@
     "sinon-chai": "^3.2.0",
     "strong-error-handler": "^3.0.0",
     "strong-task-emitter": "^0.0.8",
-    "supertest": "^3.0.0"
+    "supertest": "^3.0.0",
+    "which": "^1.3.1"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "grunt-eslint": "^21.0.0",
     "grunt-karma": "^3.0.2",
     "grunt-mocha-test": "^0.13.3",
+    "is-docker": "^2.0.0",
     "karma": "^4.1.0",
     "karma-browserify": "^6.0.0",
     "karma-chrome-launcher": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -63,9 +63,7 @@
     "underscore.string": "^3.3.5"
   },
   "devDependencies": {
-    "babel-preset-es2015": "^6.22.0",
-    "babelify": "^7.3.0",
-    "browserify": "^13.1.0",
+    "browserify": "^16.5.0",
     "chai": "^3.5.0",
     "cookie-parser": "^1.3.4",
     "coveralls": "^3.0.2",
@@ -82,7 +80,6 @@
     "grunt-eslint": "^21.0.0",
     "grunt-karma": "^3.0.2",
     "grunt-mocha-test": "^0.13.3",
-    "grunt-run": "^0.8.1",
     "karma": "^4.1.0",
     "karma-browserify": "^6.0.0",
     "karma-chrome-launcher": "^2.2.0",

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -64,7 +64,6 @@ module.exports = function(config) {
       'karma-browserify',
       'karma-es6-shim',
       'karma-mocha',
-      'karma-phantomjs-launcher',
       'karma-chrome-launcher',
       'karma-junit-reporter',
     ],
@@ -104,27 +103,18 @@ module.exports = function(config) {
         'superagent',
         'supertest',
       ],
-      transform: [
-        ['babelify', {
-          presets: [
-            ['es2015', {
-              // Disable transform-es2015-modules-commonjs which adds
-              // "use strict" to all files, even those that don't work
-              // in strict mode
-              // (e.g. chai, loopback-datasource-juggler, etc.)
-              modules: false,
-            }],
-          ],
-          // By default, browserify does not transform node_modules
-          // As a result, our dependencies like strong-remoting and juggler
-          // are kept in original ES6 form that does not work in PhantomJS
-          global: true,
-          // Prevent SyntaxError in strong-task-emitter:
-          //   strong-task-emitter/lib/task.js (83:4):
-          //   arguments is a reserved word in strict mode
-          ignore: /node_modules\/(strong-task-emitter)\//,
-        }],
-      ],
+      packageFilter: function(pkg, dir) {
+        // async@3 (used e.g. by loopback-connector) is specifying custom
+        // browserify config, in particular it wants to apply transformation
+        // `babelify`. We don't have `babelify` installed because we are
+        // testing using latest Chrome and thus don't need any transpilation.
+        // Let's remove the browserify config from the package and force
+        // browserify to use our config instead.
+        if (pkg.name === 'async') {
+          delete pkg.browserify;
+        }
+        return pkg;
+      },
       debug: true,
       // noParse: ['jquery'],
       watch: true,

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -3,12 +3,31 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+'use strict';
+
+const isDocker = require('is-docker');
+
 // Karma configuration
 // http://karma-runner.github.io/0.12/config/configuration-file.html
 
-'use strict';
 module.exports = function(config) {
+  // see https://github.com/docker/for-linux/issues/496
+  const disableChromeSandbox = isDocker() && !process.env.TRAVIS;
+  if (disableChromeSandbox) {
+    console.log('!! Disabling Chrome sandbox to support un-privileged Docker !!');
+  }
+
   config.set({
+    customLaunchers: {
+      ChromeDocker: {
+        base: 'ChromeHeadless',
+        // We must disable the Chrome sandbox when running Chrome inside Docker
+        // (Chrome's sandbox needs more permissions than Docker allows by default)
+        // See https://github.com/docker/for-linux/issues/496
+        flags: disableChromeSandbox ? ['--no-sandbox'] : [],
+      },
+    },
+
     // enable / disable watching file and executing tests whenever any file changes
     autoWatch: true,
 

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -6,6 +6,7 @@
 'use strict';
 
 const isDocker = require('is-docker');
+const which = require('which');
 
 // Karma configuration
 // http://karma-runner.github.io/0.12/config/configuration-file.html
@@ -17,10 +18,15 @@ module.exports = function(config) {
     console.log('!! Disabling Chrome sandbox to support un-privileged Docker !!');
   }
 
+  const hasChromium =
+    which.sync('chromium-browser', {nothrow: true}) ||
+    which.sync('chromium', {nothrow: true});
+
   config.set({
     customLaunchers: {
       ChromeDocker: {
-        base: 'ChromeHeadless',
+        // cis-jenkins build server does not provide Chrome, only Chromium
+        base: hasChromium ? 'ChromiumHeadless' : 'ChromeHeadless',
         // We must disable the Chrome sandbox when running Chrome inside Docker
         // (Chrome's sandbox needs more permissions than Docker allows by default)
         // See https://github.com/docker/for-linux/issues/496


### PR DESCRIPTION
Rework browser tests to run in Headless Chrome instead of PhantomJS, because the latter is no longer maintained.

This allows us to remove transpilation to ES5 via babelify, which significantly improves speed of our tests.

Fixes #4252

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
