### PR TITLE
Support middleware injected by OpenTelemetry Express Instrumentation plugin

### DIFF
--- a/lib/server-app.js
+++ b/lib/server-app.js
@@ -228,8 +228,10 @@ proto._findLayerByHandler = function(handler) {
     const isNewRelic = this._router.stack[k].handle['__NR_original'] === handler;
     const isAppDynamics = this._router.stack[k].handle['__appdynamicsProxyInfo__'] &&
       this._router.stack[k].handle['__appdynamicsProxyInfo__']['orig'] === handler;
+    const isShimmer = this._router.stack[k].handle['__wrapped'] && 
+      this._router.stack[k].handle['__original'] === handler;
 
-    if (isOriginal || isNewRelic || isAppDynamics) {
+    if (isOriginal || isNewRelic || isAppDynamics || isShimmer) {
       return this._router.stack[k];
     } else {
       // Aggressively check if the original handler has been wrapped

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -145,6 +145,27 @@ describe('app', function() {
           done();
         });
       });
+    
+    it('allows handlers to be wrapped by shimmer (ex: opentelemetry) on express stack',
+      function(done) {
+        const myHandler = namedHandler('my-handler');
+        const wrappedHandler = function(req, res, next) {
+          myHandler(req, res, next);
+        };
+        wrappedHandler['__wrapped'] = true;
+        wrappedHandler['__original'] = myHandler;
+        app.middleware('routes:before', wrappedHandler);
+        const found = app._findLayerByHandler(myHandler);
+        expect(found).to.be.an('object');
+        expect(found).have.property('phase', 'routes:before');
+        executeMiddlewareHandlers(app, function(err) {
+          if (err) return done(err);
+
+          expect(steps).to.eql(['my-handler']);
+
+          done();
+        });
+      });
 
     it('allows handlers to be wrapped as a property on express stack',
       function(done) {


### PR DESCRIPTION
[OpenTelemetry Express Instrumentation](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-express) injects a proxy object into the router stack, which it
uses for its tracing.  This is similar to how NewRelic adds a sentinel handler to the router stack. This commit adds a similar workaround so that loopback can find the original layer.

I made the variable more generic to just test if shimmer is used to wrap the handler, as this library can be used by other libraries.


See also #4119

### Checklist
* [x]  New tests added or existing tests modified to cover all changes
  * Unit tests have been added
* [x]  Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
  * All lint tests passes

