### PR TITLE
Remove "major" and "p1" from stalebot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -7,8 +7,6 @@ exemptLabels:
   - pinned
   - security
   - critical
-  - p1
-  - major
 # Label to use when marking an issue as stale
 staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
LoopBack 3 is in Maintenance LTS mode, only critical bugs and critical security fixes will be provided. Major and p1 issues are not qualified and if nobody submits a pull request for them, then they should be automatically closed as stale.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [ ] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
